### PR TITLE
fix: favorites intermittently lose locked theme on reopen (#82)

### DIFF
--- a/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
@@ -94,25 +94,20 @@ extension ReaderWindowRootView {
     }
 
     func startFavoriteWatch(_ entry: ReaderFavoriteWatchedFolder) {
+        // Restore appearance FIRST so the controller is in the correct lock state
+        // before activeFavoriteWorkspaceState triggers onChange persistence.
+        if let lockedAppearance = entry.workspaceState.lockedAppearance {
+            appearanceController.restore(from: lockedAppearance)
+        } else if appearanceController.isLocked {
+            appearanceController.unlock()
+        }
+
         // Set active favorite and restore workspace state
         activeFavoriteID = entry.id
         activeFavoriteWorkspaceState = entry.workspaceState
         sidebarPinnedGroupIDs = entry.workspaceState.pinnedGroupIDs
         sidebarCollapsedGroupIDs = entry.workspaceState.collapsedGroupIDs
         sidebarWidth = entry.workspaceState.sidebarWidth
-
-        // Defer appearance changes to the next main actor hop to avoid setting
-        // @Published properties on the controller during the view update batch
-        // triggered by the @State assignments above.
-        let lockedAppearance = entry.workspaceState.lockedAppearance
-        let wasLocked = appearanceController.isLocked
-        Task { @MainActor [appearanceController] in
-            if let locked = lockedAppearance {
-                appearanceController.restore(from: locked)
-            } else if wasLocked {
-                appearanceController.unlock()
-            }
-        }
 
         let resolvedURL = settingsStore.resolvedFavoriteWatchedFolderURL(for: entry)
         startWatchingFolder(

--- a/minimarkTests/Core/WindowAppearanceControllerTests.swift
+++ b/minimarkTests/Core/WindowAppearanceControllerTests.swift
@@ -193,4 +193,19 @@ final class WindowAppearanceControllerTests: XCTestCase {
 
         XCTAssertEqual(WindowAppearanceController.lockedWindowCount, before)
     }
+
+    // MARK: - Restore reflects in lockedAppearance immediately
+
+    func testRestoreImmediatelyReflectsInLockedAppearance() {
+        let controller = WindowAppearanceController(settingsStore: settingsStore)
+        let stored = LockedAppearance(readerTheme: .commodore64, baseFontSize: 22, syntaxTheme: .solarizedDark)
+
+        controller.restore(from: stored)
+
+        let snapshot = controller.lockedAppearance
+        XCTAssertNotNil(snapshot)
+        XCTAssertEqual(snapshot?.readerTheme, .commodore64)
+        XCTAssertEqual(snapshot?.baseFontSize, 22)
+        XCTAssertEqual(snapshot?.syntaxTheme, .solarizedDark)
+    }
 }


### PR DESCRIPTION
## Summary
Fixes a race condition in `startFavoriteWatch` that caused favorites to lose their locked appearance when reopened.

**Root cause:** `activeFavoriteWorkspaceState = entry.workspaceState` fires SwiftUI's `onChange` synchronously, which reads `appearanceController.lockedAppearance` and persists it. But `restore(from:)` was deferred to a `Task { @MainActor }` (next main actor hop), so `lockedAppearance` was still `nil` when `onChange` fired — overwriting the saved lock with `nil`.

**Fix:** Move `appearanceController.restore(from:)` to run synchronously *before* `activeFavoriteWorkspaceState` is set. The `Task` deferral served no purpose since the method is already `@MainActor`.

Closes #82

## Test plan
- [ ] Open a favorite with a locked theme → theme should be applied
- [ ] Close and reopen the same favorite → locked theme should persist
- [ ] Open multiple windows with different locked themes → each should retain its theme
- [ ] New test `testRestoreImmediatelyReflectsInLockedAppearance` passes