### PR TITLE
Add close action for sidebar groups

### DIFF
--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -635,7 +635,11 @@ private struct ReaderSidebarGroupHeader: View {
     let onCloseGroup: () -> Void
 
     private var pinButtonLabel: String {
-        isPinned ? "Unpin Group" : "Pin Group"
+        isPinned ? "Unpin group \(displayName)" : "Pin group \(displayName)"
+    }
+
+    private var closeGroupLabel: String {
+        "Close all files in group \(displayName)"
     }
 
     var body: some View {
@@ -683,8 +687,9 @@ private struct ReaderSidebarGroupHeader: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
-            .help("Close Group")
-            .accessibilityLabel("Close Group")
+            .help(closeGroupLabel)
+            .accessibilityLabel(closeGroupLabel)
+            .accessibilityHint("Closes every open file in this group")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a close icon to grouped sidebar headers that closes all files in that group
- reorder group header controls to reduce accidental closes: chevron, pin, title, count, close
- simplify the implementation by removing temporary derived state and deduplicating pin label text

## Validation
- xcodebuild -quiet test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests
- xcodebuild -quiet -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build

Closes #38