### PR TITLE
Support folder-drop Watch Folder flow

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -708,7 +708,7 @@ struct ContentView: View {
             dragTargetedSurfaces.remove(surface)
         }
 
-        let isBlockedFolderDrop = update.isTargeted && !update.canDrop && hasDroppedDirectoryURL(update.droppedFileURLs)
+        let isBlockedFolderDrop = update.isTargeted && !update.canDrop && update.containsDirectoryHint
         if isBlockedFolderDrop {
             blockedFolderDropTargetedSurfaces.insert(surface)
         } else {
@@ -727,12 +727,8 @@ struct ContentView: View {
         blockedFolderDropTargetedSurfaces.remove(surface)
     }
 
-    private func hasDroppedDirectoryURL(_ fileURLs: [URL]) -> Bool {
-        ReaderFileRouting.firstDroppedDirectoryURL(from: fileURLs) != nil
-    }
-
     private func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {
-        !hasDroppedDirectoryURL(fileURLs) || activeFolderWatch == nil
+        !ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs) || activeFolderWatch == nil
     }
 
     private func splitScrollRequest(for surface: DocumentSurfaceRole) -> ScrollSyncRequest? {

--- a/minimark/Support/ReaderFileRouting.swift
+++ b/minimark/Support/ReaderFileRouting.swift
@@ -18,10 +18,18 @@ nonisolated enum ReaderFileRouting {
     }
 
     nonisolated static func firstDroppedDirectoryURL(from urls: [URL]) -> URL? {
-        urls
+        if let hintedDirectoryURL = urls.first(where: \.hasDirectoryPath) {
+            return normalizedFileURL(hintedDirectoryURL)
+        }
+
+        return urls
             .lazy
             .map(normalizedFileURL)
             .first(where: isDirectoryURL)
+    }
+
+    nonisolated static func containsLikelyDirectoryPath(in urls: [URL]) -> Bool {
+        urls.contains(where: \.hasDirectoryPath)
     }
     
     nonisolated static func plannedOpenFileURLs(from urls: [URL]) -> [URL] {

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -21,6 +21,7 @@ struct ScrollSyncObservation: Equatable {
 struct DropTargetingUpdate: Equatable {
     let isTargeted: Bool
     let droppedFileURLs: [URL]
+    let containsDirectoryHint: Bool
     let canDrop: Bool
 }
 
@@ -1160,6 +1161,7 @@ final class DropAwareWKWebView: WKWebView {
     private static let clearedDropTargetingUpdate = DropTargetingUpdate(
         isTargeted: false,
         droppedFileURLs: [],
+        containsDirectoryHint: false,
         canDrop: false
     )
 
@@ -1215,11 +1217,13 @@ final class DropAwareWKWebView: WKWebView {
     private func dragTargetingUpdate(from draggingInfo: NSDraggingInfo) -> DropTargetingUpdate {
         let fileURLs = droppedFileURLs(from: draggingInfo)
         let hasFileURLs = !fileURLs.isEmpty
+        let containsDirectoryHint = ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs)
         let canDrop = hasFileURLs && (dropDelegate?.dropAwareWebViewCanAcceptDrop(fileURLs) ?? true)
 
         return DropTargetingUpdate(
             isTargeted: hasFileURLs,
             droppedFileURLs: fileURLs,
+            containsDirectoryHint: containsDirectoryHint,
             canDrop: canDrop
         )
     }

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -65,6 +65,15 @@ struct FileRoutingAndWatcherTests {
         #expect(ReaderFileRouting.firstDroppedDirectoryURL(from: [droppedFileURL]) == nil)
     }
 
+    @Test func containsLikelyDirectoryPathUsesURLDirectoryHints() {
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let folderHintURL = tempDirectory.appendingPathComponent("watch-folder", isDirectory: true)
+        let fileHintURL = tempDirectory.appendingPathComponent("notes.md", isDirectory: false)
+
+        #expect(ReaderFileRouting.containsLikelyDirectoryPath(in: [fileHintURL, folderHintURL]))
+        #expect(!ReaderFileRouting.containsLikelyDirectoryPath(in: [fileHintURL]))
+    }
+
     @Test @MainActor func fileChangeWatcherDetectsContentChangeWithRestoredMetadata() async throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }


### PR DESCRIPTION
## Summary
- support dropping a folder onto the reader content area to start the existing Watch Folder flow
- reject folder drops while a watch is already active and show a blocked-state overlay
- improve blocked overlay readability with an opaque warning box and high-contrast text
- preserve existing markdown file drop behavior
- add dropped-directory routing coverage in infrastructure tests
- simplify duplicated drag-targeting notification paths in the web view drop layer

## Validation
- xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build
- xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests/FileRoutingAndWatcherTests

Closes #29
