### PR TITLE
Redesign top bar with layered layout and watch strip

### DIFF
--- a/minimark/Views/Content/ReaderTopBar.swift
+++ b/minimark/Views/Content/ReaderTopBar.swift
@@ -100,7 +100,6 @@ struct ReaderTopBar: View {
                     onActivate: handleFolderWatchToolbarButton,
                     onStartFavoriteWatch: onStartFavoriteWatch,
                     onStartRecentFolderWatch: onStartRecentFolderWatch,
-                    onClearFavoriteWatchedFolders: onClearFavoriteWatchedFolders,
                     onEditFavoriteWatchedFolders: { isEditingFavorites = true },
                     onClearRecentWatchedFolders: onClearRecentWatchedFolders
                 )
@@ -254,7 +253,6 @@ struct ReaderTopBar: View {
         let onActivate: () -> Void
         let onStartFavoriteWatch: (ReaderFavoriteWatchedFolder) -> Void
         let onStartRecentFolderWatch: (ReaderRecentWatchedFolder) -> Void
-        let onClearFavoriteWatchedFolders: () -> Void
         let onEditFavoriteWatchedFolders: () -> Void
         let onClearRecentWatchedFolders: () -> Void
 
@@ -320,17 +318,19 @@ struct ReaderTopBar: View {
                     .strokeBorder(borderColor, lineWidth: 1)
             }
             .overlay(alignment: .topTrailing) {
-                if isInitialScanInProgress {
-                    ProgressView()
-                        .scaleEffect(0.6)
-                        .controlSize(.small)
-                        .offset(x: -4, y: 4)
-                } else if didInitialScanFail {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.red)
-                        .offset(x: -4, y: 4)
+                Group {
+                    if isInitialScanInProgress {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                            .controlSize(.small)
+                    } else if didInitialScanFail {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.red)
+                    }
                 }
+                .offset(x: -4, y: 4)
+                .allowsHitTesting(false)
             }
             .fixedSize(horizontal: true, vertical: true)
         }
@@ -554,8 +554,8 @@ struct ReaderTopBar: View {
                 .buttonStyle(.plain)
                 .modifier(PointingHandCursor())
                 .help("Reveal in Finder")
+                .accessibilityElement(children: .combine)
                 .accessibilityLabel("Current document")
-                .accessibilityValue(titleText)
                 .accessibilityHint("Reveals this file in Finder")
             } else {
                 VStack(alignment: .leading, spacing: 1) {


### PR DESCRIPTION
## Summary
- Restructure the top bar into a two-layer design: main toolbar (44px) with consistent 28px controls, and a contextual green watch strip (30px) that appears when watching a folder
- Replace icon-based view mode toggle with text labels (Preview/Split/Source) and add breadcrumb document path with click-to-reveal-in-Finder
- Add split watch button with integrated favorites/recent dropdown, indigo active state, and move star/stop controls into the watch strip
- Watch strip shows full tilde-abbreviated folder path (clickable), filtered subdirectory count, and uses a dedicated green palette that adapts to light/dark mode

## Test plan
- [ ] Verify top bar layout in all states: no document, document open, watching folder, watching with changes, split mode with source editing
- [ ] Confirm watch button text stays stable ("Watch Folder" / "Watching") without shifting adjacent elements
- [ ] Click filename and breadcrumb path to verify Reveal in Finder works
- [ ] Click watch strip folder path to verify Reveal in Finder for the watched folder
- [ ] Open the watch button dropdown and verify favorites and recent watches appear and work
- [ ] Verify light mode and dark mode rendering for both the indigo button and green strip
- [ ] Confirm the source editing yellow banner still appears correctly below the watch strip
- [ ] Run unit tests: all 248 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)