### PR TITLE
fix: restore sidebar width from favorite when sidebar re-appears

### DIFF
--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -180,6 +180,10 @@ struct ReaderWindowRootView: View {
                     return
                 }
 
+                if isSidebarVisible, let favoriteWidth = activeFavoriteWorkspaceState?.sidebarWidth {
+                    sidebarWidth = favoriteWidth
+                }
+
                 let delta = isSidebarVisible
                     ? sidebarWidth
                     : -lastAppliedSidebarDelta


### PR DESCRIPTION
## Summary

- When the sidebar hides (document count drops to 1), the local `sidebarWidth` state resets to `sidebarIdealWidth`. When the sidebar re-appears within the same favorite session, the stale default was driving the divider position instead of the stored favorite width.
- Restores `sidebarWidth` from `activeFavoriteWorkspaceState.sidebarWidth` before computing the window frame delta in the `onChange(of: documents.count)` handler.

## Test plan

- [x] Build passes
- [x] All existing unit tests pass (data model round-trip, store persistence already covered)
- [ ] Manual: open a favorited folder with 2+ docs, drag sidebar to custom width, close all but one doc, re-open a second doc — sidebar should restore to the custom width

Fixes #156