### PR TITLE
fix: preserve manual group order when switching sort modes

### DIFF
--- a/minimark/Models/ReaderSidebarSortMode.swift
+++ b/minimark/Models/ReaderSidebarSortMode.swift
@@ -16,6 +16,10 @@ nonisolated enum ReaderSidebarSortMode: String, Codable, Sendable {
         .lastChangedOldestFirst
     ]
 
+    static func availableCases(hasManualOrder: Bool) -> [ReaderSidebarSortMode] {
+        hasManualOrder ? allCases + [.manualOrder] : allCases
+    }
+
     var displayName: String {
         switch self {
         case .openOrder:

--- a/minimark/Stores/SidebarGroupStateController.swift
+++ b/minimark/Stores/SidebarGroupStateController.swift
@@ -9,9 +9,6 @@ final class SidebarGroupStateController {
 
     var sortMode: ReaderSidebarSortMode = .lastChangedNewestFirst {
         didSet {
-            if sortMode != .manualOrder {
-                manualGroupOrder = nil
-            }
             recomputeGroupingIfNeeded()
         }
     }

--- a/minimark/Stores/SidebarGroupStateController.swift
+++ b/minimark/Stores/SidebarGroupStateController.swift
@@ -243,7 +243,8 @@ final class SidebarGroupStateController {
         pinnedGroupIDs.formIntersection(activeGroupIDs)
         savedCollapsedGroupIDs?.formIntersection(activeGroupIDs)
         if let manualGroupOrder {
-            self.manualGroupOrder = manualGroupOrder.filter { activeGroupIDs.contains($0) }
+            let pruned = manualGroupOrder.filter { activeGroupIDs.contains($0) }
+            self.manualGroupOrder = pruned.isEmpty ? nil : pruned
         }
     }
 

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -194,7 +194,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
 
     private var sidebarGroupSortMenu: some View {
         Menu {
-            ForEach(ReaderSidebarSortMode.allCases, id: \.self) { mode in
+            ForEach(ReaderSidebarSortMode.availableCases(hasManualOrder: groupState.manualGroupOrder != nil), id: \.self) { mode in
                 Button {
                     groupState.sortMode = mode
                 } label: {

--- a/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
+++ b/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
@@ -312,7 +312,7 @@ struct SidebarGroupStateControllerTests {
             return
         }
 
-        #expect(controller.manualGroupOrder != nil)
+        #expect(controller.manualGroupOrder == [harness.directoryPath(for: "beta")])
         #expect(groups.first?.displayName == "alpha")
     }
 

--- a/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
+++ b/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
@@ -293,7 +293,7 @@ struct SidebarGroupStateControllerTests {
         #expect(groups.map(\.id) == [gammaPath, alphaPath, harness.directoryPath(for: "beta")])
     }
 
-    @Test @MainActor func selectingAlgorithmicSortClearsManualOrder() throws {
+    @Test @MainActor func selectingAlgorithmicSortPreservesManualOrder() throws {
         let harness = try ReaderSidebarGroupingTestHarness(
             subdirectories: ["alpha", "beta"],
             filesPerSubdirectory: 1
@@ -312,8 +312,36 @@ struct SidebarGroupStateControllerTests {
             return
         }
 
-        #expect(controller.manualGroupOrder == nil)
+        #expect(controller.manualGroupOrder != nil)
         #expect(groups.first?.displayName == "alpha")
+    }
+
+    @Test @MainActor func switchingBackToManualOrderRestoresCustomOrder() throws {
+        let harness = try ReaderSidebarGroupingTestHarness(
+            subdirectories: ["alpha", "beta", "gamma"],
+            filesPerSubdirectory: 1
+        )
+        defer { harness.cleanup() }
+
+        let controller = SidebarGroupStateController()
+        controller.updateDocuments(harness.documents)
+
+        let gammaPath = harness.directoryPath(for: "gamma")
+        let alphaPath = harness.directoryPath(for: "alpha")
+        let betaPath = harness.directoryPath(for: "beta")
+        controller.manualGroupOrder = [gammaPath, alphaPath, betaPath]
+        controller.sortMode = .manualOrder
+
+        controller.sortMode = .nameAscending
+
+        controller.sortMode = .manualOrder
+
+        guard case .grouped(let groups) = controller.computedGrouping else {
+            Issue.record("Expected grouped result")
+            return
+        }
+
+        #expect(groups.map(\.id) == [gammaPath, alphaPath, betaPath])
     }
 
     @Test @MainActor func manualOrderPreservesPinnedGroupFloat() throws {


### PR DESCRIPTION
## Summary
- Keep `manualGroupOrder` when switching away from manual sort mode, so users can return to their custom ordering via the dropdown
- Show "Manual" entry in the group sort dropdown whenever a manual order has been defined

Closes #197

## Test plan
- [x] `selectingAlgorithmicSortPreservesManualOrder` — verifies order is retained after switching
- [x] `switchingBackToManualOrderRestoresCustomOrder` — round-trip: manual → name ascending → manual restores custom order
- [ ] Manual: drag-reorder groups, switch to "Name A-Z", verify "Manual" still appears in dropdown, switch back and confirm order is restored