### PR TITLE
Styled empty state for content area

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -513,6 +513,7 @@ struct ContentView: View {
             loadingOverlaySubtitle: loadingOverlaySubtitle,
             emptyStateVariant: emptyStateVariant,
             currentReaderTheme: currentReaderTheme,
+            onDroppedFileURLs: handleDroppedFileURLs,
             previewSurface: documentSurfacePane(for: .preview),
             sourceSurface: documentSurfacePane(for: .source)
         )
@@ -1078,6 +1079,7 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
     let loadingOverlaySubtitle: String?
     let emptyStateVariant: ContentEmptyStateView.Variant
     let currentReaderTheme: ReaderTheme
+    let onDroppedFileURLs: ([URL]) -> Void
     let previewSurface: PreviewSurface
     let sourceSurface: SourceSurface
 
@@ -1093,6 +1095,12 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
                 variant: emptyStateVariant,
                 theme: currentReaderTheme
             )
+            .dropDestination(for: URL.self) { urls, _ in
+                let fileURLs = urls.filter { $0.isFileURL }
+                guard !fileURLs.isEmpty else { return false }
+                onDroppedFileURLs(fileURLs)
+                return true
+            }
         } else {
             switch documentViewMode {
             case .preview:

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -507,9 +507,11 @@ struct ContentView: View {
     private var documentSurfaceLayout: some View {
         DocumentSurfaceLayoutView(
             documentViewMode: readerStore.documentViewMode,
+            hasOpenDocument: readerStore.hasOpenDocument,
             showsLoadingOverlay: shouldShowDocumentLoadingOverlay,
             loadingOverlayHeadline: loadingOverlayHeadline,
             loadingOverlaySubtitle: loadingOverlaySubtitle,
+            emptyStateVariant: emptyStateVariant,
             currentReaderTheme: currentReaderTheme,
             previewSurface: documentSurfacePane(for: .preview),
             sourceSurface: documentSurfacePane(for: .source)
@@ -683,6 +685,13 @@ struct ContentView: View {
 
     private var currentReaderTheme: ReaderTheme {
         ReaderTheme.theme(for: folderWatchState.effectiveReaderTheme)
+    }
+
+    private var emptyStateVariant: ContentEmptyStateView.Variant {
+        if let activeWatch = folderWatchState.activeFolderWatch {
+            return .folderWatchEmpty(folderName: activeWatch.folderURL.lastPathComponent)
+        }
+        return .noDocument
     }
 
     private var shouldShowDocumentLoadingOverlay: Bool {
@@ -1063,9 +1072,11 @@ private struct FolderDropBlockedOverlayView: View {
 
 private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: View {
     let documentViewMode: ReaderDocumentViewMode
+    let hasOpenDocument: Bool
     let showsLoadingOverlay: Bool
     let loadingOverlayHeadline: String
     let loadingOverlaySubtitle: String?
+    let emptyStateVariant: ContentEmptyStateView.Variant
     let currentReaderTheme: ReaderTheme
     let previewSurface: PreviewSurface
     let sourceSurface: SourceSurface
@@ -1076,6 +1087,11 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
                 theme: currentReaderTheme,
                 headline: loadingOverlayHeadline,
                 subtitle: loadingOverlaySubtitle
+            )
+        } else if !hasOpenDocument {
+            ContentEmptyStateView(
+                variant: emptyStateVariant,
+                theme: currentReaderTheme
             )
         } else {
             switch documentViewMode {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -690,7 +690,7 @@ struct ContentView: View {
 
     private var emptyStateVariant: ContentEmptyStateView.Variant {
         if let activeWatch = folderWatchState.activeFolderWatch {
-            return .folderWatchEmpty(folderName: activeWatch.folderURL.lastPathComponent)
+            return .folderWatchEmpty(folderName: activeWatch.detailSummaryTitle)
         }
         return .noDocument
     }

--- a/minimark/Support/WatchActiveColor.swift
+++ b/minimark/Support/WatchActiveColor.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+enum WatchActiveColor {
+    static func color(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 0.59, green: 0.49, blue: 1.0)
+            : Color(red: 0.34, green: 0.24, blue: 0.71)
+    }
+}

--- a/minimark/Views/Content/ContentEmptyStateView.swift
+++ b/minimark/Views/Content/ContentEmptyStateView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ContentEmptyStateView: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    enum Variant {
+    enum Variant: Equatable {
         case noDocument
         case folderWatchEmpty(folderName: String)
     }
@@ -56,10 +56,12 @@ struct ContentEmptyStateView: View {
             Image(systemName: "doc.text")
                 .font(.system(size: 48, weight: .thin))
                 .foregroundStyle(Color(hex: theme.secondaryForegroundHex)?.opacity(0.5) ?? .secondary)
+                .accessibilityHidden(true)
         case .folderWatchEmpty:
             Image(systemName: "binoculars.fill")
                 .font(.system(size: 48))
                 .foregroundStyle(watchTintColor.opacity(0.5))
+                .accessibilityHidden(true)
         }
     }
 
@@ -67,7 +69,7 @@ struct ContentEmptyStateView: View {
     private var headline: some View {
         switch variant {
         case .noDocument:
-            Text("Open a Markdown File")
+            Text("Open a Markdown file")
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(Color(hex: theme.foregroundHex)?.opacity(0.7) ?? .primary)
         case .folderWatchEmpty:

--- a/minimark/Views/Content/ContentEmptyStateView.swift
+++ b/minimark/Views/Content/ContentEmptyStateView.swift
@@ -24,7 +24,6 @@ struct ContentEmptyStateView: View {
                     .padding(.bottom, 16)
 
                 headline
-                    .padding(.bottom, subtitlePaddingBottom)
 
                 subtitle
             }
@@ -59,7 +58,7 @@ struct ContentEmptyStateView: View {
                 .foregroundStyle(Color(hex: theme.secondaryForegroundHex)?.opacity(0.5) ?? .secondary)
         case .folderWatchEmpty:
             Image(systemName: "binoculars.fill")
-                .font(.system(size: 48, weight: .thin))
+                .font(.system(size: 48))
                 .foregroundStyle(watchTintColor.opacity(0.5))
         }
     }
@@ -75,13 +74,6 @@ struct ContentEmptyStateView: View {
             Text("Waiting for Markdown files\u{2026}")
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(Color(hex: theme.foregroundHex)?.opacity(0.7) ?? .primary)
-        }
-    }
-
-    private var subtitlePaddingBottom: CGFloat {
-        switch variant {
-        case .noDocument: return 0
-        case .folderWatchEmpty: return 0
         }
     }
 

--- a/minimark/Views/Content/ContentEmptyStateView.swift
+++ b/minimark/Views/Content/ContentEmptyStateView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct ContentEmptyStateView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    enum Variant {
+        case noDocument
+        case folderWatchEmpty(folderName: String)
+    }
+
+    let variant: Variant
+    let theme: ReaderTheme
+
+    private var watchTintColor: Color {
+        WatchActiveColor.color(for: colorScheme)
+    }
+
+    var body: some View {
+        ZStack {
+            background
+
+            VStack(spacing: 0) {
+                icon
+                    .padding(.bottom, 16)
+
+                headline
+                    .padding(.bottom, subtitlePaddingBottom)
+
+                subtitle
+            }
+            .padding(24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .colorScheme(theme.kind.isDark ? .dark : .light)
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch variant {
+        case .noDocument:
+            Rectangle()
+                .fill(Color(hex: theme.backgroundHex) ?? .clear)
+        case .folderWatchEmpty:
+            Rectangle()
+                .fill(Color(hex: theme.backgroundHex) ?? .clear)
+                .overlay {
+                    Rectangle()
+                        .fill(watchTintColor.opacity(0.05))
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        switch variant {
+        case .noDocument:
+            Image(systemName: "doc.text")
+                .font(.system(size: 48, weight: .thin))
+                .foregroundStyle(Color(hex: theme.secondaryForegroundHex)?.opacity(0.5) ?? .secondary)
+        case .folderWatchEmpty:
+            Image(systemName: "binoculars.fill")
+                .font(.system(size: 48, weight: .thin))
+                .foregroundStyle(watchTintColor.opacity(0.5))
+        }
+    }
+
+    @ViewBuilder
+    private var headline: some View {
+        switch variant {
+        case .noDocument:
+            Text("Open a Markdown File")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color(hex: theme.foregroundHex)?.opacity(0.7) ?? .primary)
+        case .folderWatchEmpty:
+            Text("Waiting for Markdown files\u{2026}")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color(hex: theme.foregroundHex)?.opacity(0.7) ?? .primary)
+        }
+    }
+
+    private var subtitlePaddingBottom: CGFloat {
+        switch variant {
+        case .noDocument: return 0
+        case .folderWatchEmpty: return 0
+        }
+    }
+
+    @ViewBuilder
+    private var subtitle: some View {
+        switch variant {
+        case .noDocument:
+            VStack(spacing: 2) {
+                Text("\u{2318}O to open a file  \u{00B7}  \u{2325}\u{2318}W to watch a folder")
+                Text("or drop a file here")
+            }
+            .font(.system(size: 13))
+            .foregroundStyle(Color(hex: theme.secondaryForegroundHex)?.opacity(0.6) ?? .secondary)
+
+        case .folderWatchEmpty(let folderName):
+            Text("Watching ")
+                .font(.system(size: 13))
+                .foregroundStyle(Color(hex: theme.secondaryForegroundHex)?.opacity(0.7) ?? .secondary)
+            +
+            Text(folderName)
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundStyle(watchTintColor.opacity(0.7))
+        }
+    }
+}

--- a/minimark/Views/Content/ReaderTopBarComponents.swift
+++ b/minimark/Views/Content/ReaderTopBarComponents.swift
@@ -32,9 +32,7 @@ struct FolderWatchToolbarButton: View {
     }
 
     private var activeButtonColor: Color {
-        colorScheme == .dark
-            ? Color(red: 0.59, green: 0.49, blue: 1.0)
-            : Color(red: 0.34, green: 0.24, blue: 0.71)
+        WatchActiveColor.color(for: colorScheme)
     }
 
     private var backgroundFill: Color {

--- a/minimarkTests/Core/ContentEmptyStateTests.swift
+++ b/minimarkTests/Core/ContentEmptyStateTests.swift
@@ -3,24 +3,25 @@ import Testing
 @testable import minimark
 
 struct ContentEmptyStateTests {
-    @Test func noDocumentVariantShowsCorrectContent() {
+    @Test func noDocumentVariantIsEquatable() {
         let variant = ContentEmptyStateView.Variant.noDocument
-        switch variant {
-        case .noDocument:
-            // Expected path
-            break
-        case .folderWatchEmpty:
-            Issue.record("Expected .noDocument variant")
-        }
+        #expect(variant == .noDocument)
     }
 
     @Test func folderWatchEmptyVariantCarriesFolderName() {
         let variant = ContentEmptyStateView.Variant.folderWatchEmpty(folderName: "my-docs")
-        switch variant {
-        case .folderWatchEmpty(let name):
-            #expect(name == "my-docs")
-        case .noDocument:
-            Issue.record("Expected .folderWatchEmpty variant")
-        }
+        #expect(variant == .folderWatchEmpty(folderName: "my-docs"))
+    }
+
+    @Test func folderWatchEmptyVariantDistinguishesFolderNames() {
+        let a = ContentEmptyStateView.Variant.folderWatchEmpty(folderName: "docs")
+        let b = ContentEmptyStateView.Variant.folderWatchEmpty(folderName: "notes")
+        #expect(a != b)
+    }
+
+    @Test func variantsAreDistinct() {
+        let noDoc = ContentEmptyStateView.Variant.noDocument
+        let watchEmpty = ContentEmptyStateView.Variant.folderWatchEmpty(folderName: "test")
+        #expect(noDoc != watchEmpty)
     }
 }

--- a/minimarkTests/Core/ContentEmptyStateTests.swift
+++ b/minimarkTests/Core/ContentEmptyStateTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import minimark
+
+struct ContentEmptyStateTests {
+    @Test func noDocumentVariantShowsCorrectContent() {
+        let variant = ContentEmptyStateView.Variant.noDocument
+        switch variant {
+        case .noDocument:
+            // Expected path
+            break
+        case .folderWatchEmpty:
+            Issue.record("Expected .noDocument variant")
+        }
+    }
+
+    @Test func folderWatchEmptyVariantCarriesFolderName() {
+        let variant = ContentEmptyStateView.Variant.folderWatchEmpty(folderName: "my-docs")
+        switch variant {
+        case .folderWatchEmpty(let name):
+            #expect(name == "my-docs")
+        case .noDocument:
+            Issue.record("Expected .folderWatchEmpty variant")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a styled empty state view in the content area when no document is loaded
- **State 1 (no document):** doc.text icon, "Open a Markdown File" headline, keyboard shortcut hints + "or drop a file here"
- **State 2 (folder watch, no files):** binoculars.fill icon, "Waiting for Markdown files…", watched folder name, subtle purple tint matching the active watch button

## Implementation
- New `ContentEmptyStateView` with two variants driven by an enum
- Extracted `WatchActiveColor` into shared helper so toolbar button and empty state use the same purple tint
- Wired into `DocumentSurfaceLayoutView` as a branch between loading overlay and document surface
- Theme-aware: uses `ReaderTheme` colors across all 11 themes

Closes #223

## Test plan
- [x] Unit tests for variant enum
- [x] Full test suite passes
- [x] Manual: launch with no document → State 1 visible with correct icon/text
- [x] Manual: watch an empty folder → State 2 visible with purple tint and folder name
- [ ] Manual: open a file → empty state disappears immediately
- [ ] Manual: verify across light/dark/themed appearances