### PR TITLE
Chrome & controls polish (#214–#218)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -557,8 +557,6 @@ struct ContentView: View {
                     ChangeNavigationPill(
                         currentIndex: currentChangedRegionIndex,
                         totalCount: readerStore.changedRegions.count,
-                        canGoPrevious: currentChangedRegionIndex != nil && currentChangedRegionIndex! > 0,
-                        canGoNext: currentChangedRegionIndex != nil && currentChangedRegionIndex! < readerStore.changedRegions.count - 1,
                         onNavigate: requestChangedRegionNavigation
                     )
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
@@ -566,7 +564,7 @@ struct ContentView: View {
                     .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
                     .transition(.asymmetric(
                         insertion: .opacity.combined(with: .move(edge: .top)),
-                        removal: .opacity.combined(with: .move(edge: .top))
+                        removal: .opacity
                     ))
                 }
             }
@@ -593,7 +591,7 @@ struct ContentView: View {
                     .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
                     .transition(.asymmetric(
                         insertion: .opacity.combined(with: .move(edge: .top)),
-                        removal: .opacity.combined(with: .move(edge: .top))
+                        removal: .opacity
                     ))
                 }
             }

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -557,13 +557,20 @@ struct ContentView: View {
                     ChangeNavigationPill(
                         currentIndex: currentChangedRegionIndex,
                         totalCount: readerStore.changedRegions.count,
+                        canGoPrevious: currentChangedRegionIndex != nil && currentChangedRegionIndex! > 0,
+                        canGoNext: currentChangedRegionIndex != nil && currentChangedRegionIndex! < readerStore.changedRegions.count - 1,
                         onNavigate: requestChangedRegionNavigation
                     )
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
                     .padding(.leading, 8)
                     .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .move(edge: .top)),
+                        removal: .opacity.combined(with: .move(edge: .top))
+                    ))
                 }
             }
+            .animation(.easeOut(duration: 0.25), value: canNavigateChangedRegions)
             .overlay(alignment: .top) {
                 if let activeWatch = folderWatchState.activeFolderWatch {
                     WatchPill(
@@ -584,8 +591,13 @@ struct ContentView: View {
                     .padding(.leading, canNavigateChangedRegions ? 150 : 60)
                     .padding(.trailing, 70)
                     .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .move(edge: .top)),
+                        removal: .opacity.combined(with: .move(edge: .top))
+                    ))
                 }
             }
