### PR TITLE
Redesign folder watch dialog for clarity and compactness

### DIFF
--- a/minimark/Views/Content/FolderWatchOptionsSheet.swift
+++ b/minimark/Views/Content/FolderWatchOptionsSheet.swift
@@ -322,7 +322,9 @@ struct FolderWatchOptionsSheet: View {
                         .font(.system(size: 10.5, weight: .regular, design: .monospaced))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .truncationMode(.middle)
                         .textSelection(.enabled)
+                        .help(selectedFolderPath)
                         .accessibilityLabel("Folder path")
                         .accessibilityValue(selectedFolderPath)
                 }
@@ -370,9 +372,9 @@ struct FolderWatchOptionsSheet: View {
                     Spacer()
 
                     Picker("Folder scope", selection: scopeSelectionBinding) {
-                        Text("This Folder")
+                        Text("Selected Folder")
                             .tag(ReaderFolderWatchScope.selectedFolderOnly)
-                        Text("Subfolders")
+                        Text("Include Subfolders")
                             .tag(ReaderFolderWatchScope.includeSubfolders)
                     }
                     .pickerStyle(.segmented)
@@ -402,12 +404,14 @@ struct FolderWatchOptionsSheet: View {
                     } else if let summary = directoryScanModel.summary {
                         HStack(spacing: 8) {
                             FolderWatchMetricPill(
-                                title: "\(summary.subdirectoryCount) subdirs",
+                                title: "\(summary.subdirectoryCount) " +
+                                    (summary.subdirectoryCount == 1 ? "subdirectory" : "subdirectories"),
                                 symbol: "folder.badge.gearshape"
                             )
 
                             FolderWatchMetricPill(
-                                title: "\(summary.markdownFileCount) files",
+                                title: "\(summary.markdownFileCount) " +
+                                    (summary.markdownFileCount == 1 ? "file" : "files"),
                                 symbol: "doc.text.magnifyingglass"
                             )
                         }


### PR DESCRIPTION
## Summary
- Replaces the cluttered 5-card stacked layout with a streamlined dialog: compact header, simple folder bar, two inline option rows, and a left-bordered summary sentence
- Hides the optimization/warning card in the happy path — only shown when the folder tree actually exceeds the threshold
- Reduces dialog width from 560px to 480px and removes ~120 net lines of code
- Removes redundant sub-views (`FolderWatchHeaderView`, `FolderWatchSummaryCard`, `FolderWatchOptionSection`, `FolderWatchScopeSummaryView`) that added visual noise without reuse value

## Test plan
- [x] Build succeeds
- [x] All 262 unit tests pass
- [x] Dialog opens correctly from Watch menu (favorites + recent folders)
- [x] Both segmented pickers (On start / Scope) work correctly
- [x] Summary text updates dynamically when options change
- [x] Subfolder scan progress shown inline when "Subfolders" scope selected
- [x] Metric pills (subdirs/files) appear after scan completes
- [ ] Warning card appears for folders exceeding subdirectory threshold
- [ ] Large folder exclusion dialog (nested sheet) still works
- [ ] Cancel and Start Watching buttons function correctly
- [ ] Keyboard shortcuts (Escape / Return) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)