### PR TITLE
Improve notification text formatting

### DIFF
--- a/minimark/Models/ReaderFolderWatchChangeEvent.swift
+++ b/minimark/Models/ReaderFolderWatchChangeEvent.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ReaderFolderWatchChangeKind: String, Equatable, Hashable, Codable, Sendable {
     case added
     case modified
+    case deleted
 }
 
 struct ReaderFolderWatchChangeEvent: Equatable, Hashable, Codable, Sendable {

--- a/minimark/Services/ReaderSystemNotificationService.swift
+++ b/minimark/Services/ReaderSystemNotificationService.swift
@@ -155,17 +155,12 @@ struct ReaderNotificationStatus: Equatable {
     }
 }
 
-private enum ReaderNotificationCopy {
-    static let appName = "MarkdownObserver"
-}
-
 protocol ReaderSystemNotifying {
-    func notifyFileAutoLoaded(
+    func notifyFileChanged(
         _ fileURL: URL,
         changeKind: ReaderFolderWatchChangeKind,
         watchedFolderURL: URL?
     )
-    func notifyExternalChange(for fileURL: URL, autoRefreshed: Bool, watchedFolderURL: URL?)
 }
 
 private enum ReaderSystemNotificationUserInfoKey {
@@ -174,32 +169,16 @@ private enum ReaderSystemNotificationUserInfoKey {
 }
 
 private enum ReaderSystemNotificationEvent {
-    case fileAutoLoaded(changeKind: ReaderFolderWatchChangeKind)
-    case externalChange(autoRefreshed: Bool)
+    case fileChanged(changeKind: ReaderFolderWatchChangeKind)
 
-    var statusText: String {
+    var titleText: String {
         switch self {
-        case .fileAutoLoaded(changeKind: .added):
-            return "Opened automatically in \(ReaderNotificationCopy.appName)"
-        case .fileAutoLoaded(changeKind: .modified):
-            return "Updated and opened in \(ReaderNotificationCopy.appName)"
-        case .externalChange(autoRefreshed: true):
-            return "Reloaded after edits outside \(ReaderNotificationCopy.appName)"
-        case .externalChange(autoRefreshed: false):
-            return "Edited outside \(ReaderNotificationCopy.appName)"
-        }
-    }
-
-    var folderlessSubtitle: String {
-        switch self {
-        case .fileAutoLoaded(changeKind: .added):
-            return "New file"
-        case .fileAutoLoaded(changeKind: .modified):
-            return "Updated file"
-        case .externalChange(autoRefreshed: true):
-            return "External edit reloaded"
-        case .externalChange(autoRefreshed: false):
-            return "External edit detected"
+        case .fileChanged(changeKind: .added):
+            return "🟢 Created"
+        case .fileChanged(changeKind: .modified):
+            return "🟡 Modified"
+        case .fileChanged(changeKind: .deleted):
+            return "🔴 Deleted"
         }
     }
 }
@@ -226,19 +205,10 @@ private struct ReaderSystemNotificationDescriptor {
         let normalizedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
         let normalizedWatchedFolderURL = watchedFolderURL.map(ReaderFileRouting.normalizedFileURL)
         let fileName = normalizedFileURL.lastPathComponent
-        let watchedFolderName = normalizedWatchedFolderURL.map(Self.displayName(for:))
-        let parentFolderName = Self.displayName(for: normalizedFileURL.deletingLastPathComponent())
 
-        title = fileName.isEmpty ? normalizedFileURL.path : fileName
-        subtitle = watchedFolderName.map { "Folder watch: \($0)" } ?? event.folderlessSubtitle
-
-        var bodyLines = [event.statusText]
-        if watchedFolderName == nil {
-            bodyLines.append("Folder: \(parentFolderName)")
-        } else if watchedFolderName != parentFolderName {
-            bodyLines.append("Subfolder: \(parentFolderName)")
-        }
-        body = bodyLines.joined(separator: "\n")
+        title = event.titleText
+        subtitle = fileName.isEmpty ? normalizedFileURL.path : fileName
+        body = ""
 
         var userInfo: [AnyHashable: Any] = [
             ReaderSystemNotificationUserInfoKey.filePath: normalizedFileURL.path
@@ -247,11 +217,6 @@ private struct ReaderSystemNotificationDescriptor {
             userInfo[ReaderSystemNotificationUserInfoKey.watchedFolderPath] = normalizedWatchedFolderURL.path
         }
         self.userInfo = userInfo
-    }
-
-    private nonisolated static func displayName(for url: URL) -> String {
-        let lastPathComponent = url.lastPathComponent
-        return lastPathComponent.isEmpty ? url.path : lastPathComponent
     }
 }
 
@@ -335,7 +300,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
         )
     }
 
-    func notifyFileAutoLoaded(
+    func notifyFileChanged(
         _ fileURL: URL,
         changeKind: ReaderFolderWatchChangeKind,
         watchedFolderURL: URL?
@@ -344,17 +309,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
             ReaderSystemNotificationDescriptor(
                 fileURL: fileURL,
                 watchedFolderURL: watchedFolderURL,
-                event: .fileAutoLoaded(changeKind: changeKind)
-            )
-        )
-    }
-
-    func notifyExternalChange(for fileURL: URL, autoRefreshed: Bool, watchedFolderURL: URL?) {
-        postNotification(
-            ReaderSystemNotificationDescriptor(
-                fileURL: fileURL,
-                watchedFolderURL: watchedFolderURL,
-                event: .externalChange(autoRefreshed: autoRefreshed)
+                event: .fileChanged(changeKind: changeKind)
             )
         )
     }

--- a/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
@@ -97,7 +97,7 @@ extension ReaderStore {
             return
         }
 
-        systemNotifier.notifyFileAutoLoaded(
+        systemNotifier.notifyFileChanged(
             normalizedURL,
             changeKind: initialDiffBaselineMarkdown == nil ? .added : .modified,
             watchedFolderURL: activeFolderWatchSession?.folderURL

--- a/minimark/Stores/Coordination/ReaderStore+ExternalChangeFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+ExternalChangeFlow.swift
@@ -46,9 +46,9 @@ extension ReaderStore {
         noteObservedExternalChange(kind: .modified)
         if let fileURL,
            settingsStore.currentSettings.notificationsEnabled {
-            systemNotifier.notifyExternalChange(
-                for: fileURL,
-                autoRefreshed: settingsStore.currentSettings.autoRefreshOnExternalChange,
+            systemNotifier.notifyFileChanged(
+                fileURL,
+                changeKind: currentDocumentHasBeenDeleted ? .deleted : .modified,
                 watchedFolderURL: watchedFolderURLForCurrentFile
             )
         }

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -329,7 +329,7 @@ final class ReaderFolderWatchController {
         if origin.shouldNotifyFileAutoLoaded,
            events.count == 1,
            settingsStore.currentSettings.notificationsEnabled {
-            systemNotifier.notifyFileAutoLoaded(
+            systemNotifier.notifyFileChanged(
                 events[0].fileURL,
                 changeKind: events[0].kind,
                 watchedFolderURL: session.folderURL

--- a/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
+++ b/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
@@ -680,7 +680,7 @@ struct ReaderSettingsAndModelsTests {
         let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
         let fileURL = watchedFolderURL.appendingPathComponent("roadmap.md")
 
-        notifier.notifyFileAutoLoaded(
+        notifier.notifyFileChanged(
             fileURL,
             changeKind: .modified,
             watchedFolderURL: watchedFolderURL
@@ -695,9 +695,9 @@ struct ReaderSettingsAndModelsTests {
 
         let request = try #require(notificationCenter.addedRequests.first)
         #expect(request.trigger == nil)
-        #expect(request.content.title == "roadmap.md")
-        #expect(request.content.subtitle == "Folder watch: docs")
-        #expect(request.content.body == "Updated and opened in MarkdownObserver")
+        #expect(request.content.title == "🟡 Modified")
+        #expect(request.content.subtitle == "roadmap.md")
+        #expect(request.content.body == "")
         #expect(request.content.userInfo["filePath"] as? String == fileURL.path)
         #expect(request.content.userInfo["watchedFolderPath"] as? String == watchedFolderURL.path)
     }

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -45,10 +45,10 @@ struct ReaderStoreExternalChangeTests {
         fixture.store.openFile(at: fixture.primaryFileURL)
         fixture.store.handleObservedFileChange()
 
-        #expect(fixture.notifier.externalChangeNotifications == [
-            TestReaderSystemNotifier.ExternalChangeNotification(
+        #expect(fixture.notifier.fileChangeNotifications == [
+            TestReaderSystemNotifier.FileChangeNotification(
                 fileURL: ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL),
-                autoRefreshed: false,
+                changeKind: .modified,
                 watchedFolderURL: nil
             )
         ])
@@ -64,7 +64,7 @@ struct ReaderStoreExternalChangeTests {
         fixture.store.openFile(at: fixture.primaryFileURL)
         fixture.store.handleObservedFileChange()
 
-        #expect(fixture.notifier.externalChangeNotifications.isEmpty)
+        #expect(fixture.notifier.fileChangeNotifications.isEmpty)
     }
 
     @Test @MainActor func folderWatchAutoOpenSkipsSystemNotificationWhenDisabled() throws {
@@ -76,7 +76,7 @@ struct ReaderStoreExternalChangeTests {
 
         fixture.store.openFile(at: fixture.primaryFileURL, origin: .folderWatchAutoOpen)
 
-        #expect(fixture.notifier.autoLoadedNotifications.isEmpty)
+        #expect(fixture.notifier.fileChangeNotifications.isEmpty)
     }
 
     @Test @MainActor func decoratedWindowTitlePrependsAsteriskOnlyWhenPending() throws {
@@ -280,7 +280,7 @@ struct ReaderStoreExternalChangeTests {
 
         fixture.store.openFile(at: fixture.primaryFileURL, origin: .folderWatchAutoOpen)
 
-        #expect(fixture.notifier.autoLoadedNotifications.isEmpty)
+        #expect(fixture.notifier.fileChangeNotifications.isEmpty)
     }
 
     @Test @MainActor func folderWatchAutoOpenStillHighlightsAfterIgnoredInitialWatcherNoise() throws {
@@ -524,7 +524,7 @@ struct ReaderStoreExternalChangeTests {
         await Task.yield()
 
         #expect(fixture.store.hasUnacknowledgedExternalChange)
-        #expect(fixture.notifier.externalChangeNotifications.count == 1)
+        #expect(fixture.notifier.fileChangeNotifications.count == 1)
     }
 
     @Test @MainActor func autoRefreshDisabledStillMarksExternalChangeAsPending() throws {
@@ -587,7 +587,7 @@ struct ReaderStoreExternalChangeTests {
         ])
 
         #expect(!fixture.store.hasUnacknowledgedExternalChange)
-        #expect(fixture.notifier.externalChangeNotifications.isEmpty)
+        #expect(fixture.notifier.fileChangeNotifications.isEmpty)
         #expect(fixture.watcher.startCallCount == 1)
     }
 
@@ -611,7 +611,7 @@ struct ReaderStoreExternalChangeTests {
         await Task.yield()
 
         #expect(fixture.store.hasUnacknowledgedExternalChange)
-        #expect(fixture.notifier.externalChangeNotifications.count == 1)
+        #expect(fixture.notifier.fileChangeNotifications.count == 1)
     }
 
     @Test @MainActor func watchedFolderChangesOpenMarkdownAsAdditionalDocuments() throws {

--- a/minimarkTests/ReaderStore/ReaderStoreSourceEditingTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreSourceEditingTests.swift
@@ -161,7 +161,7 @@ struct ReaderStoreSourceEditingTests {
         #expect(fixture.store.changedRegions == [Self.sampleChangedRegion])
         #expect(!fixture.store.hasUnacknowledgedExternalChange)
         #expect(fixture.store.lastExternalChangeAt == nil)
-        #expect(fixture.notifier.externalChangeNotifications.isEmpty)
+        #expect(fixture.notifier.fileChangeNotifications.isEmpty)
     }
 
     @Test @MainActor func discardDraftRestoresSavedContent() throws {

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -615,40 +615,23 @@ final class TestWorkspace: WorkspaceControlling {
 }
 
 final class TestReaderSystemNotifier: ReaderSystemNotifying {
-    struct AutoLoadedNotification: Equatable {
+    struct FileChangeNotification: Equatable {
         let fileURL: URL
         let changeKind: ReaderFolderWatchChangeKind
         let watchedFolderURL: URL?
     }
 
-    struct ExternalChangeNotification: Equatable {
-        let fileURL: URL
-        let autoRefreshed: Bool
-        let watchedFolderURL: URL?
-    }
+    private(set) var fileChangeNotifications: [FileChangeNotification] = []
 
-    private(set) var autoLoadedNotifications: [AutoLoadedNotification] = []
-    private(set) var externalChangeNotifications: [ExternalChangeNotification] = []
-
-    func notifyFileAutoLoaded(
+    func notifyFileChanged(
         _ fileURL: URL,
         changeKind: ReaderFolderWatchChangeKind,
         watchedFolderURL: URL?
     ) {
-        autoLoadedNotifications.append(
-            AutoLoadedNotification(
+        fileChangeNotifications.append(
+            FileChangeNotification(
                 fileURL: ReaderFileRouting.normalizedFileURL(fileURL),
                 changeKind: changeKind,
-                watchedFolderURL: watchedFolderURL.map(ReaderFileRouting.normalizedFileURL)
-            )
-        )
-    }
-
-    func notifyExternalChange(for fileURL: URL, autoRefreshed: Bool, watchedFolderURL: URL?) {
-        externalChangeNotifications.append(
-            ExternalChangeNotification(
-                fileURL: ReaderFileRouting.normalizedFileURL(fileURL),
-                autoRefreshed: autoRefreshed,
                 watchedFolderURL: watchedFolderURL.map(ReaderFileRouting.normalizedFileURL)
             )
         )


### PR DESCRIPTION
Closes #195

## Summary

- Replaced verbose notification text with a clean two-line format: **emoji + event label** as title, **filename** as subtitle, empty body
- Collapsed the two-method protocol (`notifyFileAutoLoaded` + `notifyExternalChange`) into a single `notifyFileChanged(_:changeKind:watchedFolderURL:)`
- Added `.deleted` case to `ReaderFolderWatchChangeKind` — deletion notifications now fire when the **currently open file** is removed
- Simplified `ReaderSystemNotificationEvent` from two cases to one, removing `statusText` and `folderlessSubtitle`

## New notification format

| Event | title | subtitle |
|---|---|---|
| File created | 🟢 Created | `roadmap.md` |
| File modified | 🟡 Modified | `roadmap.md` |
| File deleted | 🔴 Deleted | `roadmap.md` |

## Scope clarification

Deletion notifications currently apply to the **currently open/observed file** only (detected via `currentDocumentHasBeenDeleted` in ExternalChangeFlow). The folder-watch diffing logic does not yet emit `.deleted` events for files removed from watched folders — that is a separate enhancement. The `.deleted` case is added to `ReaderFolderWatchChangeKind` now so the model and notification format are ready.

## Changes

- `ReaderFolderWatchChangeKind` gains `.deleted` case
- `ReaderSystemNotificationEvent` collapsed to single `.fileChanged(changeKind:)` case
- `ReaderSystemNotificationDescriptor` simplified — no more folder context in body
- `ReaderSystemNotifying` protocol unified to one method
- External change flow now sends `.deleted` when `currentDocumentHasBeenDeleted` is true
- Test double simplified from 2 methods/2 structs to 1/1

## Test plan

- [x] All existing tests updated and passing (`xcodebuild test -only-testing:minimarkTests` — **TEST SUCCEEDED**)
- [ ] Manual: trigger file create/modify in a watched folder and verify notification banner format
- [ ] Manual: delete the currently open file and verify 🔴 Deleted notification appears