### PR TITLE
perf: fix 80-second scan delay when opening favorites

### DIFF
--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -18,6 +18,8 @@ protocol FolderChangeWatching: AnyObject, Sendable {
         includeSubfolders: Bool,
         excludedSubdirectoryURLs: [URL]
     ) throws -> [URL]
+
+    func cachedMarkdownFileURLs() -> [URL]?
 }
 
 extension FolderChangeWatching {
@@ -295,6 +297,17 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         )
     }
 
+    func cachedMarkdownFileURLs() -> [URL]? {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            guard didCompleteStartup else { return nil }
+            return lastSnapshot.keys.sorted(by: { $0.path < $1.path })
+        }
+        return queue.sync {
+            guard didCompleteStartup else { return nil }
+            return lastSnapshot.keys.sorted(by: { $0.path < $1.path })
+        }
+    }
+
     var isUsingEventSourcesForTesting: Bool {
         if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
             return usesEventSource
@@ -367,9 +380,12 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             return
         }
 
+        let signpostID = Self.signposter.makeSignpostID()
+        let intervalState = Self.signposter.beginInterval("populateContentPhase", id: signpostID)
+        Self.signposter.emitEvent("contentScanStart", "files \(total)")
+
         var completed = 0
-        var lastYieldedCompleted = 0
-        let yieldInterval = max(1, total / 100)
+        var lastYieldTime = CFAbsoluteTimeGetCurrent()
 
         for url in urls {
             guard startupSequence == self.startupSequence else {
@@ -383,12 +399,16 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             }
             completed += 1
 
+            let now = CFAbsoluteTimeGetCurrent()
             let isLast = completed == total
-            if isLast || (completed - lastYieldedCompleted) >= yieldInterval {
+            if isLast || (now - lastYieldTime) >= 0.25 {
                 scanProgressContinuation?.yield(ScanProgress(completed: completed, total: total))
-                lastYieldedCompleted = completed
+                lastYieldTime = now
             }
         }
+
+        Self.signposter.endInterval("populateContentPhase", intervalState)
+        Self.signposter.emitEvent("contentScanEnd", "files \(total)")
 
         scanProgressContinuation?.finish()
         scanProgressContinuation = nil

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -217,6 +217,12 @@ final class ReaderFolderWatchController {
             return
         }
 
+        if let cachedURLs = folderWatcher.cachedMarkdownFileURLs() {
+            completion(cachedURLs)
+            return
+        }
+
+        // Fall back to full enumeration if scan not yet complete
         let folderURL = session.folderURL
         let includeSubfolders = session.options.scope == .includeSubfolders
         let excludedURLs = session.options.resolvedExcludedSubdirectoryURLs(relativeTo: folderURL)

--- a/minimarkTests/Infrastructure/FolderChangeWatcherScanProgressTests.swift
+++ b/minimarkTests/Infrastructure/FolderChangeWatcherScanProgressTests.swift
@@ -60,6 +60,62 @@ struct FolderChangeWatcherScanProgressTests {
         #expect(final.isFinished)
     }
 
+    @Test @MainActor func scanProgressStreamCompletesForManyFiles() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileCount = 20
+        for i in 0..<fileCount {
+            let fileURL = directoryURL.appendingPathComponent("file\(i).md")
+            try "# File \(i)\nContent for file \(i)".write(to: fileURL, atomically: false, encoding: .utf8)
+        }
+
+        let watcher = makeFolderChangeWatcher()
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: false) { _ in }
+        defer { watcher.stopWatching() }
+
+        var progressUpdates: [FolderChangeWatcher.ScanProgress] = []
+        for await progress in watcher.scanProgressStream {
+            progressUpdates.append(progress)
+        }
+
+        #expect(!progressUpdates.isEmpty)
+
+        let final = try #require(progressUpdates.last)
+        #expect(final.total == fileCount)
+        #expect(final.completed == fileCount)
+        #expect(final.isFinished)
+    }
+
+    @Test @MainActor func cachedMarkdownFileURLsReturnsSnapshotURLs() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileURL1 = directoryURL.appendingPathComponent("a.md")
+        let fileURL2 = directoryURL.appendingPathComponent("b.md")
+        try "# A".write(to: fileURL1, atomically: false, encoding: .utf8)
+        try "# B".write(to: fileURL2, atomically: false, encoding: .utf8)
+
+        let watcher = makeFolderChangeWatcher()
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: false) { _ in }
+        defer { watcher.stopWatching() }
+
+        // Wait for scan to complete by draining the stream
+        for await _ in watcher.scanProgressStream {}
+
+        let cachedURLs = try #require(watcher.cachedMarkdownFileURLs())
+        #expect(cachedURLs.count == 2)
+        let paths = Set(cachedURLs.map(\.lastPathComponent))
+        #expect(paths.contains("a.md"))
+        #expect(paths.contains("b.md"))
+    }
+
+    @Test @MainActor func cachedMarkdownFileURLsReturnsNilWhenNotWatching() {
+        let watcher = makeFolderChangeWatcher()
+        #expect(watcher.cachedMarkdownFileURLs() == nil)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -447,6 +447,7 @@ final class TestFolderWatcher: FolderChangeWatching, @unchecked Sendable {
     var markdownFilesToReturn: [URL] = []
     var markdownFilesError: Error?
     var markdownFilesDelay: TimeInterval = 0
+    var cachedMarkdownFileURLsToReturn: [URL]?
 
     var scanProgressStreamToReturn: AsyncStream<FolderChangeWatcher.ScanProgress> = AsyncStream { $0.finish() }
     var scanProgressStream: AsyncStream<FolderChangeWatcher.ScanProgress> {
@@ -483,6 +484,10 @@ final class TestFolderWatcher: FolderChangeWatching, @unchecked Sendable {
         }
         lastExcludedSubdirectoryURLs = excludedSubdirectoryURLs
         return markdownFilesToReturn
+    }
+
+    func cachedMarkdownFileURLs() -> [URL]? {
+        cachedMarkdownFileURLsToReturn
     }
 
     func emitChangedMarkdownEvents(_ events: [ReaderFolderWatchChangeEvent]) {


### PR DESCRIPTION
## Summary

- Fixes the ~80s "Scanning N/M files" progress bar when opening a favorite with 138 markdown files
- Root cause was a SwiftUI re-render storm: each of 138 progress events triggered a full sidebar re-render (~0.55s each), not slow file I/O (which completes in <0.1s)
- Throttles scan progress yields to at most once per 250ms (time-based instead of count-based)
- Adds `cachedMarkdownFileURLs()` to avoid redundant filesystem enumeration when opening favorites
- Adds signpost profiling for the content population phase

## Test plan

- [x] Open the `markdownobserver-open-source` favorite — progress bar no longer visible (scan completes instantly)
- [x] All `FolderChangeWatcherScanProgressTests` pass (5 tests including 3 new)
- [x] All `FolderWatchControllerScanProgressTests` pass
- [x] All `FolderWatchCoordinationTests` pass
- [x] All `FolderSnapshotDifferTests` pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)