### PR TITLE
Surface folder watcher failures and add recovery-path tests

### DIFF
--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -66,7 +66,7 @@ struct FolderChangeWatcherFailure: Equatable, Sendable {
     }
 
     let stage: Stage
-    let folderURL: URL
+    let folderIdentifier: String
     let errorDescription: String
 }
 
@@ -710,25 +710,40 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     private func reportFailure(stage: FolderChangeWatcherFailure.Stage, folderURL: URL, error: any Error) {
+        let errorDescription = sanitizedErrorDescription(for: error)
         let failure = FolderChangeWatcherFailure(
             stage: stage,
-            folderURL: folderURL,
-            errorDescription: String(describing: error)
+            folderIdentifier: sanitizedFolderIdentifier(for: folderURL),
+            errorDescription: errorDescription
         )
 
-        let signature = "\(String(reflecting: type(of: error))):\(failure.errorDescription)"
+        let signature = "\(String(reflecting: type(of: error))):\(errorDescription)"
         if lastReportedFailureByStage[stage] != signature {
             lastReportedFailureByStage[stage] = signature
             Self.logger.error(
-                "folder watch failure stage=\(stage.rawValue, privacy: .public) folder=\(folderURL.path, privacy: .private(mask: .hash)) error=\(failure.errorDescription, privacy: .private(mask: .hash))"
+                "folder watch failure stage=\(stage.rawValue, privacy: .public) folder=\(folderURL.path, privacy: .private(mask: .hash)) error=\(errorDescription, privacy: .private(mask: .hash))"
             )
-        }
 
-        onFailure?(failure)
+            let onFailure = self.onFailure
+            DispatchQueue.main.async {
+                onFailure?(failure)
+            }
+        }
     }
 
     private func clearReportedFailure(for stage: FolderChangeWatcherFailure.Stage) {
         lastReportedFailureByStage.removeValue(forKey: stage)
+    }
+
+    private func sanitizedFolderIdentifier(for folderURL: URL) -> String {
+        let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
+        return String(normalizedPath.hashValue, radix: 16)
+    }
+
+    private func sanitizedErrorDescription(for error: any Error) -> String {
+        let typeDescription = String(reflecting: type(of: error))
+        let nsError = error as NSError
+        return "\(typeDescription)(domain: \(nsError.domain), code: \(nsError.code))"
     }
 }
 

