### PR TITLE
fix: scanning progress bar not visible when opening favorites (#135)

### DIFF
--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -111,7 +111,6 @@ final class ReaderFolderWatchController {
 
             let isAutoOpenPath = performInitialAutoOpen && options.openMode == .openAllMarkdownFiles
             isInitialMarkdownScanInProgress = true
-            didInitialMarkdownScanFail = false
 
             let progressStream = folderWatcher.scanProgressStream
             scanProgressTask?.cancel()


### PR DESCRIPTION
## Summary
Fixes two root causes that prevented the scanning progress bar from appearing when opening a favorite:

1. **Stream race condition** — The `scanProgressTask` consumer was created *after* `folderWatcher.startWatching()`, which starts producing events on a background queue. For fast scans (~127 files), the stream finished before the `for await` loop was scheduled. Fix: capture the `scanProgressStream` reference synchronously before creating the async task.

2. **Scan flag never set for favorites** — The `isInitialMarkdownScanInProgress` flag was only set when `performInitialAutoOpen == true`, which favorites don't use. Fix: set the flag for all folder watch starts; clear it from the scan progress task when not in the auto-open path (where the load completion manages it instead).

Closes #135

## Test plan
- [ ] Open a favorite with many files (100+) — sidebar footer should show "Scanning X/Y files" progress bar
- [ ] Toolbar button should show a spinner during scan
- [ ] Both indicators clear after scan completes
- [ ] `performInitialAutoOpen` path (non-favorite) still works — existing test `folderWatchControllerIgnoresStaleInitialScanCompletionAfterRestart` passes