### PR TITLE
Redesign exclusion dialog with progress ring and toggle switches

### DIFF
--- a/minimark/Views/Content/FolderWatchOptionsSheet.swift
+++ b/minimark/Views/Content/FolderWatchOptionsSheet.swift
@@ -835,8 +835,9 @@ private struct LargeFolderExclusionDialog: View {
     }
 
     private var progressRingFraction: Double {
-        guard !preparedSubdirectoryPaths.isEmpty else { return 0 }
-        return Double(activeSubdirectoryCount) / Double(preparedSubdirectoryPaths.count)
+        guard threshold > 0 else { return 0 }
+        let fraction = Double(activeSubdirectoryCount) / Double(threshold)
+        return min(1.0, fraction)
     }
 
     private var progressRingColor: Color {
@@ -1193,7 +1194,11 @@ private struct FolderWatchTreeNodeRow: View {
     private var toggleBinding: Binding<Bool> {
         Binding(
             get: { isActive },
-            set: { _ in toggleExclusion() }
+            set: { newValue in
+                if newValue != isActive {
+                    toggleExclusion()
+                }
+            }
         )
     }
 
@@ -1236,7 +1241,9 @@ private struct FolderWatchTreeNodeRow: View {
                 .controlSize(.mini)
                 .labelsHidden()
                 .disabled(!canToggle)
-                .help(isExcludedByAncestor ? "Inherited" : "")
+                .help(isExcludedByAncestor ? "Exclusion inherited from a parent folder" : "Toggle to include or exclude this folder")
+                .accessibilityLabel("\(node.name)")
+                .accessibilityValue(isEffectivelyExcluded ? (isExcludedByAncestor ? "Inherited" : "Deactivated") : "Active")
             }
             .padding(.leading, CGFloat(level) * 16)
             .padding(.horizontal, 10)


### PR DESCRIPTION
## Summary

- Replace the cluttered `LargeFolderExclusionDialog` with a compact split-panel layout featuring a circular progress ring, inline toggle switches, and a centered status divider
- Reduce dialog width from 700pt to 620pt and cut per-row visual elements from 7 (chevron, icon, name, subfolder count, file count, status badge, action button) to 4 (chevron, icon, name+stats, toggle)
- Fix summary text truncation in the parent `FolderWatchOptionsSheet` by adding `fixedSize(horizontal: false, vertical: true)`

## Test plan

- [x] Build succeeds
- [x] UI test `testFolderWatchThresholdFlowRequiresExclusionsThenEnablesStartWhenThresholdIsMet` passes
- [ ] Manual: open folder watch sheet, select Include Subfolders on a folder with >256 subdirectories, verify progress ring renders correctly
- [ ] Manual: toggle individual folders on/off, verify ring updates and threshold status changes
- [ ] Manual: use Deactivate All / Activate All bulk actions
- [ ] Manual: verify VoiceOver reads dialog elements correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)