### PR TITLE
Fix sidebar width growing on each favorite reopen

### DIFF
--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -15,9 +15,9 @@ private struct SidebarWidthPreferenceKey: PreferenceKey {
     }
 }
 
-/// Sets the NSSplitView divider position once when the sidebar first appears.
-/// HSplitView ignores `idealWidth` for restored widths — this bridges to AppKit
-/// to apply the correct position programmatically.
+/// Bridges to AppKit to set the NSSplitView divider position and holding priorities.
+/// HSplitView ignores `idealWidth` for restored widths, so this applies the correct
+/// position programmatically on first appearance and whenever width or placement changes.
 private struct SidebarDividerPositionSetter: NSViewRepresentable {
     let targetWidth: CGFloat
     let placement: ReaderMultiFileDisplayMode.SidebarPlacement


### PR DESCRIPTION
## Summary

- Sidebar width grew by ~20-50px each time a favorite watch was reopened
- Root cause: NSSplitView proportionally redistributed space during the animated window expansion, inflating the sidebar. GeometryReader read the inflated value back, which was persisted to the favorite.
- Fix: set `holdingPriority` (251, one tick above `.defaultLow`) on the sidebar subview so it resists proportional resizing. Detail panel absorbs all window size changes.
- Also fixes: sidebar no longer changes width when the window is manually resized
- Also fixes: `updateNSView` now propagates both width and placement changes, so toggling sidebar left/right correctly recalculates the divider position

Related issues filed for deferred findings:
- #74 — Extract shared CRT CSS from terminal themes
- #75 — Remove dead-wrapper computed properties in sidebar view

## Test plan

- [x] All unit tests pass
- [ ] Manual: open a favorite watch, note sidebar width, close, reopen — width should stay the same
- [ ] Manual: resize the app window — sidebar width should not change
- [ ] Manual: toggle sidebar placement (left/right) — divider should reposition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)