### PR TITLE
Coalesce adjacent changed regions into single change (#234)

### DIFF
--- a/minimark/Services/ChangedRegionDiffer.swift
+++ b/minimark/Services/ChangedRegionDiffer.swift
@@ -34,6 +34,7 @@ struct ChangedRegionDiffer: ChangedRegionDiffering {
         }
 
         changedRegions = coalescedDeletedRegions(changedRegions)
+        changedRegions = coalescedAdjacentRegions(changedRegions)
 
         return changedRegions.sorted { lhs, rhs in
             if lhs.lineRange.lowerBound != rhs.lineRange.lowerBound {
@@ -372,6 +373,47 @@ struct ChangedRegionDiffer: ChangedRegionDiffering {
         switch (lhs, rhs) {
         case let (lhs?, rhs?) where !lhs.isEmpty && !rhs.isEmpty:
             return normalizedSnippet(lhs + "\n" + rhs)
+        case let (lhs?, _):
+            return lhs
+        case let (_, rhs?):
+            return rhs
+        default:
+            return nil
+        }
+    }
+
+    private func coalescedAdjacentRegions(_ regions: [ChangedRegion]) -> [ChangedRegion] {
+        let sorted = regions.sorted { $0.lineRange.lowerBound < $1.lineRange.lowerBound }
+        var coalesced: [ChangedRegion] = []
+
+        for region in sorted {
+            guard region.kind != .deleted,
+                  let last = coalesced.last,
+                  last.kind == region.kind,
+                  region.lineRange.lowerBound == last.lineRange.upperBound + 1 else {
+                coalesced.append(region)
+                continue
+            }
+
+            coalesced.removeLast()
+            coalesced.append(
+                ChangedRegion(
+                    blockIndex: min(last.blockIndex, region.blockIndex),
+                    lineRange: last.lineRange.lowerBound...region.lineRange.upperBound,
+                    kind: last.kind,
+                    previousTextSnippet: mergedSnippet(last.previousTextSnippet, region.previousTextSnippet),
+                    currentTextSnippet: mergedSnippet(last.currentTextSnippet, region.currentTextSnippet)
+                )
+            )
+        }
+
+        return coalesced
+    }
+
+    private func mergedSnippet(_ lhs: String?, _ rhs: String?) -> String? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?) where !lhs.isEmpty && !rhs.isEmpty:
+            return truncatedSnippet(lhs + "\n" + rhs)
         case let (lhs?, _):
             return lhs
         case let (_, rhs?):

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -751,4 +751,87 @@ struct RenderingAndDiffTests {
         #expect(regions.contains { $0.kind == .added || $0.kind == .edited })
         #expect(!regions.contains { $0.kind == .deleted })
     }
+
+    // MARK: - Adjacent region coalescing (#234)
+
+    @Test @MainActor func changedRegionDifferCoalescesConsecutiveEditedLinesIntoOneRegion() {
+        let differ = ChangedRegionDiffer()
+
+        let oldMarkdown = "# Title\n\nLine one\nLine two\nLine three\n\nEnd"
+        let newMarkdown = "# Title\n\nLine one modified\nLine two modified\nLine three modified\n\nEnd"
+
+        let regions = differ.computeChangedRegions(
+            oldMarkdown: oldMarkdown,
+            newMarkdown: newMarkdown
+        )
+
+        let editedRegions = regions.filter { $0.kind == .edited }
+        #expect(editedRegions.count == 1)
+        #expect(editedRegions.first?.lineRange == 3...5)
+    }
+
+    @Test @MainActor func changedRegionDifferCoalescesConsecutiveAddedLinesIntoOneRegion() {
+        let differ = ChangedRegionDiffer()
+
+        let oldMarkdown = "# Title\n\nEnd"
+        let newMarkdown = "# Title\n\nNew line one\nNew line two\n\nEnd"
+
+        let regions = differ.computeChangedRegions(
+            oldMarkdown: oldMarkdown,
+            newMarkdown: newMarkdown
+        )
+
+        let addedRegions = regions.filter { $0.kind == .added }
+        #expect(addedRegions.count == 1)
+        #expect(addedRegions.first?.lineRange == 3...4)
+    }
+
+    @Test @MainActor func changedRegionDifferKeepsSeparateRegionsForLinesSeparatedByBlankLine() {
+        let differ = ChangedRegionDiffer()
+
+        let oldMarkdown = "# Title\n\nParagraph one\n\nParagraph two"
+        let newMarkdown = "# Title\n\nParagraph one modified\n\nParagraph two modified"
+
+        let regions = differ.computeChangedRegions(
+            oldMarkdown: oldMarkdown,
+            newMarkdown: newMarkdown
+        )
+
+        let editedRegions = regions.filter { $0.kind == .edited }
+        #expect(editedRegions.count == 2)
+    }
+
+    @Test @MainActor func changedRegionDifferDoesNotCoalesceDeletedWithEdited() {
+        let differ = ChangedRegionDiffer()
+
+        let oldMarkdown = "# Title\n\nRemove me\nKeep me\n\nEnd"
+        let newMarkdown = "# Title\n\nKeep me modified\n\nEnd"
+
+        let regions = differ.computeChangedRegions(
+            oldMarkdown: oldMarkdown,
+            newMarkdown: newMarkdown
+        )
+
+        let deletedRegions = regions.filter { $0.kind == .deleted }
+        let editedRegions = regions.filter { $0.kind == .edited }
+        #expect(deletedRegions.count + editedRegions.count >= 2)
+        #expect(!deletedRegions.isEmpty)
+        #expect(!editedRegions.isEmpty)
+    }
+
+    @Test @MainActor func changedRegionDifferSingleLineEditProducesOneRegion() {
+        let differ = ChangedRegionDiffer()
+
+        let oldMarkdown = "# Title\n\nOriginal line\n\nEnd"
+        let newMarkdown = "# Title\n\nModified line\n\nEnd"
+
+        let regions = differ.computeChangedRegions(
+            oldMarkdown: oldMarkdown,
+            newMarkdown: newMarkdown
+        )
+
+        let editedRegions = regions.filter { $0.kind == .edited }
+        #expect(editedRegions.count == 1)
+        #expect(editedRegions.first?.lineRange == 3...3)
+    }
 }


### PR DESCRIPTION
## Summary

- Fix change counter overcounting when multiple source lines within the same rendered block are edited
- Add `coalescedAdjacentRegions` to merge consecutive non-deleted regions of the same kind, mirroring the existing `coalescedDeletedRegions` pattern
- Empty lines naturally prevent merging since they create lineRange gaps, so separate paragraphs remain separate changes

Closes #234

## Test plan

- [x] 3 consecutive edited lines produce 1 `.edited` region spanning all 3
- [x] 2 consecutive added lines produce 1 `.added` region
- [x] Lines separated by a blank line remain separate regions
- [x] `.deleted` regions are not merged with `.edited` regions
- [x] Single-line edit still produces exactly 1 region (regression check)
- [x] Full test suite passes with no regressions