### PR TITLE
perf: extract ContentViewAdapter to narrow observation scope

### DIFF
--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -15,16 +15,22 @@ struct ContentViewAdapter: View {
     let sharedFolderWatchSession: ReaderFolderWatchSession?
     let canStopSharedFolderWatch: Bool
     let pendingFolderWatchURL: URL?
-    let isSharedFolderWatchAFavorite: Bool
 
     let callbacks: ContentViewCallbacks
 
     @Binding var isFolderWatchOptionsPresented: Bool
-    let pendingFolderWatchOpenMode: Binding<ReaderFolderWatchOpenMode>
-    let pendingFolderWatchScope: Binding<ReaderFolderWatchScope>
-    let pendingFolderWatchExcludedSubdirectoryPaths: Binding<[String]>
+    @Binding var pendingFolderWatchOpenMode: ReaderFolderWatchOpenMode
+    @Binding var pendingFolderWatchScope: ReaderFolderWatchScope
+    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
 
     var body: some View {
+        let favorites = settingsStore.currentSettings.favoriteWatchedFolders
+        let isCurrentWatchAFavorite: Bool = {
+            guard let session = sharedFolderWatchSession else { return false }
+            let normalizedPath = ReaderFileRouting.normalizedFileURL(session.folderURL).path
+            return favorites.contains { $0.matches(folderPath: normalizedPath, options: session.options) }
+        }()
+
         ContentView(
             readerStore: readerStore,
             folderWatchState: ContentViewFolderWatchState(
@@ -33,8 +39,8 @@ struct ContentViewAdapter: View {
                 isFolderWatchInitialScanFailed: sidebarDocumentController.didFolderWatchInitialScanFail,
                 canStopFolderWatch: canStopSharedFolderWatch,
                 pendingFolderWatchURL: pendingFolderWatchURL,
-                isCurrentWatchAFavorite: isSharedFolderWatchAFavorite,
-                favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
+                isCurrentWatchAFavorite: isCurrentWatchAFavorite,
+                favoriteWatchedFolders: favorites,
                 recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
                 recentManuallyOpenedFiles: settingsStore.currentSettings.recentManuallyOpenedFiles,
                 isAppearanceLocked: appearanceController.isLocked,
@@ -42,9 +48,9 @@ struct ContentViewAdapter: View {
             ),
             callbacks: callbacks,
             isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
-            pendingFolderWatchOpenMode: pendingFolderWatchOpenMode,
-            pendingFolderWatchScope: pendingFolderWatchScope,
-            pendingFolderWatchExcludedSubdirectoryPaths: pendingFolderWatchExcludedSubdirectoryPaths
+            pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
+            pendingFolderWatchScope: $pendingFolderWatchScope,
+            pendingFolderWatchExcludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths
         )
     }
 }

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -466,7 +466,6 @@ struct ReaderWindowRootView: View {
             sharedFolderWatchSession: sharedFolderWatchSession,
             canStopSharedFolderWatch: canStopSharedFolderWatch,
             pendingFolderWatchURL: pendingFolderWatchURL,
-            isSharedFolderWatchAFavorite: isSharedFolderWatchAFavorite,
             callbacks: ContentViewCallbacks(
                 onRequestFileOpen: { [self] request in
                     fileOpenCoordinator.open(request)


### PR DESCRIPTION
## Summary

- Introduces `ContentViewAdapter`, a child view that sits between `ReaderSidebarWorkspaceView`'s detail closure and `ContentView`
- Moves `ContentViewFolderWatchState` construction (which reads ~5 `@Observable` properties and copies 3 arrays by value) from the sidebar workspace's observation scope into the adapter's narrower scope
- Changes to `settingsStore.currentSettings`, `appearanceController.isLocked`, and `sidebarDocumentController.isFolderWatchInitialScanInProgress` now only trigger the adapter's body — not the entire sidebar workspace layout

Closes #168

## Test plan

- [x] Build succeeds
- [x] All unit tests pass
- [ ] Manual: open a folder watch, verify content view renders correctly
- [ ] Manual: toggle appearance lock, verify it propagates to all documents
- [ ] Manual: add/remove favorites, verify lists update in menus