### PR TITLE
feat: animate sidebar group expand/collapse

### DIFF
--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -624,7 +624,9 @@ private struct SidebarGroupListContent: View {
 private struct SidebarGroupDisclosureStyle: DisclosureGroupStyle {
     func makeBody(configuration: Configuration) -> some View {
         Button {
-            configuration.isExpanded.toggle()
+            withAnimation(.easeInOut(duration: 0.2)) {
+                configuration.isExpanded.toggle()
+            }
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: "chevron.right")
@@ -649,6 +651,7 @@ private struct SidebarGroupDisclosureStyle: DisclosureGroupStyle {
         if configuration.isExpanded {
             configuration.content
                 .padding(.leading, 12)
+                .transition(.opacity.combined(with: .move(edge: .top)))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Wrap the disclosure toggle action in `withAnimation(.easeInOut(duration: 0.2))` for smooth expand/collapse
- Add `.transition(.opacity.combined(with: .move(edge: .top)))` to the content block so rows slide in/out
- The custom `DisclosureGroupStyle` renders content directly in `makeBody` (not as `NSOutlineView` child rows), so SwiftUI animation works despite the sidebar `List` being backed by `NSOutlineView`

## Technical note

The chevron rotation was already implicitly animated via `.rotationEffect`. Now it shares the same animation timing as the content reveal.

`collapsedGroupIDs` changes remain synchronous and do not trigger `recomputeGrouping` — only the view-level expand/collapse is affected.

Closes #164