+            .animation(.easeOut(duration: 0.25), value: folderWatchState.activeFolderWatch != nil)
     }
 
     private var contentUtilityRail: some View {
@@ -831,10 +843,12 @@ struct ContentView: View {
 
         let count = readerStore.changedRegions.count
         if let current = currentChangedRegionIndex {
-            if direction == .next {
-                currentChangedRegionIndex = current >= count - 1 ? 0 : current + 1
+            if direction == .next, current < count - 1 {
+                currentChangedRegionIndex = current + 1
+            } else if direction == .previous, current > 0 {
+                currentChangedRegionIndex = current - 1
             } else {
-                currentChangedRegionIndex = current <= 0 ? count - 1 : current - 1
+                return
             }
         } else {
             currentChangedRegionIndex = direction == .next ? 0 : count - 1

--- a/minimark/Views/Content/ChangeNavigationPill.swift
+++ b/minimark/Views/Content/ChangeNavigationPill.swift
@@ -3,12 +3,20 @@ import SwiftUI
 struct ChangeNavigationPill: View {
     let currentIndex: Int?
     let totalCount: Int
-    let canGoPrevious: Bool
-    let canGoNext: Bool
     let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovering = false
+
+    private var canGoPrevious: Bool {
+        if let currentIndex { return currentIndex > 0 }
+        return totalCount > 0
+    }
+
+    private var canGoNext: Bool {
+        if let currentIndex { return currentIndex < totalCount - 1 }
+        return totalCount > 0
+    }
 
     fileprivate enum Metrics {
         static let pillHeight: CGFloat = 30

--- a/minimark/Views/Content/ChangeNavigationPill.swift
+++ b/minimark/Views/Content/ChangeNavigationPill.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ChangeNavigationPill: View {
     let currentIndex: Int?
     let totalCount: Int
+    let canGoPrevious: Bool
+    let canGoNext: Bool
     let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
 
     @Environment(\.colorScheme) private var colorScheme
@@ -24,6 +26,7 @@ struct ChangeNavigationPill: View {
             NavigationChevronButton(
                 symbolName: "chevron.up",
                 label: "Previous change",
+                isEnabled: canGoPrevious,
                 direction: .previous,
                 onNavigate: onNavigate
             )
@@ -39,6 +42,7 @@ struct ChangeNavigationPill: View {
             NavigationChevronButton(
                 symbolName: "chevron.down",
                 label: "Next change",
+                isEnabled: canGoNext,
                 direction: .next,
                 onNavigate: onNavigate
             )
@@ -64,10 +68,16 @@ struct ChangeNavigationPill: View {
 private struct NavigationChevronButton: View {
     let symbolName: String
     let label: String
+    let isEnabled: Bool
     let direction: ReaderChangedRegionNavigationDirection
     let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
 
     @State private var isHovered = false
+
+    private var foregroundOpacity: Double {
+        if !isEnabled { return 0.25 }
+        return isHovered ? 0.75 : 0.6
+    }
 
     var body: some View {
         Button {
@@ -78,13 +88,15 @@ private struct NavigationChevronButton: View {
                 .frame(width: ChangeNavigationPill.Metrics.controlHeight, height: ChangeNavigationPill.Metrics.controlHeight)
                 .background(
                     Circle()
-                        .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+                        .fill(Color.primary.opacity(isEnabled && isHovered ? 0.08 : 0))
                 )
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.primary.opacity(isHovered ? 0.75 : 0.55))
+        .disabled(!isEnabled)
+        .foregroundStyle(.primary.opacity(foregroundOpacity))
         .onHover { hovering in
+            guard isEnabled else { return }
             withAnimation(.easeInOut(duration: 0.12)) {
                 isHovered = hovering
             }

--- a/minimark/Views/Content/ContentUtilityRail.swift
+++ b/minimark/Views/Content/ContentUtilityRail.swift
@@ -12,6 +12,7 @@ struct ContentUtilityRail: View {
     let isTOCVisible: Binding<Bool>
 
     @State private var isHovering = false
+    @Namespace private var viewModeNamespace
 
     private enum Metrics {
         static let railWidth: CGFloat = 44
@@ -61,11 +62,12 @@ struct ContentUtilityRail: View {
     // MARK: - View Mode Group
 
     private var viewModeGroup: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 6) {
             ForEach(ReaderDocumentViewMode.allCases, id: \.self) { mode in
                 viewModeButton(mode: mode)
             }
         }
+        .animation(.easeInOut(duration: 0.25), value: documentViewMode)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Document view mode")
         .accessibilityHint("Switch between preview, split, and source views of the document.")
@@ -80,9 +82,20 @@ struct ContentUtilityRail: View {
             Image(systemName: mode.systemImageName)
                 .font(.system(size: Metrics.iconSize, weight: isSelected ? .bold : .semibold))
                 .frame(width: Metrics.buttonSize, height: Metrics.buttonSize)
+                .background {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Metrics.buttonCornerRadius, style: .continuous)
+                            .fill(Color.primary.opacity(0.12))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Metrics.buttonCornerRadius, style: .continuous)
+                                    .strokeBorder(Color.primary.opacity(0.18), lineWidth: 1)
+                            )
+                            .matchedGeometryEffect(id: "viewModeIndicator", in: viewModeNamespace)
+                    }
+                }
                 .railButtonBackground(cornerRadius: Metrics.buttonCornerRadius,
-                    fill: isSelected ? Color.primary.opacity(0.12) : Color.clear,
-                    border: isSelected ? Color.primary.opacity(0.18) : Color.clear,
+                    fill: Color.clear,
+                    border: Color.clear,
                     hoverFill: isSelected ? nil : Color.primary.opacity(0.06),
                     hoverBorder: isSelected ? nil : Color.primary.opacity(0.08)
                 )
@@ -149,7 +162,7 @@ struct ContentUtilityRail: View {
         Rectangle()
             .fill(Color.primary.opacity(0.10))
             .frame(width: Metrics.separatorWidth, height: 1)
-            .padding(.vertical, 2)
+            .padding(.vertical, 4)
     }
 }
 


### PR DESCRIPTION
## Summary
- **#215** — ChangeNavigationPill: disabled buttons now clearly grayed out (0.25 opacity) with no hover effect; enabled idle bumped to 0.6; removed wrap-around at boundaries
- **#216** — WatchPill and ChangeNavigationPill fade + slide in/out with asymmetric transitions
- **#217** — View mode buttons in ContentUtilityRail get a `matchedGeometryEffect` sliding indicator
- **#218** — Utility rail intra-group spacing 4→6pt, separator padding 2→4pt
- **#214** — Already implemented (lock.fill/lock.open icons in place)

Closes #214, closes #215, closes #216, closes #217, closes #218

## Test plan
- [ ] Start a folder watch → verify WatchPill slides in from top with fade
- [ ] Stop the watch → verify it slides out
- [ ] Trigger changed regions → verify ChangeNavigationPill animates in
- [ ] Navigate to first/last change → verify prev/next buttons are visually disabled (grayed out, no hover circle)
- [ ] Switch view modes (Preview/Split/Source) → verify indicator slides between buttons
- [ ] Verify utility rail groups have comfortable spacing and dividers