### PR TITLE
Fix top bar text unreadable in empty state with opposing theme color schemes

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -5,8 +5,6 @@ import OSLog
 import SwiftUI
 
 struct ContentView: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     private enum Metrics {
         static let splitPaneMinimumWidth: CGFloat = 320
     }
@@ -191,7 +189,7 @@ struct ContentView: View {
                     readerStore.discardSourceDraft()
                 }
             )
-            .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+            .environment(\.colorScheme, overlayColorScheme)
         }
         .overlay(alignment: .bottomLeading) {
             if isUITestModeEnabled {
@@ -519,9 +517,8 @@ struct ContentView: View {
         )
     }
 
-    private var overlayColorScheme: ColorScheme? {
-        guard readerStore.fileURL != nil else { return nil }
-        return currentReaderTheme.hasLightBackground ? .light : .dark
+    private var overlayColorScheme: ColorScheme {
+        currentReaderTheme.hasLightBackground ? .light : .dark
     }
 
     private var overlayTopInset: CGFloat {
@@ -549,7 +546,7 @@ struct ContentView: View {
             .overlay(alignment: .topTrailing) {
                 contentUtilityRail
                     .padding(.top, overlayInsets.railTopPadding)
-                    .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+                    .environment(\.colorScheme, overlayColorScheme)
             }
             .overlayPreferenceValue(TOCButtonAnchorKey.self) { anchor in
                 if readerStore.isTOCVisible, let anchor {
@@ -573,7 +570,7 @@ struct ContentView: View {
                     }
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
                     .padding(.leading, 8)
-                    .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+                    .environment(\.colorScheme, overlayColorScheme)
                     .transition(.asymmetric(
                         insertion: .opacity.combined(with: .move(edge: .top)),
                         removal: .opacity
@@ -600,7 +597,7 @@ struct ContentView: View {
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
                     .padding(.leading, canNavigateChangedRegions ? 150 : 60)
                     .padding(.trailing, 70)
-                    .environment(\.colorScheme, overlayColorScheme ?? colorScheme)
+                    .environment(\.colorScheme, overlayColorScheme)
                     .transition(.asymmetric(
                         insertion: .opacity.combined(with: .move(edge: .top)),
                         removal: .opacity

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -518,7 +518,7 @@ struct ContentView: View {
     }
 
     private var overlayColorScheme: ColorScheme {
-        currentReaderTheme.hasLightBackground ? .light : .dark
+        currentReaderTheme.kind.isDark ? .dark : .light
     }
 
     private var overlayTopInset: CGFloat {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -630,7 +630,7 @@ struct ContentView: View {
     @ViewBuilder
     private func tocOverlay(buttonAnchor: Anchor<CGRect>) -> some View {
         let gap: CGFloat = 8
-        let tocColorScheme: ColorScheme = currentReaderTheme.hasLightBackground ? .light : .dark
+        let tocColorScheme: ColorScheme = currentReaderTheme.kind.isDark ? .dark : .light
 
         GeometryReader { proxy in
             let buttonFrame = proxy[buttonAnchor]

--- a/minimarkTests/Rendering/ThemeDefinitionTests.swift
+++ b/minimarkTests/Rendering/ThemeDefinitionTests.swift
@@ -338,6 +338,18 @@ final class ThemeDefinitionTests: XCTestCase {
         XCTAssertTrue(css.contains("font-weight: bold"), "Should use weight to differentiate")
     }
 
+    // MARK: - Theme Color Scheme Consistency
+
+    func testIsDarkAndHasLightBackgroundAreConsistentForAllThemes() {
+        for kind in ReaderThemeKind.allCases {
+            let theme = ReaderTheme.theme(for: kind)
+            XCTAssertEqual(
+                kind.isDark, !theme.hasLightBackground,
+                "\(kind): isDark (\(kind.isDark)) must be opposite of hasLightBackground (\(theme.hasLightBackground))"
+            )
+        }
+    }
+
     // MARK: - Backward Compatibility
 
     func testSimpleThemesCSSOutputContainsExpectedVariables() {


### PR DESCRIPTION
## Summary

- Fixes top bar text being unreadable when app theme and reader theme have opposing color schemes and no file is open (e.g. Dark app + Newspaper reader)
- Root cause: `overlayColorScheme` returned `nil` when no file was open, falling back to the OS color scheme instead of the reader theme's scheme
- Made `overlayColorScheme` non-optional so it always derives from the reader theme, matching `ContentEmptyStateView`'s existing behavior

Closes #232

## Test plan

- [x] Unit test added: `isDark` / `hasLightBackground` consistency across all themes
- [x] All existing tests pass
- [x] Visual verification: Dark app theme + Newspaper reader, empty state — top bar text is readable