### PR TITLE
fix: prevent table cells from shrinking below readable width

### DIFF
--- a/minimark/Support/ReaderCSSThemeGenerator.swift
+++ b/minimark/Support/ReaderCSSThemeGenerator.swift
@@ -372,7 +372,7 @@ enum ReaderCSSThemeGenerator {
           padding: 0.45em 0.65em;
           border: 1px solid var(--reader-border);
           vertical-align: top;
-          min-width: 4em;
+          min-width: 8ch;
           word-break: keep-all;
         }
 


### PR DESCRIPTION
## Summary

- Add `min-width: 4em` to `td`/`th` CSS rules so table cells never shrink below ~4 characters wide
- Add `word-break: keep-all` to prevent short words from breaking across lines
- Existing `overflow-x: auto` on tables handles any horizontal overflow from wider minimum widths

Closes #159