### PR TITLE
Fix dock badge not updating on change-kind transition (#203)

### DIFF
--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -550,6 +550,9 @@ final class ReaderSidebarDocumentController {
         }
 
         for document in documents where documentObservationTasks[document.id] == nil {
+            document.readerStore.onExternalChangeKindChanged = { [weak self] in
+                self?.updateRowStateIfNeeded(for: document.id)
+            }
             documentObservationTasks[document.id] = Task { [weak self] in
                 let store = document.readerStore
                 while !Task.isCancelled {

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -550,11 +550,13 @@ final class ReaderSidebarDocumentController {
         }
 
         for document in documents where documentObservationTasks[document.id] == nil {
+            let documentID = document.id
             document.readerStore.onExternalChangeKindChanged = { [weak self] in
-                self?.updateRowStateIfNeeded(for: document.id)
+                self?.updateRowStateIfNeeded(for: documentID)
             }
             documentObservationTasks[document.id] = Task { [weak self] in
                 let store = document.readerStore
+                defer { store.onExternalChangeKindChanged = nil }
                 while !Task.isCancelled {
                     let cancelled = await Self.awaitObservationChange {
                         _ = store.fileDisplayName

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -62,6 +62,7 @@ final class ReaderStore {
     private let documentIO: ReaderDocumentIO
     let requestWatchedFolderReauthorization: (URL) -> URL?
 
+    @ObservationIgnored var onExternalChangeKindChanged: (() -> Void)?
     @ObservationIgnored private var settingsCancellable: AnyCancellable?
     @ObservationIgnored private var appearanceOverride: LockedAppearance?
     private(set) var needsAppearanceRender = false
@@ -211,9 +212,14 @@ final class ReaderStore {
     }
 
     func noteObservedExternalChange(kind: ReaderExternalChangeKind = .modified) {
+        let previousKind = document.unacknowledgedExternalChangeKind
+        let wasAcknowledged = !document.hasUnacknowledgedExternalChange
         document.lastExternalChangeAt = Date()
         document.hasUnacknowledgedExternalChange = true
         document.unacknowledgedExternalChangeKind = kind
+        if !wasAcknowledged && previousKind != kind {
+            onExternalChangeKindChanged?()
+        }
     }
 
     func clearExternalChangeIndicator() {

--- a/minimarkTests/Infrastructure/DockTileControllerTests.swift
+++ b/minimarkTests/Infrastructure/DockTileControllerTests.swift
@@ -145,6 +145,32 @@ struct DockTileControllerTests {
         #expect(controller.createdCount == 0)
     }
 
+    @Test @MainActor func transitionFromAddedToModifiedUpdatesCount() {
+        let controller = DockTileController()
+        let windowToken = UUID()
+        let docA = UUID()
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .addedExternalChange, indicatorPulseToken: 0
+            ),
+        ])
+
+        #expect(controller.createdCount == 1)
+        #expect(controller.modifiedCount == 0)
+
+        controller.updateRowStates(for: windowToken, rowStates: [
+            docA: SidebarRowState(
+                id: docA, title: "a.md", lastModified: nil, sortDate: nil,
+                isFileMissing: false, indicatorState: .externalChange, indicatorPulseToken: 1
+            ),
+        ])
+
+        #expect(controller.createdCount == 0)
+        #expect(controller.modifiedCount == 1)
+    }
+
     @Test @MainActor func notifiesOnCountChange() {
         var updateCount = 0
         let controller = DockTileController()

--- a/minimarkTests/Sidebar/SidebarRowStateTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateTests.swift
@@ -109,4 +109,34 @@ struct SidebarRowStateDerivationTests {
         #expect(updatedState?.indicatorPulseToken == (initialState?.indicatorPulseToken ?? 0) + 1)
         #expect(initialState != updatedState)
     }
+
+    @Test @MainActor func controllerUpdatesRowStateWhenChangeKindTransitions() async throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = FileOpenCoordinator(controller: harness.controller)
+        coordinator.open(FileOpenRequest(
+            fileURLs: [harness.primaryFileURL],
+            origin: .manual
+        ))
+
+        let docID = harness.controller.documents[0].id
+        let store = harness.controller.documents[0].readerStore
+
+        await Task.yield()
+
+        // Simulate file-created indicator (green badge)
+        store.noteObservedExternalChange(kind: .added)
+        try await Task.sleep(for: .milliseconds(50))
+
+        let addedState = harness.controller.rowStates[docID]
+        #expect(addedState?.indicatorState == .addedExternalChange)
+
+        // Simulate file-modified indicator (yellow badge) — should replace green
+        store.noteObservedExternalChange(kind: .modified)
+        try await Task.sleep(for: .milliseconds(50))
+
+        let modifiedState = harness.controller.rowStates[docID]
+        #expect(modifiedState?.indicatorState == .externalChange)
+    }
 }


### PR DESCRIPTION
## Summary
- When a file transitioned from "created" (green badge) to "modified" (yellow badge), the green count stayed stale due to a `withObservationTracking` re-registration gap
- Added `onExternalChangeKindChanged` callback on `ReaderStore` that fires when `unacknowledgedExternalChangeKind` transitions while the change is still unacknowledged
- `ReaderSidebarDocumentController` registers this callback to call `updateRowStateIfNeeded` directly, bypassing the observation gap

## Test plan
- [x] New test: `transitionFromAddedToModifiedUpdatesCount` — verifies DockTileController counts update on indicator state transition
- [x] New test: `controllerUpdatesRowStateWhenChangeKindTransitions` — verifies row state updates via observation when change kind transitions from `.added` to `.modified`
- [x] Existing test `liveAutoOpenedAddedFileTurnsYellowAfterExternalEdit` passes (full integration scenario)
- [x] Full test suite passes (2 runs)