### PR TITLE
Hover feedback polish for sidebar, TOC, and pill controls

### DIFF
--- a/minimark/Views/Content/ChangeNavigationPill.swift
+++ b/minimark/Views/Content/ChangeNavigationPill.swift
@@ -8,7 +8,7 @@ struct ChangeNavigationPill: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovering = false
 
-    private enum Metrics {
+    fileprivate enum Metrics {
         static let pillHeight: CGFloat = 30
         static let horizontalPadding: CGFloat = 10
         static let controlHeight: CGFloat = 28
@@ -21,10 +21,11 @@ struct ChangeNavigationPill: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            navigationButton(
+            NavigationChevronButton(
                 symbolName: "chevron.up",
                 label: "Previous change",
-                direction: .previous
+                direction: .previous,
+                onNavigate: onNavigate
             )
 
             (
@@ -35,10 +36,11 @@ struct ChangeNavigationPill: View {
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
 
-            navigationButton(
+            NavigationChevronButton(
                 symbolName: "chevron.down",
                 label: "Next change",
-                direction: .next
+                direction: .next,
+                onNavigate: onNavigate
             )
         }
         .padding(.horizontal, Metrics.horizontalPadding)
@@ -57,21 +59,36 @@ struct ChangeNavigationPill: View {
         .fixedSize()
     }
 
-    private func navigationButton(
-        symbolName: String,
-        label: String,
-        direction: ReaderChangedRegionNavigationDirection
-    ) -> some View {
+}
+
+private struct NavigationChevronButton: View {
+    let symbolName: String
+    let label: String
+    let direction: ReaderChangedRegionNavigationDirection
+    let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
         Button {
             onNavigate(direction)
         } label: {
             Image(systemName: symbolName)
-                .font(.system(size: Metrics.iconSize, weight: .semibold))
-                .frame(width: Metrics.controlHeight, height: Metrics.controlHeight)
-                .contentShape(Rectangle())
+                .font(.system(size: ChangeNavigationPill.Metrics.iconSize, weight: .semibold))
+                .frame(width: ChangeNavigationPill.Metrics.controlHeight, height: ChangeNavigationPill.Metrics.controlHeight)
+                .background(
+                    Circle()
+                        .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+                )
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.primary.opacity(0.55))
+        .foregroundStyle(.primary.opacity(isHovered ? 0.75 : 0.55))
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.12)) {
+                isHovered = hovering
+            }
+        }
         .help(label)
         .accessibilityLabel(label)
         .accessibilityHint("Jumps to a changed region in the current preview")

--- a/minimark/Views/Content/ContentUtilityRail.swift
+++ b/minimark/Views/Content/ContentUtilityRail.swift
@@ -82,7 +82,9 @@ struct ContentUtilityRail: View {
                 .frame(width: Metrics.buttonSize, height: Metrics.buttonSize)
                 .railButtonBackground(cornerRadius: Metrics.buttonCornerRadius,
                     fill: isSelected ? Color.primary.opacity(0.12) : Color.clear,
-                    border: isSelected ? Color.primary.opacity(0.18) : Color.clear
+                    border: isSelected ? Color.primary.opacity(0.18) : Color.clear,
+                    hoverFill: isSelected ? nil : Color.primary.opacity(0.06),
+                    hoverBorder: isSelected ? nil : Color.primary.opacity(0.08)
                 )
         }
         .buttonStyle(.plain)
@@ -104,7 +106,9 @@ struct ContentUtilityRail: View {
                 .frame(width: Metrics.buttonSize, height: Metrics.buttonSize)
                 .railButtonBackground(cornerRadius: Metrics.buttonCornerRadius,
                     fill: Color.primary.opacity(canStartSourceEditing ? 0.06 : 0.03),
-                    border: Color.primary.opacity(canStartSourceEditing ? 0.10 : 0.05)
+                    border: Color.primary.opacity(canStartSourceEditing ? 0.10 : 0.05),
+                    hoverFill: canStartSourceEditing ? Color.primary.opacity(0.10) : nil,
+                    hoverBorder: canStartSourceEditing ? Color.primary.opacity(0.14) : nil
                 )
         }
         .buttonStyle(.plain)
@@ -125,7 +129,9 @@ struct ContentUtilityRail: View {
                 .frame(width: Metrics.buttonSize, height: Metrics.buttonSize)
                 .railButtonBackground(cornerRadius: Metrics.buttonCornerRadius,
                     fill: Color.primary.opacity(0.06),
-                    border: Color.primary.opacity(0.10)
+                    border: Color.primary.opacity(0.10),
+                    hoverFill: Color.primary.opacity(0.10),
+                    hoverBorder: Color.primary.opacity(0.14)
                 )
         }
         .buttonStyle(.plain)
@@ -160,25 +166,46 @@ struct TOCButtonAnchorKey: PreferenceKey {
 
 private struct RailButtonBackgroundModifier: ViewModifier {
     let fill: Color
+    let hoverFill: Color
     let border: Color
+    let hoverBorder: Color
     let cornerRadius: CGFloat
+
+    @State private var isHovered = false
 
     func body(content: Content) -> some View {
         content
             .background(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(fill)
+                    .fill(isHovered ? hoverFill : fill)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(border, lineWidth: 1)
+                    .strokeBorder(isHovered ? hoverBorder : border, lineWidth: 1)
             )
             .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .onHover { hovering in
+                withAnimation(.easeInOut(duration: 0.12)) {
+                    isHovered = hovering
+                }
+            }
     }
 }
 
 private extension View {
-    func railButtonBackground(cornerRadius: CGFloat, fill: Color, border: Color) -> some View {
-        modifier(RailButtonBackgroundModifier(fill: fill, border: border, cornerRadius: cornerRadius))
+    func railButtonBackground(
+        cornerRadius: CGFloat,
+        fill: Color,
+        border: Color,
+        hoverFill: Color? = nil,
+        hoverBorder: Color? = nil
+    ) -> some View {
+        modifier(RailButtonBackgroundModifier(
+            fill: fill,
+            hoverFill: hoverFill ?? fill,
+            border: border,
+            hoverBorder: hoverBorder ?? border,
+            cornerRadius: cornerRadius
+        ))
     }
 }

--- a/minimark/Views/Content/TOCPopoverView.swift
+++ b/minimark/Views/Content/TOCPopoverView.swift
@@ -39,7 +39,11 @@ struct TOCPopoverView: View {
                     .buttonStyle(.plain)
                     .modifier(PointingHandCursor())
                     .onHover { isHovered in
-                        hoveredHeadingID = isHovered ? heading.id : nil
+                        if isHovered {
+                            hoveredHeadingID = heading.id
+                        } else if hoveredHeadingID == heading.id {
+                            hoveredHeadingID = nil
+                        }
                     }
                 }
             }

--- a/minimark/Views/Content/TOCPopoverView.swift
+++ b/minimark/Views/Content/TOCPopoverView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TOCPopoverView: View {
     let headings: [TOCHeading]
     let onSelect: (TOCHeading) -> Void
+    @State private var hoveredHeadingID: Int?
 
     private enum Metrics {
         static let popoverMinWidth: CGFloat = 320
@@ -29,12 +30,20 @@ struct TOCPopoverView: View {
                             .padding(.leading, Metrics.rowHorizontalPadding + CGFloat(heading.level - 1) * Metrics.indentPerLevel)
                             .padding(.trailing, Metrics.rowHorizontalPadding)
                             .padding(.vertical, Metrics.rowVerticalPadding)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                    .fill(hoveredHeadingID == heading.id ? Color.primary.opacity(0.06) : .clear)
+                            )
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .modifier(PointingHandCursor())
+                    .onHover { isHovered in
+                        hoveredHeadingID = isHovered ? heading.id : nil
+                    }
                 }
             }
+            .animation(.easeInOut(duration: 0.12), value: hoveredHeadingID)
             .padding(.vertical, 8)
         }
         .frame(minWidth: Metrics.popoverMinWidth, maxWidth: Metrics.popoverMaxWidth, maxHeight: Metrics.popoverMaxHeight)

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -439,12 +439,18 @@ private struct ReaderSidebarDocumentRow: View {
         .padding(.horizontal, 4)
         .background(
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(showsSelectionBackground && isSelected ? selectionBackgroundColor : .clear)
+                .fill(
+                    showsSelectionBackground && isSelected
+                        ? selectionBackgroundColor
+                        : (isHovered ? Color.primary.opacity(0.04) : .clear)
+                )
         )
         .padding(.vertical, 2)
         .accessibilityIdentifier("sidebar-document-\(title)")
         .onHover { hovering in
-            isHovered = hovering
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = hovering
+            }
         }
         .onAppear {
             triggerIndicatorPulseIfNeeded(for: state.indicatorPulseToken)


### PR DESCRIPTION
## Summary
- Add subtle hover background tint to sidebar document rows and animate close button fade-in/out
- Add hover highlight to Table of Contents heading rows
- Add individual button hover states to change navigation pill chevrons (circular background + foreground shift)
- Add per-button hover to utility rail buttons via extended RailButtonBackgroundModifier with optional hover colors

## Test Plan
- [x] All 685 unit tests pass
- [ ] Visual verification: hover sidebar document rows — subtle background tint appears, close button fades in smoothly
- [ ] Visual verification: hover TOC headings — rounded background highlight appears
- [ ] Visual verification: hover change navigation pill chevrons — circular background and foreground darken
- [ ] Visual verification: hover utility rail buttons — fill/border intensify on non-selected, non-disabled buttons
- [ ] Verify dark mode and light mode both look correct