### PR TITLE
fix: prevent sidebar width from changing during window resize

### DIFF
--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -68,13 +68,23 @@ private final class SidebarPositionHelperView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         removeMouseMonitors()
-        guard window != nil else { return }
+        guard window != nil else {
+            resetDividerDragIfNeeded()
+            return
+        }
         installMouseMonitors()
         applyPosition()
     }
 
     deinit {
+        resetDividerDragIfNeeded()
         removeMouseMonitors()
+    }
+
+    private func resetDividerDragIfNeeded() {
+        guard isDraggingDivider else { return }
+        isDraggingDivider = false
+        onDividerDragActive?(false)
     }
 
     private func installMouseMonitors() {
@@ -386,7 +396,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
         .frame(
             minWidth: ReaderSidebarWorkspaceMetrics.sidebarMinimumWidth,
             idealWidth: sidebarWidth,
-            maxWidth: isDraggingDivider ? .infinity : sidebarWidth,
+            maxWidth: isDraggingDivider ? .infinity : max(sidebarWidth, ReaderSidebarWorkspaceMetrics.sidebarMinimumWidth),
             maxHeight: .infinity
         )
         .background(

--- a/minimarkUITests/minimarkUITests.swift
+++ b/minimarkUITests/minimarkUITests.swift
@@ -229,19 +229,25 @@ final class minimarkUITests: XCTestCase {
             app.staticTexts["README.md"].exists
         }
 
-        Thread.sleep(forTimeInterval: 1.0)
-
         let window = app.windows.firstMatch
+
+        // Wait for sidebar layout to stabilize
+        waitForCondition(timeout: 3) {
+            sidebar.frame.width > 100
+        }
+
         let initialSidebarWidth = sidebar.frame.width
         let initialWindowWidth = window.frame.width
-        XCTAssertGreaterThan(initialSidebarWidth, 100, "Sidebar should have measurable width")
 
         // Drag right edge of window 300px wider
         let rightEdge = window.coordinate(withNormalizedOffset: CGVector(dx: 1.0, dy: 0.5))
         let expandTarget = rightEdge.withOffset(CGVector(dx: 300, dy: 0))
         rightEdge.click(forDuration: 0.1, thenDragTo: expandTarget)
 
-        Thread.sleep(forTimeInterval: 1.0)
+        // Wait for window to have expanded
+        waitForCondition(timeout: 3) {
+            window.frame.width > initialWindowWidth + 100
+        }
 
         let expandedWindowWidth = window.frame.width
         XCTAssertGreaterThan(


### PR DESCRIPTION
## Summary
- Sidebar width no longer changes proportionally when the window is resized — `maxWidth: sidebarWidth` constrains NSSplitView, and the GeometryReader write-back is gated to only fire during active divider drags
- Mouse event monitors on the NSSplitView divider area temporarily lift the `maxWidth` constraint during divider drags so manual resizing still works
- Holding priority raised from 251 to `.defaultHigh` (750) for stronger resistance to proportional redistribution

Fixes #71 — sidebar width changing during window resize
Fixes #83 — initial sidebar size not respecting expected value
Fixes #84 — saved sidebar width not recalled when reopening favorite

## Test plan
- [x] UI test: `testSidebarWidthRemainsStableWhenWindowIsResized` — verifies sidebar stays within 5px after 300px window expand
- [x] All unit tests pass
- [ ] Manual: resize window by dragging edges/corners — sidebar width should not change
- [ ] Manual: drag the sidebar divider — sidebar should resize freely
- [ ] Manual: reopen a favorite — saved sidebar width should be restored