### PR TITLE
fix: remove redundant deriveRowState calls (#204)

### DIFF
--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -500,13 +500,17 @@ final class ReaderSidebarDocumentController {
         Document(id: UUID(), readerStore: makeReaderStore())
     }
 
-    func deriveRowState(from document: Document) -> SidebarRowState {
-        let store = document.readerStore
-        let indicatorState = ReaderDocumentIndicatorState(
+    private func deriveIndicatorState(from store: ReaderStore) -> ReaderDocumentIndicatorState {
+        ReaderDocumentIndicatorState(
             hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
             isCurrentFileMissing: store.isCurrentFileMissing,
             unacknowledgedExternalChangeKind: store.document.unacknowledgedExternalChangeKind
         )
+    }
+
+    func deriveRowState(from document: Document) -> SidebarRowState {
+        let store = document.readerStore
+        let indicatorState = deriveIndicatorState(from: store)
         return SidebarRowState(
             id: document.id,
             title: store.fileDisplayName.isEmpty ? "Untitled" : store.fileDisplayName,
@@ -522,12 +526,7 @@ final class ReaderSidebarDocumentController {
         var states: [UUID: SidebarRowState] = [:]
         for document in documents {
             let previousIndicatorState = rowStates[document.id]?.indicatorState
-            let store = document.readerStore
-            let currentIndicatorState = ReaderDocumentIndicatorState(
-                hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
-                isCurrentFileMissing: store.isCurrentFileMissing,
-                unacknowledgedExternalChangeKind: store.document.unacknowledgedExternalChangeKind
-            )
+            let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
             if let previousIndicatorState,
                previousIndicatorState != currentIndicatorState,
                currentIndicatorState.showsIndicator {
@@ -574,12 +573,7 @@ final class ReaderSidebarDocumentController {
     private func updateRowStateIfNeeded(for documentID: UUID) {
         guard let document = documents.first(where: { $0.id == documentID }) else { return }
         let previousIndicatorState = rowStates[documentID]?.indicatorState
-        let store = document.readerStore
-        let currentIndicatorState = ReaderDocumentIndicatorState(
-            hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
-            isCurrentFileMissing: store.isCurrentFileMissing,
-            unacknowledgedExternalChangeKind: store.document.unacknowledgedExternalChangeKind
-        )
+        let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
         if let previousIndicatorState,
            previousIndicatorState != currentIndicatorState,
            currentIndicatorState.showsIndicator {

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -522,10 +522,15 @@ final class ReaderSidebarDocumentController {
         var states: [UUID: SidebarRowState] = [:]
         for document in documents {
             let previousIndicatorState = rowStates[document.id]?.indicatorState
-            let candidateState = deriveRowState(from: document)
+            let store = document.readerStore
+            let currentIndicatorState = ReaderDocumentIndicatorState(
+                hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
+                isCurrentFileMissing: store.isCurrentFileMissing,
+                unacknowledgedExternalChangeKind: store.document.unacknowledgedExternalChangeKind
+            )
             if let previousIndicatorState,
-               previousIndicatorState != candidateState.indicatorState,
-               candidateState.indicatorState.showsIndicator {
+               previousIndicatorState != currentIndicatorState,
+               currentIndicatorState.showsIndicator {
                 rowIndicatorPulseTokens[document.id, default: 0] += 1
             }
             states[document.id] = deriveRowState(from: document)
@@ -569,15 +574,20 @@ final class ReaderSidebarDocumentController {
     private func updateRowStateIfNeeded(for documentID: UUID) {
         guard let document = documents.first(where: { $0.id == documentID }) else { return }
         let previousIndicatorState = rowStates[documentID]?.indicatorState
-        let candidateState = deriveRowState(from: document)
+        let store = document.readerStore
+        let currentIndicatorState = ReaderDocumentIndicatorState(
+            hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
+            isCurrentFileMissing: store.isCurrentFileMissing,
+            unacknowledgedExternalChangeKind: store.document.unacknowledgedExternalChangeKind
+        )
         if let previousIndicatorState,
-           previousIndicatorState != candidateState.indicatorState,
-           candidateState.indicatorState.showsIndicator {
+           previousIndicatorState != currentIndicatorState,
+           currentIndicatorState.showsIndicator {
             rowIndicatorPulseTokens[documentID, default: 0] += 1
         }
-        let refreshedState = deriveRowState(from: document)
-        if rowStates[documentID] != refreshedState {
-            rowStates[documentID] = refreshedState
+        let state = deriveRowState(from: document)
+        if rowStates[documentID] != state {
+            rowStates[documentID] = state
             onRowStatesChanged?(rowStates)
             onDockTileRowStatesChanged?(rowStates)
         }


### PR DESCRIPTION
## Summary

- Eliminates redundant double `deriveRowState(from:)` calls in `rebuildAllRowStates()` and `updateRowStateIfNeeded(for:)` 
- Computes indicator state directly from store properties for the pulse-token check, then calls `deriveRowState` once with the already-bumped token
- No behavioral change — existing tests (71/71) pass unchanged

Closes #204