### PR TITLE
Dock icon indicators for created/modified/deleted counts

### DIFF
--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -32,6 +32,7 @@ final class ReaderSidebarDocumentController {
     @ObservationIgnored private var selectedStoreObservationTask: Task<Void, Never>?
     @ObservationIgnored private var storeConfigurator: ((ReaderStore) -> Void)?
     @ObservationIgnored var onRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
+    @ObservationIgnored var onDockTileRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
     @ObservationIgnored private var selectedStoreBindingGeneration: UInt = 0
     @ObservationIgnored private var documentObservationTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var rowIndicatorPulseTokens: [UUID: Int] = [:]
@@ -533,6 +534,7 @@ final class ReaderSidebarDocumentController {
         guard states != rowStates else { return }
         rowStates = states
         onRowStatesChanged?(states)
+        onDockTileRowStatesChanged?(states)
     }
 
     private func synchronizeDocumentChangeObservers() {
@@ -577,6 +579,7 @@ final class ReaderSidebarDocumentController {
         if rowStates[documentID] != refreshedState {
             rowStates[documentID] = refreshedState
             onRowStatesChanged?(rowStates)
+            onDockTileRowStatesChanged?(rowStates)
         }
     }
 

--- a/minimark/Support/DockTileController.swift
+++ b/minimark/Support/DockTileController.swift
@@ -19,25 +19,10 @@ final class DockTileController {
     func configureDockTileIfNeeded() {
         guard !isConfigured else { return }
         isConfigured = true
-        configureDockTile()
-    }
 
-    private func configureDockTile() {
         let view = DockTileBadgeView(frame: NSRect(x: 0, y: 0, width: 128, height: 128))
         badgeView = view
         NSApp?.dockTile.contentView = view
-        NSApp?.dockTile.display()
-
-        onCountsChanged = { [weak self] created, modified, deleted in
-            self?.updateBadgeView(created: created, modified: modified, deleted: deleted)
-        }
-    }
-
-    private func updateBadgeView(created: Int, modified: Int, deleted: Int) {
-        guard let badgeView else { return }
-        badgeView.counts = DockTileBadgeView.Counts(
-            created: created, modified: modified, deleted: deleted
-        )
         NSApp?.dockTile.display()
     }
 
@@ -78,6 +63,13 @@ final class DockTileController {
 
         if changed {
             onCountsChanged?(created, modified, deleted)
+
+            if let badgeView {
+                badgeView.counts = DockTileBadgeView.Counts(
+                    created: created, modified: modified, deleted: deleted
+                )
+                NSApp?.dockTile.display()
+            }
         }
     }
 

--- a/minimark/Support/DockTileController.swift
+++ b/minimark/Support/DockTileController.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@MainActor
+final class DockTileController {
+    static let shared = DockTileController()
+
+    private(set) var createdCount = 0
+    private(set) var modifiedCount = 0
+    private(set) var deletedCount = 0
+
+    var onCountsChanged: ((_ created: Int, _ modified: Int, _ deleted: Int) -> Void)?
+
+    private var rowStatesByWindow: [UUID: [UUID: SidebarRowState]] = [:]
+
+    init() {}
+
+    func updateRowStates(for windowToken: UUID, rowStates: [UUID: SidebarRowState]) {
+        rowStatesByWindow[windowToken] = rowStates
+        recomputeCounts()
+    }
+
+    func removeRowStates(for windowToken: UUID) {
+        rowStatesByWindow.removeValue(forKey: windowToken)
+        recomputeCounts()
+    }
+
+    private func recomputeCounts() {
+        var created = 0
+        var modified = 0
+        var deleted = 0
+
+        for (_, rowStates) in rowStatesByWindow {
+            for (_, state) in rowStates {
+                switch state.indicatorState {
+                case .addedExternalChange:
+                    created += 1
+                case .externalChange:
+                    modified += 1
+                case .deletedExternalChange:
+                    deleted += 1
+                case .none:
+                    break
+                }
+            }
+        }
+
+        let changed = created != createdCount || modified != modifiedCount || deleted != deletedCount
+        createdCount = created
+        modifiedCount = modified
+        deletedCount = deleted
+
+        if changed {
+            onCountsChanged?(created, modified, deleted)
+        }
+    }
+
+    func resetForTesting() {
+        rowStatesByWindow.removeAll()
+        createdCount = 0
+        modifiedCount = 0
+        deletedCount = 0
+        onCountsChanged = nil
+    }
+}

--- a/minimark/Support/DockTileController.swift
+++ b/minimark/Support/DockTileController.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 
 @MainActor
 final class DockTileController {
@@ -11,8 +11,35 @@ final class DockTileController {
     var onCountsChanged: ((_ created: Int, _ modified: Int, _ deleted: Int) -> Void)?
 
     private var rowStatesByWindow: [UUID: [UUID: SidebarRowState]] = [:]
+    private var badgeView: DockTileBadgeView?
+    private var isConfigured = false
 
     init() {}
+
+    func configureDockTileIfNeeded() {
+        guard !isConfigured else { return }
+        isConfigured = true
+        configureDockTile()
+    }
+
+    private func configureDockTile() {
+        let view = DockTileBadgeView(frame: NSRect(x: 0, y: 0, width: 128, height: 128))
+        badgeView = view
+        NSApp?.dockTile.contentView = view
+        NSApp?.dockTile.display()
+
+        onCountsChanged = { [weak self] created, modified, deleted in
+            self?.updateBadgeView(created: created, modified: modified, deleted: deleted)
+        }
+    }
+
+    private func updateBadgeView(created: Int, modified: Int, deleted: Int) {
+        guard let badgeView else { return }
+        badgeView.counts = DockTileBadgeView.Counts(
+            created: created, modified: modified, deleted: deleted
+        )
+        NSApp?.dockTile.display()
+    }
 
     func updateRowStates(for windowToken: UUID, rowStates: [UUID: SidebarRowState]) {
         rowStatesByWindow[windowToken] = rowStates
@@ -60,5 +87,7 @@ final class DockTileController {
         modifiedCount = 0
         deletedCount = 0
         onCountsChanged = nil
+        badgeView = nil
+        isConfigured = false
     }
 }

--- a/minimark/Views/DockTileBadgeView.swift
+++ b/minimark/Views/DockTileBadgeView.swift
@@ -1,0 +1,86 @@
+import AppKit
+
+final class DockTileBadgeView: NSView {
+    struct Counts: Equatable {
+        var created: Int
+        var modified: Int
+        var deleted: Int
+
+        var isEmpty: Bool { created == 0 && modified == 0 && deleted == 0 }
+    }
+
+    var counts = Counts(created: 0, modified: 0, deleted: 0) {
+        didSet {
+            if counts != oldValue {
+                needsDisplay = true
+            }
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let appIcon = NSApp?.applicationIconImage else { return }
+        appIcon.draw(in: bounds)
+
+        guard !counts.isEmpty else { return }
+
+        let bubbleDiameter: CGFloat = 24
+        let bubbleSpacing: CGFloat = 3
+        let borderWidth: CGFloat = 2
+        let fontSize: CGFloat = 11
+
+        let activeBubbles: [(color: NSColor, count: Int)] = [
+            (.systemGreen, counts.created),
+            (.systemYellow, counts.modified),
+            (.systemRed, counts.deleted),
+        ].filter { $0.count > 0 }
+
+        let totalWidth = CGFloat(activeBubbles.count) * bubbleDiameter
+            + CGFloat(max(activeBubbles.count - 1, 0)) * bubbleSpacing
+
+        let startX = bounds.maxX - totalWidth - 2
+        let centerY = bounds.maxY - bubbleDiameter / 2 - 2
+
+        let font = NSFont.boldSystemFont(ofSize: fontSize)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+
+        for (index, bubble) in activeBubbles.enumerated() {
+            let centerX = startX + CGFloat(index) * (bubbleDiameter + bubbleSpacing) + bubbleDiameter / 2
+            let bubbleRect = NSRect(
+                x: centerX - bubbleDiameter / 2,
+                y: centerY - bubbleDiameter / 2,
+                width: bubbleDiameter,
+                height: bubbleDiameter
+            )
+
+            // White border
+            let borderPath = NSBezierPath(ovalIn: bubbleRect)
+            NSColor.white.setFill()
+            borderPath.fill()
+
+            // Colored fill
+            let insetRect = bubbleRect.insetBy(dx: borderWidth, dy: borderWidth)
+            let fillPath = NSBezierPath(ovalIn: insetRect)
+            bubble.color.setFill()
+            fillPath.fill()
+
+            // Count text
+            let text = "\(bubble.count)" as NSString
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: NSColor.white,
+                .paragraphStyle: paragraphStyle,
+            ]
+            let textSize = text.size(withAttributes: attributes)
+            let textRect = NSRect(
+                x: centerX - textSize.width / 2,
+                y: centerY - textSize.height / 2,
+                width: textSize.width,
+                height: textSize.height
+            )
+            text.draw(in: textRect, withAttributes: attributes)
+        }
+    }
+}

--- a/minimark/Views/DockTileBadgeView.swift
+++ b/minimark/Views/DockTileBadgeView.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 final class DockTileBadgeView: NSView {
     struct Counts: Equatable {
         var created: Int
@@ -25,22 +26,22 @@ final class DockTileBadgeView: NSView {
 
         guard !counts.isEmpty else { return }
 
-        let bubbleDiameter: CGFloat = 24
-        let bubbleSpacing: CGFloat = 3
-        let borderWidth: CGFloat = 2
-        let fontSize: CGFloat = 11
+        let bubbleDiameter: CGFloat = 42
+        let bubbleSpacing: CGFloat = 4
+        let borderWidth: CGFloat = 2.5
+        let fontSize: CGFloat = 24
 
-        let activeBubbles: [(color: NSColor, count: Int)] = [
-            (.systemGreen, counts.created),
-            (.systemYellow, counts.modified),
-            (.systemRed, counts.deleted),
+        let activeBubbles: [(fill: NSColor, text: NSColor, count: Int)] = [
+            (NSColor(red: 0.20, green: 0.70, blue: 0.30, alpha: 1), .white, counts.created),
+            (NSColor(red: 0.90, green: 0.72, blue: 0.15, alpha: 1), NSColor(red: 0.25, green: 0.20, blue: 0.05, alpha: 1), counts.modified),
+            (NSColor(red: 0.85, green: 0.20, blue: 0.18, alpha: 1), .white, counts.deleted),
         ].filter { $0.count > 0 }
 
         let totalWidth = CGFloat(activeBubbles.count) * bubbleDiameter
             + CGFloat(max(activeBubbles.count - 1, 0)) * bubbleSpacing
 
-        let startX = bounds.maxX - totalWidth - 2
-        let centerY = bounds.maxY - bubbleDiameter / 2 - 2
+        let startX = bounds.maxX - totalWidth - 4
+        let centerY = bounds.maxY - bubbleDiameter / 2 - 4
 
         let font = NSFont.boldSystemFont(ofSize: fontSize)
         let paragraphStyle = NSMutableParagraphStyle()
@@ -63,14 +64,14 @@ final class DockTileBadgeView: NSView {
             // Colored fill
             let insetRect = bubbleRect.insetBy(dx: borderWidth, dy: borderWidth)
             let fillPath = NSBezierPath(ovalIn: insetRect)
-            bubble.color.setFill()
+            bubble.fill.setFill()
             fillPath.fill()
 
             // Count text
             let text = "\(bubble.count)" as NSString
             let attributes: [NSAttributedString.Key: Any] = [
                 .font: font,
-                .foregroundColor: NSColor.white,
+                .foregroundColor: bubble.text,
                 .paragraphStyle: paragraphStyle,
             ]
             let textSize = text.size(withAttributes: attributes)

--- a/minimark/Views/DockTileBadgeView.swift
+++ b/minimark/Views/DockTileBadgeView.swift
@@ -26,22 +26,23 @@ final class DockTileBadgeView: NSView {
 
         guard !counts.isEmpty else { return }
 
-        let bubbleDiameter: CGFloat = 42
-        let bubbleSpacing: CGFloat = 4
-        let borderWidth: CGFloat = 2.5
-        let fontSize: CGFloat = 24
-
         let activeBubbles: [(fill: NSColor, text: NSColor, count: Int)] = [
             (NSColor(red: 0.20, green: 0.70, blue: 0.30, alpha: 1), .white, counts.created),
             (NSColor(red: 0.90, green: 0.72, blue: 0.15, alpha: 1), NSColor(red: 0.25, green: 0.20, blue: 0.05, alpha: 1), counts.modified),
             (NSColor(red: 0.85, green: 0.20, blue: 0.18, alpha: 1), .white, counts.deleted),
         ].filter { $0.count > 0 }
 
-        let totalWidth = CGFloat(activeBubbles.count) * bubbleDiameter
-            + CGFloat(max(activeBubbles.count - 1, 0)) * bubbleSpacing
+        let padding: CGFloat = 4
+        let bubbleSpacing: CGFloat = 4
+        let bubbleCount = CGFloat(activeBubbles.count)
+        let availableWidth = bounds.width - 2 * padding
+        let bubbleDiameter = min(42, (availableWidth - (bubbleCount - 1) * bubbleSpacing) / bubbleCount)
+        let borderWidth: CGFloat = 2.5
+        let fontSize = bubbleDiameter * 0.57
 
-        let startX = bounds.maxX - totalWidth - 4
-        let centerY = bounds.maxY - bubbleDiameter / 2 - 4
+        let totalWidth = bubbleCount * bubbleDiameter + (bubbleCount - 1) * bubbleSpacing
+        let startX = bounds.maxX - totalWidth - padding
+        let centerY = bounds.maxY - bubbleDiameter / 2 - padding
 
         let font = NSFont.boldSystemFont(ofSize: fontSize)
         let paragraphStyle = NSMutableParagraphStyle()

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -22,6 +22,7 @@ struct ReaderWindowRootView: View {
     @State private var uiTestWatchFlowTask: Task<Void, Never>?
     @State private var hasAppliedUITestLaunchConfiguration = false
     @State var effectiveWindowTitle = ReaderWindowTitleFormatter.appName
+    @State private var dockTileWindowToken = UUID()
     @State var groupStateController = SidebarGroupStateController()
     @State var sidebarWidth: CGFloat = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
     @State private var lastAppliedSidebarDelta: CGFloat = 0
@@ -309,6 +310,13 @@ struct ReaderWindowRootView: View {
                     rowStates: sidebarDocumentController.rowStates
                 )
                 groupStateController.observeRowStates(from: sidebarDocumentController)
+                DockTileController.shared.configureDockTileIfNeeded()
+                sidebarDocumentController.onDockTileRowStatesChanged = { [dockTileWindowToken] rowStates in
+                    DockTileController.shared.updateRowStates(for: dockTileWindowToken, rowStates: rowStates)
+                }
+            }
+            .onDisappear {
+                DockTileController.shared.removeRowStates(for: dockTileWindowToken)
             }
             .onChange(of: appearanceController.effectiveAppearance) { _, _ in
                 reapplyAppearance()

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -314,8 +314,13 @@ struct ReaderWindowRootView: View {
                 sidebarDocumentController.onDockTileRowStatesChanged = { [dockTileWindowToken] rowStates in
                     DockTileController.shared.updateRowStates(for: dockTileWindowToken, rowStates: rowStates)
                 }
+                DockTileController.shared.updateRowStates(
+                    for: dockTileWindowToken,
+                    rowStates: sidebarDocumentController.rowStates
+                )
             }
             .onDisappear {
+                sidebarDocumentController.onDockTileRowStatesChanged = nil
                 DockTileController.shared.removeRowStates(for: dockTileWindowToken)
             }
             .onChange(of: appearanceController.effectiveAppearance) { _, _ in

--- a/minimarkTests/Infrastructure/DockTileControllerTests.swift
+++ b/minimarkTests/Infrastructure/DockTileControllerTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct DockTileControllerTests {
+
+    @Test @MainActor func emptyByDefault() {
+        let controller = DockTileController()
+        #expect(controller.createdCount == 0)
+        #expect(controller.modifiedCount == 0)
+        #expect(controller.deletedCount == 0)
+    }
+
+    @Test @MainActor func countsSingleWindowRowStates() {
+        let controller = DockTileController()
+        let windowToken = UUID()
+
+        let docA = UUID()
+        let docB = UUID()
+        let docC = UUID()
+
+        let rowStates: [UUID: SidebarRowState] = [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .addedExternalChange, indicatorPulseToken: 0
+            ),
+            docB: SidebarRowState(
+                id: docB, title: "b.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+            docC: SidebarRowState(
+                id: docC, title: "c.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .deletedExternalChange, indicatorPulseToken: 0
+            ),
+        ]
+
+        controller.updateRowStates(for: windowToken, rowStates: rowStates)
+
+        #expect(controller.createdCount == 1)
+        #expect(controller.modifiedCount == 1)
+        #expect(controller.deletedCount == 1)
+    }
+
+    @Test @MainActor func aggregatesAcrossMultipleWindows() {
+        let controller = DockTileController()
+        let window1 = UUID()
+        let window2 = UUID()
+
+        let docA = UUID()
+        let docB = UUID()
+
+        controller.updateRowStates(for: window1, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .addedExternalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        controller.updateRowStates(for: window2, rowStates: [
+            docB: SidebarRowState(
+                id: docB, title: "b.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .addedExternalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.createdCount == 2)
+        #expect(controller.modifiedCount == 0)
+        #expect(controller.deletedCount == 0)
+    }
+
+    @Test @MainActor func removingWindowUpdatesCount() {
+        let controller = DockTileController()
+        let window1 = UUID()
+        let window2 = UUID()
+
+        let docA = UUID()
+        let docB = UUID()
+
+        controller.updateRowStates(for: window1, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+        ])
+        controller.updateRowStates(for: window2, rowStates: [
+            docB: SidebarRowState(
+                id: docB, title: "b.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.modifiedCount == 2)
+
+        controller.removeRowStates(for: window1)
+
+        #expect(controller.modifiedCount == 1)
+    }
+
+    @Test @MainActor func ignoresNoneIndicatorState() {
+        let controller = DockTileController()
+        let windowToken = UUID()
+
+        let docA = UUID()
+        let docB = UUID()
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .none, indicatorPulseToken: 0
+            ),
+            docB: SidebarRowState(
+                id: docB, title: "b.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.createdCount == 0)
+        #expect(controller.modifiedCount == 1)
+        #expect(controller.deletedCount == 0)
+    }
+
+    @Test @MainActor func updatingWindowReplacesOldStates() {
+        let controller = DockTileController()
+        let windowToken = UUID()
+
+        let docA = UUID()
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .addedExternalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.createdCount == 1)
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .none, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.createdCount == 0)
+    }
+
+    @Test @MainActor func notifiesOnCountChange() {
+        var updateCount = 0
+        let controller = DockTileController()
+        controller.onCountsChanged = { _, _, _ in
+            updateCount += 1
+        }
+
+        let windowToken = UUID()
+        let docA = UUID()
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(updateCount == 1)
+    }
+
+    @Test @MainActor func doesNotNotifyWhenCountsUnchanged() {
+        var updateCount = 0
+        let controller = DockTileController()
+        controller.onCountsChanged = { _, _, _ in
+            updateCount += 1
+        }
+
+        let windowToken = UUID()
+        let docA = UUID()
+
+        let rowStates: [UUID: SidebarRowState] = [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 0
+            ),
+        ]
+
+        controller.updateRowStates(for: windowToken, rowStates: rowStates)
+        #expect(updateCount == 1)
+
+        // Same counts, different pulse token — should not notify
+        let rowStates2: [UUID: SidebarRowState] = [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 1
+            ),
+        ]
+
+        controller.updateRowStates(for: windowToken, rowStates: rowStates2)
+        #expect(updateCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Add colored count bubbles to the dock icon showing unacknowledged external change counts (green=created, yellow=modified, red=deleted)
- Counts are summed across all open windows
- Bubbles only appear for non-zero counts; all zero shows the plain icon
- Positioned in top-right corner of the dock icon

Closes #203

## Architecture

- **DockTileController** (singleton) — aggregates `SidebarRowState` indicator counts across all windows via per-window registration
- **DockTileBadgeView** (`NSView`) — draws app icon with overlaid count bubbles using custom colors for contrast
- **Integration** — each `ReaderWindowRootView` registers/unregisters on appear/disappear via a second callback on `ReaderSidebarDocumentController`

## New files

- `minimark/Support/DockTileController.swift`
- `minimark/Views/DockTileBadgeView.swift`
- `minimarkTests/Infrastructure/DockTileControllerTests.swift` (8 tests)

## Test plan

- [x] Unit tests for count aggregation (single window, multi-window, removal, no-op suppression)
- [x] Manual: open folder watch, modify/create/delete files externally, verify dock badges appear
- [x] Manual: acknowledge changes, verify badges disappear
- [ ] Manual: open second window, verify counts aggregate across both