### PR TITLE
fix: prevent file selection dialog on live auto-open (#33)

### DIFF
--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -188,12 +188,9 @@ final class ReaderFolderWatchController {
         lastWatchedFolderEventAt = .now
         let livePlan = folderWatchAutoOpenPlanner.livePlan(
             for: eventsExcludingOpenDocuments(markdownFileEvents),
-            activeSession: session,
+            activeSession: nil,
             currentDocumentFileURL: currentDocumentFileURLProvider?()
         )
-        if let warning = livePlan.warning {
-            folderWatchAutoOpenWarning = warning
-        }
         let plannedEvents = livePlan.autoOpenEvents
         dispatchOpenEvents(plannedEvents, session: session, origin: .folderWatchAutoOpen)
     }

--- a/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
+++ b/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
@@ -713,6 +713,47 @@ struct FolderWatchCoordinationTests {
         #expect(flushBatch?.openOrigin == .folderWatchAutoOpen)
     }
 
+    @Test @MainActor func folderWatchControllerDoesNotSetWarningForLiveEventsExceedingLimit() async throws {
+        let folderURL = URL(fileURLWithPath: "/tmp/watched-\(UUID().uuidString)", isDirectory: true)
+        let watcher = TestFolderWatcher()
+        let settingsStore = ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "reader.settings.folder-watch.live-no-warning.\(UUID().uuidString)"
+        )
+        let controller = ReaderFolderWatchController(
+            folderWatcher: watcher,
+            settingsStore: settingsStore,
+            securityScope: TestSecurityScopeAccess(),
+            systemNotifier: TestReaderSystemNotifier(),
+            folderWatchAutoOpenPlanner: ReaderFolderWatchAutoOpenPlanner()
+        )
+        var openedEvents: [ReaderFolderWatchChangeEvent] = []
+        controller.openEventsHandler = { events, _, _ in
+            openedEvents.append(contentsOf: events)
+        }
+
+        try controller.startWatching(
+            folderURL: folderURL,
+            options: ReaderFolderWatchOptions(
+                openMode: .watchChangesOnly,
+                scope: .selectedFolderOnly
+            )
+        )
+
+        let liveEvents = (0..<(ReaderFolderWatchAutoOpenPolicy.maximumLiveAutoOpenFileCount + 5)).map { index in
+            ReaderFolderWatchChangeEvent(
+                fileURL: folderURL.appendingPathComponent(String(format: "live-%02d.md", index)),
+                kind: .added
+            )
+        }
+        watcher.emitChangedMarkdownEvents(liveEvents)
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(controller.folderWatchAutoOpenWarning == nil)
+        #expect(openedEvents.count == ReaderFolderWatchAutoOpenPolicy.maximumLiveAutoOpenFileCount)
+    }
+
     @Test @MainActor func focusNotificationTargetFallsBackToWatchedFolderWindow() {
         ReaderWindowRegistry.shared.resetForTesting()
         defer { ReaderWindowRegistry.shared.resetForTesting() }

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -376,7 +376,7 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(harness.controller.selectedFolderWatchAutoOpenWarning == nil)
     }
 
-    @Test @MainActor func sidebarControllerLiveBurstPublishesWarningForOmittedFiles() async throws {
+    @Test @MainActor func sidebarControllerLiveBurstDoesNotPublishWarningForOmittedFiles() async throws {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
@@ -404,9 +404,7 @@ struct ReaderSidebarDocumentControllerTests {
         await Task.yield()
 
         #expect(harness.controller.documents.count == autoOpenLimit + 1)
-        #expect(harness.controller.selectedFolderWatchAutoOpenWarning?.autoOpenedFileCount == autoOpenLimit)
-        #expect(harness.controller.selectedFolderWatchAutoOpenWarning?.folderURL == ReaderFileRouting.normalizedFileURL(harness.temporaryDirectoryURL))
-        #expect(harness.controller.selectedFolderWatchAutoOpenWarning?.omittedFileURLs == Array(fileURLs.dropFirst(autoOpenLimit)).map(ReaderFileRouting.normalizedFileURL))
+        #expect(harness.controller.selectedFolderWatchAutoOpenWarning == nil)
     }
 
     @Test @MainActor func sidebarControllerCloseOtherDocumentsKeepsRequestedDocumentOnly() throws {


### PR DESCRIPTION
## Summary
- Live folder-watch events exceeding the auto-open limit (12 files) incorrectly triggered the file selection dialog by generating a `folderWatchAutoOpenWarning`. This dialog is only intended for initial folder watch startup.
- Fixed by passing `activeSession: nil` to `livePlan()` in `handleObservedWatchedFolderChanges`, preventing warning generation for live events. Files exceeding the limit are silently capped.
- Updated existing test and added new test to verify live events don't produce warnings.

Closes #33

## Test plan
- [x] New test: `folderWatchControllerDoesNotSetWarningForLiveEventsExceedingLimit` — verifies warning stays nil after live burst exceeding limit
- [x] Updated test: `sidebarControllerLiveBurstDoesNotPublishWarningForOmittedFiles` — asserts no warning propagates to sidebar controller
- [x] All existing FolderWatchCoordination and SidebarDocumentController tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)