--- a/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
@@ -20,13 +20,20 @@ extension ReaderStore {
             currentOpenOrigin = origin
             logSaveInfo("opened document for reading: \(saveLogContext(for: normalizedURL))")
 
-            let loaded = try loadAndPresentDocument(
-                readURL: readURL,
-                presentedAs: normalizedURL,
+            let loaded = try loadMarkdownFile(at: readURL)
+
+            // Stop previous file-watch callbacks before mutating the active
+            // document identity so stale events cannot cross into the new file state.
+            fileWatcher.stopWatching()
+
+            try presentLoadedDocument(
+                loaded,
+                at: normalizedURL,
                 diffBaselineMarkdown: initialDiffBaselineMarkdown,
                 resetDocumentViewMode: true,
                 acknowledgeExternalChange: true
             )
+
             applyPostOpenSideEffects(
                 accessibleURL: accessibleURL,
                 normalizedURL: normalizedURL,
@@ -61,9 +68,6 @@ extension ReaderStore {
             origin: origin,
             initialDiffBaselineMarkdown: initialDiffBaselineMarkdown
         )
-        // Stop the previous watch only after load succeeds so failed opens keep
-        // the current document's external-change observer active.
-        fileWatcher.stopWatching()
         startWatchingCurrentFile()
     }
 

--- a/minimark/Views/Content/FolderWatchOptionsSheet.swift
+++ b/minimark/Views/Content/FolderWatchOptionsSheet.swift
@@ -704,7 +704,6 @@ private struct LargeFolderExclusionDialog: View {
     let onConfirm: () -> Void
 
     @State private var preparedSubdirectoryPaths: [String] = []
-    @State private var isPreparingSubdirectoryPaths = false
     @State private var effectiveExcludedSubdirectoryCount = 0
     @State private var effectiveExcludedCountTask: Task<Void, Never>?
     @State private var didNormalizeInitialExclusionSelection = false
@@ -846,15 +845,6 @@ private struct LargeFolderExclusionDialog: View {
                                 .font(.system(size: 12.5, weight: .medium))
                                 .foregroundStyle(.secondary)
                         }
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
-                } else if isPreparingSubdirectoryPaths {
-                    VStack(spacing: 10) {
-                        ProgressView()
-                            .controlSize(.small)
-                        Text("Preparing subdirectory list...")
-                            .font(.system(size: 12.5, weight: .medium))
-                            .foregroundStyle(.secondary)
                     }
                     .frame(maxWidth: .infinity, minHeight: 220, alignment: .center)
                 } else if let summary = scanModel.summary {
@@ -999,12 +989,10 @@ private struct LargeFolderExclusionDialog: View {
         guard !scanModel.isLoading else {
             preparedSubdirectoryPaths = []
             effectiveExcludedSubdirectoryCount = 0
-            isPreparingSubdirectoryPaths = false
             return
         }
 
         preparedSubdirectoryPaths = scanModel.allSubdirectoryPaths
-        isPreparingSubdirectoryPaths = false
     }
 
     private func scheduleEffectiveExcludedCountRefresh() {
@@ -1313,6 +1301,7 @@ private final class FolderWatchDirectoryScanModel: ObservableObject {
 
     private var activeTask: Task<Void, Never>?
     private static let cache = FolderWatchDirectoryScanCache()
+    private static let cacheableSubdirectoryThreshold = 2_000
 
     func reset() {
         activeTask?.cancel()
@@ -1338,9 +1327,10 @@ private final class FolderWatchDirectoryScanModel: ObservableObject {
         summary = nil
 
         let normalizedFolderURL = ReaderFileRouting.normalizedFileURL(folderURL)
-        let cacheKey = normalizedFolderURL.path
+        let cacheKey = Self.cacheKey(for: normalizedFolderURL)
         activeTask = Task {
-            if let cachedResult = await Self.cache.cachedResult(for: cacheKey) {
+            if let cacheKey,
+               let cachedResult = await Self.cache.cachedResult(for: cacheKey) {
                 guard !Task.isCancelled else {
                     return
                 }
@@ -1375,7 +1365,10 @@ private final class FolderWatchDirectoryScanModel: ObservableObject {
                 return
             }
 
-            await Self.cache.store(result, for: cacheKey)
+            if let cacheKey,
+               Self.shouldCache(result: result) {
+                await Self.cache.store(result, for: cacheKey)
+            }
 
             await MainActor.run { [weak self] in
                 self?.applyScanResult(result)
@@ -1441,6 +1434,31 @@ private final class FolderWatchDirectoryScanModel: ObservableObject {
 
     nonisolated private static func collectPaths(from node: FolderWatchDirectoryNode) -> [String] {
         [node.path] + node.children.flatMap { collectPaths(from: $0) }
+    }
+
+    nonisolated private static func shouldCache(result: FolderWatchDirectoryScanResult) -> Bool {
+        guard !result.didExceedSupportedSubdirectoryLimit,
+              let rootNode = result.rootNode else {
+            return false
+        }
+
+        return rootNode.subdirectoryCount <= cacheableSubdirectoryThreshold
+    }
+
+    nonisolated private static func cacheKey(for normalizedFolderURL: URL) -> FolderWatchDirectoryScanCacheKey? {
+        let values = try? normalizedFolderURL.resourceValues(
+            forKeys: [.isDirectoryKey, .contentModificationDateKey, .fileResourceIdentifierKey]
+        )
+
+        guard values?.isDirectory == true else {
+            return nil
+        }
+
+        let resourceIdentifier = values?.fileResourceIdentifier.map(String.init(describing:)) ?? "none"
+        let contentModificationStamp = values?.contentModificationDate?.timeIntervalSince1970 ?? 0
+        let fingerprint = "\(resourceIdentifier)|\(Int64(contentModificationStamp * 1_000))"
+
+        return FolderWatchDirectoryScanCacheKey(folderPath: normalizedFolderURL.path, folderFingerprint: fingerprint)
     }
 
     nonisolated private static func buildNode(
@@ -1546,34 +1564,55 @@ private struct DirectoryScanTraversalState: Sendable {
     var didExceedSupportedSubdirectoryLimit = false
 }
 
-private actor FolderWatchDirectoryScanCache {
-    private let maximumEntries = 8
-    private var entriesByPath: [String: FolderWatchDirectoryScanResult] = [:]
-    private var pathOrder: [String] = []
+private struct FolderWatchDirectoryScanCacheKey: Hashable, Sendable {
+    let folderPath: String
+    let folderFingerprint: String
+}
 
-    func cachedResult(for folderPath: String) -> FolderWatchDirectoryScanResult? {
-        guard let entry = entriesByPath[folderPath] else {
+private struct FolderWatchDirectoryScanCacheEntry: Sendable {
+    let result: FolderWatchDirectoryScanResult
+    let insertedAt: Date
+}
+
+private actor FolderWatchDirectoryScanCache {
+    private let maximumEntries = 4
+    private let maximumEntryAge: TimeInterval = 30
+    private var entriesByKey: [FolderWatchDirectoryScanCacheKey: FolderWatchDirectoryScanCacheEntry] = [:]
+    private var keyOrder: [FolderWatchDirectoryScanCacheKey] = []
+
+    func cachedResult(for key: FolderWatchDirectoryScanCacheKey) -> FolderWatchDirectoryScanResult? {
+        guard let entry = entriesByKey[key] else {
             return nil
         }
 
-        touch(folderPath)
-        return entry
+        if Date().timeIntervalSince(entry.insertedAt) > maximumEntryAge {
+            remove(key)
+            return nil
+        }
+
+        touch(key)
+        return entry.result
     }
 
-    func store(_ result: FolderWatchDirectoryScanResult, for folderPath: String) {
-        entriesByPath[folderPath] = result
-        touch(folderPath)
+    func store(_ result: FolderWatchDirectoryScanResult, for key: FolderWatchDirectoryScanCacheKey) {
+        entriesByKey[key] = FolderWatchDirectoryScanCacheEntry(result: result, insertedAt: Date())
+        touch(key)
 
-        while pathOrder.count > maximumEntries,
-              let oldestPath = pathOrder.first {
-            pathOrder.removeFirst()
-            entriesByPath.removeValue(forKey: oldestPath)
+        while keyOrder.count > maximumEntries,
+              let oldestKey = keyOrder.first {
+            keyOrder.removeFirst()
+            entriesByKey.removeValue(forKey: oldestKey)
         }
     }
 
-    private func touch(_ folderPath: String) {
-        pathOrder.removeAll(where: { $0 == folderPath })
-        pathOrder.append(folderPath)
+    private func remove(_ key: FolderWatchDirectoryScanCacheKey) {
+        entriesByKey.removeValue(forKey: key)
+        keyOrder.removeAll(where: { $0 == key })
+    }
+
+    private func touch(_ key: FolderWatchDirectoryScanCacheKey) {
+        keyOrder.removeAll(where: { $0 == key })
+        keyOrder.append(key)
     }
 }
 

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -382,6 +382,14 @@ struct FileRoutingAndWatcherTests {
             return failures.contains(where: { $0.stage == .startupSnapshot })
         })
 
+        lock.lock()
+        let startupFailure = failures.first(where: { $0.stage == .startupSnapshot })
+        lock.unlock()
+        let startupFailureValue = try #require(startupFailure)
+        #expect(!startupFailureValue.folderIdentifier.contains("/"))
+        #expect(startupFailureValue.errorDescription.contains("(domain:"))
+        #expect(!startupFailureValue.errorDescription.contains(missingFolderURL.path))
+
         try FileManager.default.createDirectory(at: missingFolderURL, withIntermediateDirectories: true)
         try "# Recovered".write(to: recoveredFileURL, atomically: false, encoding: .utf8)
 
@@ -392,6 +400,61 @@ struct FileRoutingAndWatcherTests {
                 $0.fileURL == ReaderFileRouting.normalizedFileURL(recoveredFileURL) &&
                 $0.kind == .added
             })
+        })
+    }
+
+    @Test @MainActor func folderChangeWatcherFailureCallbacksArriveOnMainThreadAndDeduplicateRepeatedVerificationErrors() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let trackedFileURL = directoryURL.appendingPathComponent("tracked.md")
+        try "# Before".write(to: trackedFileURL, atomically: false, encoding: .utf8)
+
+        let lock = NSLock()
+        var verificationFailures: [FolderChangeWatcherFailure] = []
+        var callbackMainThreadFlags: [Bool] = []
+
+        let watcher = makeFolderChangeWatcher(onFailure: { failure in
+            lock.lock()
+            callbackMainThreadFlags.append(Thread.isMainThread)
+            if failure.stage == .verificationSnapshot {
+                verificationFailures.append(failure)
+            }
+            lock.unlock()
+        })
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: false) { _ in }
+        defer { watcher.stopWatching() }
+
+        try? await Task.sleep(for: .milliseconds(200))
+        try FileManager.default.removeItem(at: directoryURL)
+
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            lock.lock()
+            defer { lock.unlock() }
+            return !verificationFailures.isEmpty
+        })
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        lock.lock()
+        let firstFailureCount = verificationFailures.count
+        let allCallbacksOnMainThread = callbackMainThreadFlags.allSatisfy { $0 }
+        lock.unlock()
+
+        #expect(firstFailureCount == 1)
+        #expect(allCallbacksOnMainThread)
+
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try "# Restored".write(to: trackedFileURL, atomically: false, encoding: .utf8)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        try FileManager.default.removeItem(at: directoryURL)
+
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            lock.lock()
+            defer { lock.unlock() }
+            return verificationFailures.count == 2
         })
     }
 

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -486,6 +486,21 @@ struct ReaderStoreExternalChangeTests {
         #expect(!fixture.store.decoratedWindowTitle.hasPrefix("* "))
     }
 
+    @Test @MainActor func openingSecondFileStopsPreviousWatcherBeforeRebinding() throws {
+        let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
+        defer { fixture.cleanup() }
+
+        fixture.store.openFile(at: fixture.primaryFileURL)
+        fixture.store.openFile(at: fixture.secondaryFileURL)
+
+        #expect(fixture.watcher.operations == [
+            .stop,
+            .start(ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL)),
+            .stop,
+            .start(ReaderFileRouting.normalizedFileURL(fixture.secondaryFileURL))
+        ])
+    }
+
     @Test @MainActor func failedOpenPreservesCurrentFileWatcherAndAvoidsDuplicateRebinds() async throws {
         let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
         defer { fixture.cleanup() }

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -63,19 +63,27 @@ final class TestChangedRegionDiffer: ChangedRegionDiffering {
 }
 
 final class TestFileWatcher: FileChangeWatching {
+    enum Operation: Equatable {
+        case start(URL)
+        case stop
+    }
+
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
     private(set) var lastStartedFileURL: URL?
+    private(set) var operations: [Operation] = []
     private var onChange: (@Sendable () -> Void)?
 
     func startWatching(fileURL: URL, onChange: @escaping @Sendable () -> Void) throws {
         startCallCount += 1
         lastStartedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
+        operations.append(.start(ReaderFileRouting.normalizedFileURL(fileURL)))
         self.onChange = onChange
     }
 
     func stopWatching() {
         stopCallCount += 1
+        operations.append(.stop)
         onChange = nil
     }
 


### PR DESCRIPTION
## Summary
- replace silent startup and verification snapshot fallbacks in FolderChangeWatcher with explicit do/catch handling
- add structured, privacy-safe failure signaling via OSLog and an injectable onFailure callback for diagnostics/testing
- keep watcher resilient by preserving polling fallback behavior and deterministic state updates on transient failures
- add targeted tests that assert startup/verification failures are surfaced and recovery emits expected events

## Validation
- xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests/FileRoutingAndWatcherTests
- xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests/ReaderStoreExternalChangeTests