### PR TITLE
fix: migrate ReaderStoreAppearanceRenderTests to Swift Testing

### DIFF
--- a/minimark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/minimark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "3baa0508c7e288a721862104043572008dfe994a2ae32fd5444fcf60e940c4c9",
+  "pins" : [
+    {
+      "identity" : "differ",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tonyarnold/Differ.git",
+      "state" : {
+        "revision" : "5520fda947f1f9777a806389c2ba587219bc0538",
+        "version" : "1.4.6"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/minimarkTests/ReaderStore/ReaderStoreAppearanceRenderTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreAppearanceRenderTests.swift
@@ -1,46 +1,52 @@
-import XCTest
+//
+//  ReaderStoreAppearanceRenderTests.swift
+//  minimarkTests
+//
+
+import Foundation
+import Testing
 @testable import minimark
 
-@MainActor
-final class ReaderStoreAppearanceRenderTests: XCTestCase {
+@Suite(.serialized)
+struct ReaderStoreAppearanceRenderTests {
     private let testAppearance = LockedAppearance(readerTheme: .newspaper, baseFontSize: 20, syntaxTheme: .nord)
 
-    func testSetAppearanceOverrideSetsNeedsAppearanceRender() throws {
+    @Test @MainActor func setAppearanceOverrideSetsNeedsAppearanceRender() throws {
         let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: true)
         defer { fixture.cleanup() }
 
-        XCTAssertFalse(fixture.store.needsAppearanceRender)
+        #expect(!fixture.store.needsAppearanceRender)
 
         fixture.store.setAppearanceOverride(testAppearance)
 
-        XCTAssertTrue(fixture.store.needsAppearanceRender)
+        #expect(fixture.store.needsAppearanceRender)
     }
 
-    func testRenderWithAppearanceClearsNeedsAppearanceRender() throws {
+    @Test @MainActor func renderWithAppearanceClearsNeedsAppearanceRender() throws {
         let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: true)
         defer { fixture.cleanup() }
 
         fixture.store.openFile(at: fixture.primaryFileURL)
 
         fixture.store.setAppearanceOverride(testAppearance)
-        XCTAssertTrue(fixture.store.needsAppearanceRender)
+        #expect(fixture.store.needsAppearanceRender)
 
         try fixture.store.renderWithAppearance(testAppearance)
 
-        XCTAssertFalse(fixture.store.needsAppearanceRender)
+        #expect(!fixture.store.needsAppearanceRender)
     }
 
-    func testRenderCurrentMarkdownClearsNeedsAppearanceRender() throws {
+    @Test @MainActor func renderCurrentMarkdownClearsNeedsAppearanceRender() throws {
         let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: true)
         defer { fixture.cleanup() }
 
         fixture.store.openFile(at: fixture.primaryFileURL)
 
         fixture.store.setAppearanceOverride(testAppearance)
-        XCTAssertTrue(fixture.store.needsAppearanceRender)
+        #expect(fixture.store.needsAppearanceRender)
 
         try fixture.store.renderCurrentMarkdownImmediately()
 
-        XCTAssertFalse(fixture.store.needsAppearanceRender)
+        #expect(!fixture.store.needsAppearanceRender)
     }
 }


### PR DESCRIPTION
## Summary

- Migrates `ReaderStoreAppearanceRenderTests` from XCTest to Swift Testing to fix `signal abrt` crashes caused by XCTest's handling of `@MainActor` object deallocation (Swift runtime back-deploy deinit bug on older macOS)
- Tests pass on CI (newer macOS/Xcode) but crash locally on older macOS — Swift Testing handles actor-isolated teardown correctly on both

Note: WKWebView pre-warming (#150) was investigated but `WKProcessPool` is deprecated on macOS 12+ with no effect. Closed as won't-fix.

## Test plan

- [x] `ReaderStoreAppearanceRenderTests` — all 3 tests pass (previously crashed with signal abrt)
- [x] Full test suite passes with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)