### PR TITLE
Replace DispatchSource folder watching with FSEvents for large trees

### DIFF
--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -2,7 +2,6 @@ import Foundation
 import OSLog
 
 final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Sendable {
-    private static let adaptiveSafetyPollingMaximumUnsignaledSkips = 2
     private static let queueKey = DispatchSpecificKey<ObjectIdentifier>()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
@@ -24,8 +23,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     private var includesSubfolders = false
     private var watchedFolderURL: URL?
     private var exclusionMatcher: FolderWatchExclusionMatcher?
-    private var unsignaledVerificationSkipCycles = 0
-    private var hasPendingFileSystemSignal = false
 
     init(
         pollingInterval: DispatchTimeInterval = .seconds(1),
@@ -62,7 +59,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
             self.includesSubfolders = includeSubfolders
             self.exclusionMatcher = exclusionMatcher
             self.onEvent = onEvent
-            self.hasPendingFileSystemSignal = true
 
             self.synchronizeDirectorySources(
                 folderURL: folderURL,
@@ -170,8 +166,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         onEvent = nil
         usesEventSource = false
         needsDirectorySourceResync = false
-        unsignaledVerificationSkipCycles = 0
-        hasPendingFileSystemSignal = false
     }
 
     private func synchronizeDirectorySources(
@@ -313,9 +307,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     private func handleDirectorySourceEvent(_ events: DispatchSource.FileSystemEvent) {
-        hasPendingFileSystemSignal = true
-        unsignaledVerificationSkipCycles = 0
-
         let topologyChangeEvents: DispatchSource.FileSystemEvent = [.rename, .delete, .revoke, .write]
         if !events.intersection(topologyChangeEvents).isEmpty {
             needsDirectorySourceResync = needsDirectorySourceResync || includesSubfolders

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -80,8 +80,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     func stop() {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            // Already on a managed queue — safe to run inline
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             stopInternal()
         } else if let queue {
             queue.sync { self.stopInternal() }

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -80,7 +80,8 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     func stop() {
-        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            // Already on a managed queue — safe to run inline
             stopInternal()
         } else if let queue {
             queue.sync { self.stopInternal() }

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -81,12 +81,11 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
             self.reconfigureTimerIfNeeded()
         }
 
-        if let existingQueue = self.queue,
-           DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            _ = existingQueue
+        queue.setSpecific(key: Self.queueKey, value: 1)
+
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
             startWork()
         } else {
-            queue.setSpecific(key: Self.queueKey, value: 1)
             queue.sync(execute: startWork)
         }
     }

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -91,64 +91,20 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
 
     // MARK: - Testing properties
 
-    var isUsingEventSourcesForTesting: Bool {
+    var isUsingEventSourcesForTesting: Bool { syncRead { usesEventSource } }
+    var activeDirectorySourceCountForTesting: Int { syncRead { directorySources.count } }
+    var isUsingFallbackPollingIntervalForTesting: Bool { syncRead { timerInterval == fallbackPollingInterval } }
+    var isUsingRecursiveEventSourceSafetyPollingIntervalForTesting: Bool { syncRead { timerInterval == recursiveEventSourceSafetyPollingInterval } }
+    var currentTimerIntervalForTesting: DispatchTimeInterval? { syncRead { timerInterval } }
+
+    private func syncRead<T>(_ body: () -> T) -> T {
         if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
-            return usesEventSource
+            return body()
         }
-
         if let queue {
-            return queue.sync { usesEventSource }
+            return queue.sync(execute: body)
         }
-
-        return usesEventSource
-    }
-
-    var activeDirectorySourceCountForTesting: Int {
-        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
-            return directorySources.count
-        }
-
-        if let queue {
-            return queue.sync { directorySources.count }
-        }
-
-        return directorySources.count
-    }
-
-    var isUsingFallbackPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
-            return timerInterval == fallbackPollingInterval
-        }
-
-        if let queue {
-            return queue.sync { timerInterval == fallbackPollingInterval }
-        }
-
-        return timerInterval == fallbackPollingInterval
-    }
-
-    var isUsingRecursiveEventSourceSafetyPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
-            return timerInterval == recursiveEventSourceSafetyPollingInterval
-        }
-
-        if let queue {
-            return queue.sync { timerInterval == recursiveEventSourceSafetyPollingInterval }
-        }
-
-        return timerInterval == recursiveEventSourceSafetyPollingInterval
-    }
-
-    var currentTimerIntervalForTesting: DispatchTimeInterval? {
-        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
-            return timerInterval
-        }
-
-        if let queue {
-            return queue.sync { timerInterval }
-        }
-
-        return timerInterval
+        return body()
     }
 
     // MARK: - Private

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -2,10 +2,8 @@ import Foundation
 import OSLog
 
 final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Sendable {
-    private static let adaptiveSafetyPollingIdleCyclesPerStep = 3
-    private static let adaptiveSafetyPollingMaximumMultiplier = 4
     private static let adaptiveSafetyPollingMaximumUnsignaledSkips = 2
-    private static let queueKey = DispatchSpecificKey<UInt8>()
+    private static let queueKey = DispatchSpecificKey<ObjectIdentifier>()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
         category: "DispatchSourceFolderEventSource"
@@ -26,8 +24,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     private var includesSubfolders = false
     private var watchedFolderURL: URL?
     private var exclusionMatcher: FolderWatchExclusionMatcher?
-    private var adaptiveSafetyPollingMultiplier = 1
-    private var adaptiveSafetyPollingIdleCycles = 0
     private var unsignaledVerificationSkipCycles = 0
     private var hasPendingFileSystemSignal = false
 
@@ -77,9 +73,10 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
             self.reconfigureTimerIfNeeded()
         }
 
-        queue.setSpecific(key: Self.queueKey, value: 1)
+        let token = ObjectIdentifier(self)
+        queue.setSpecific(key: Self.queueKey, value: token)
 
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == token {
             startWork()
         } else {
             queue.sync(execute: startWork)
@@ -87,9 +84,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     func stop() {
-        if let queue,
-           DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            _ = queue
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             stopInternal()
         } else if let queue {
             queue.sync { self.stopInternal() }
@@ -101,7 +96,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     // MARK: - Testing properties
 
     var isUsingEventSourcesForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return usesEventSource
         }
 
@@ -113,7 +108,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     var activeDirectorySourceCountForTesting: Int {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return directorySources.count
         }
 
@@ -125,7 +120,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     var isUsingFallbackPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return timerInterval == fallbackPollingInterval
         }
 
@@ -137,19 +132,19 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     var isUsingRecursiveEventSourceSafetyPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval()
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
+            return timerInterval == recursiveEventSourceSafetyPollingInterval
         }
 
         if let queue {
-            return queue.sync { timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval() }
+            return queue.sync { timerInterval == recursiveEventSourceSafetyPollingInterval }
         }
 
-        return timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval()
+        return timerInterval == recursiveEventSourceSafetyPollingInterval
     }
 
     var currentTimerIntervalForTesting: DispatchTimeInterval? {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return timerInterval
         }
 
@@ -175,8 +170,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         onEvent = nil
         usesEventSource = false
         needsDirectorySourceResync = false
-        adaptiveSafetyPollingMultiplier = 1
-        adaptiveSafetyPollingIdleCycles = 0
         unsignaledVerificationSkipCycles = 0
         hasPendingFileSystemSignal = false
     }
@@ -240,7 +233,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         let desiredInterval: DispatchTimeInterval
         if usesEventSource {
             desiredInterval = includesSubfolders
-                ? resolvedRecursiveEventSourceSafetyPollingInterval()
+                ? recursiveEventSourceSafetyPollingInterval
                 : fallbackPollingInterval
         } else {
             desiredInterval = pollingInterval
@@ -305,7 +298,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     }
 
     private func handleDirectorySourceEvent(_ events: DispatchSource.FileSystemEvent) {
-        resetAdaptiveSafetyPollingToBaselineIfNeeded()
         hasPendingFileSystemSignal = true
         unsignaledVerificationSkipCycles = 0
 
@@ -313,49 +305,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         if !events.intersection(topologyChangeEvents).isEmpty {
             needsDirectorySourceResync = needsDirectorySourceResync || includesSubfolders
         }
-    }
-
-    private func resolvedRecursiveEventSourceSafetyPollingInterval() -> DispatchTimeInterval {
-        scaledInterval(recursiveEventSourceSafetyPollingInterval, multiplier: adaptiveSafetyPollingMultiplier)
-    }
-
-    private func adaptRecursiveEventSourceSafetyPollingIfNeeded(
-        changedEventCount: Int,
-        didResynchronizeDirectories: Bool
-    ) {
-        guard usesEventSource, includesSubfolders else {
-            adaptiveSafetyPollingMultiplier = 1
-            adaptiveSafetyPollingIdleCycles = 0
-            return
-        }
-
-        guard changedEventCount == 0, !didResynchronizeDirectories else {
-            resetAdaptiveSafetyPollingToBaselineIfNeeded()
-            return
-        }
-
-        adaptiveSafetyPollingIdleCycles += 1
-        guard adaptiveSafetyPollingIdleCycles >= Self.adaptiveSafetyPollingIdleCyclesPerStep else {
-            return
-        }
-
-        adaptiveSafetyPollingIdleCycles = 0
-        guard adaptiveSafetyPollingMultiplier < Self.adaptiveSafetyPollingMaximumMultiplier else {
-            return
-        }
-
-        adaptiveSafetyPollingMultiplier += 1
-        reconfigureTimerIfNeeded()
-    }
-
-    private func resetAdaptiveSafetyPollingToBaselineIfNeeded() {
-        adaptiveSafetyPollingIdleCycles = 0
-        guard adaptiveSafetyPollingMultiplier != 1 else {
-            return
-        }
-
-        adaptiveSafetyPollingMultiplier = 1
-        reconfigureTimerIfNeeded()
     }
 
     private func enumerateWatchedDirectories(
@@ -412,26 +361,5 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         }
 
         return result
-    }
-
-    private func scaledInterval(_ interval: DispatchTimeInterval, multiplier: Int) -> DispatchTimeInterval {
-        guard multiplier > 1 else {
-            return interval
-        }
-
-        switch interval {
-        case let .seconds(value):
-            return .seconds(value * multiplier)
-        case let .milliseconds(value):
-            return .milliseconds(value * multiplier)
-        case let .microseconds(value):
-            return .microseconds(value * multiplier)
-        case let .nanoseconds(value):
-            return .nanoseconds(value * multiplier)
-        case .never:
-            return .never
-        @unknown default:
-            return interval
-        }
     }
 }

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -31,10 +31,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
     private var unsignaledVerificationSkipCycles = 0
     private var hasPendingFileSystemSignal = false
 
-    var recommendedSafetyPollingInterval: DispatchTimeInterval {
-        fallbackPollingInterval
-    }
-
     init(
         pollingInterval: DispatchTimeInterval = .seconds(1),
         fallbackPollingInterval: DispatchTimeInterval = .seconds(3),
@@ -100,59 +96,6 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
         } else {
             stopInternal()
         }
-    }
-
-    // MARK: - Watcher integration
-
-    func reportVerificationResult(
-        changedEventCount: Int,
-        didResynchronizeDirectories: Bool
-    ) {
-        adaptRecursiveEventSourceSafetyPollingIfNeeded(
-            changedEventCount: changedEventCount,
-            didResynchronizeDirectories: didResynchronizeDirectories
-        )
-    }
-
-    func shouldSkipVerification() -> Bool {
-        guard usesEventSource,
-              includesSubfolders,
-              !needsDirectorySourceResync,
-              !hasPendingFileSystemSignal else {
-            unsignaledVerificationSkipCycles = 0
-            return false
-        }
-
-        guard unsignaledVerificationSkipCycles < Self.adaptiveSafetyPollingMaximumUnsignaledSkips else {
-            unsignaledVerificationSkipCycles = 0
-            return false
-        }
-
-        unsignaledVerificationSkipCycles += 1
-        return true
-    }
-
-    func consumePendingSignal() {
-        hasPendingFileSystemSignal = false
-        unsignaledVerificationSkipCycles = 0
-    }
-
-    func resynchronizeIfNeeded(
-        folderURL: URL,
-        includeSubfolders: Bool,
-        exclusionMatcher: FolderWatchExclusionMatcher
-    ) -> Bool {
-        guard needsDirectorySourceResync else {
-            return false
-        }
-
-        synchronizeDirectorySources(
-            folderURL: folderURL,
-            includeSubfolders: includeSubfolders,
-            exclusionMatcher: exclusionMatcher
-        )
-        needsDirectorySourceResync = false
-        return true
     }
 
     // MARK: - Testing properties

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -1,0 +1,495 @@
+import Foundation
+import OSLog
+
+final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Sendable {
+    private static let adaptiveSafetyPollingIdleCyclesPerStep = 3
+    private static let adaptiveSafetyPollingMaximumMultiplier = 4
+    private static let adaptiveSafetyPollingMaximumUnsignaledSkips = 2
+    private static let queueKey = DispatchSpecificKey<UInt8>()
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
+        category: "DispatchSourceFolderEventSource"
+    )
+
+    private let pollingInterval: DispatchTimeInterval
+    private let fallbackPollingInterval: DispatchTimeInterval
+    private let recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval
+    private let maximumDirectoryEventSourceCount: Int
+
+    private var queue: DispatchQueue?
+    private var directorySources: [URL: DispatchSourceFileSystemObject] = [:]
+    private var timer: DispatchSourceTimer?
+    private var timerInterval: DispatchTimeInterval?
+    private var onEvent: ((@Sendable (Set<URL>?) -> Void))?
+    private var usesEventSource = false
+    private var needsDirectorySourceResync = false
+    private var includesSubfolders = false
+    private var watchedFolderURL: URL?
+    private var exclusionMatcher: FolderWatchExclusionMatcher?
+    private var adaptiveSafetyPollingMultiplier = 1
+    private var adaptiveSafetyPollingIdleCycles = 0
+    private var unsignaledVerificationSkipCycles = 0
+    private var hasPendingFileSystemSignal = false
+
+    var recommendedSafetyPollingInterval: DispatchTimeInterval {
+        fallbackPollingInterval
+    }
+
+    init(
+        pollingInterval: DispatchTimeInterval = .seconds(1),
+        fallbackPollingInterval: DispatchTimeInterval = .seconds(3),
+        recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval = .seconds(
+            ReaderFolderWatchPerformancePolicy.recursiveEventSourceSafetyPollingIntervalSeconds
+        ),
+        maximumDirectoryEventSourceCount: Int = 128
+    ) {
+        self.pollingInterval = pollingInterval
+        self.fallbackPollingInterval = fallbackPollingInterval
+        self.recursiveEventSourceSafetyPollingInterval = recursiveEventSourceSafetyPollingInterval
+        self.maximumDirectoryEventSourceCount = max(1, maximumDirectoryEventSourceCount)
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - FolderEventSource
+
+    func start(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher,
+        queue: DispatchQueue,
+        onEvent: @escaping @Sendable (Set<URL>?) -> Void
+    ) {
+        let startWork = {
+            self.stopInternal()
+
+            self.queue = queue
+            self.watchedFolderURL = folderURL
+            self.includesSubfolders = includeSubfolders
+            self.exclusionMatcher = exclusionMatcher
+            self.onEvent = onEvent
+            self.hasPendingFileSystemSignal = true
+
+            self.synchronizeDirectorySources(
+                folderURL: folderURL,
+                includeSubfolders: includeSubfolders,
+                exclusionMatcher: exclusionMatcher
+            )
+            self.needsDirectorySourceResync = false
+            self.reconfigureTimerIfNeeded()
+        }
+
+        if let existingQueue = self.queue,
+           DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            _ = existingQueue
+            startWork()
+        } else {
+            queue.setSpecific(key: Self.queueKey, value: 1)
+            queue.sync(execute: startWork)
+        }
+    }
+
+    func stop() {
+        if let queue,
+           DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            _ = queue
+            stopInternal()
+        } else if let queue {
+            queue.sync { self.stopInternal() }
+        } else {
+            stopInternal()
+        }
+    }
+
+    // MARK: - Watcher integration
+
+    func reportVerificationResult(
+        changedEventCount: Int,
+        didResynchronizeDirectories: Bool
+    ) {
+        adaptRecursiveEventSourceSafetyPollingIfNeeded(
+            changedEventCount: changedEventCount,
+            didResynchronizeDirectories: didResynchronizeDirectories
+        )
+    }
+
+    func shouldSkipVerification() -> Bool {
+        guard usesEventSource,
+              includesSubfolders,
+              !needsDirectorySourceResync,
+              !hasPendingFileSystemSignal else {
+            unsignaledVerificationSkipCycles = 0
+            return false
+        }
+
+        guard unsignaledVerificationSkipCycles < Self.adaptiveSafetyPollingMaximumUnsignaledSkips else {
+            unsignaledVerificationSkipCycles = 0
+            return false
+        }
+
+        unsignaledVerificationSkipCycles += 1
+        return true
+    }
+
+    func consumePendingSignal() {
+        hasPendingFileSystemSignal = false
+        unsignaledVerificationSkipCycles = 0
+    }
+
+    func resynchronizeIfNeeded(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher
+    ) -> Bool {
+        guard needsDirectorySourceResync else {
+            return false
+        }
+
+        synchronizeDirectorySources(
+            folderURL: folderURL,
+            includeSubfolders: includeSubfolders,
+            exclusionMatcher: exclusionMatcher
+        )
+        needsDirectorySourceResync = false
+        return true
+    }
+
+    // MARK: - Testing properties
+
+    var isUsingEventSourcesForTesting: Bool {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            return usesEventSource
+        }
+
+        if let queue {
+            return queue.sync { usesEventSource }
+        }
+
+        return usesEventSource
+    }
+
+    var activeDirectorySourceCountForTesting: Int {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            return directorySources.count
+        }
+
+        if let queue {
+            return queue.sync { directorySources.count }
+        }
+
+        return directorySources.count
+    }
+
+    var isUsingFallbackPollingIntervalForTesting: Bool {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            return timerInterval == fallbackPollingInterval
+        }
+
+        if let queue {
+            return queue.sync { timerInterval == fallbackPollingInterval }
+        }
+
+        return timerInterval == fallbackPollingInterval
+    }
+
+    var isUsingRecursiveEventSourceSafetyPollingIntervalForTesting: Bool {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            return timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval()
+        }
+
+        if let queue {
+            return queue.sync { timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval() }
+        }
+
+        return timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval()
+    }
+
+    var currentTimerIntervalForTesting: DispatchTimeInterval? {
+        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+            return timerInterval
+        }
+
+        if let queue {
+            return queue.sync { timerInterval }
+        }
+
+        return timerInterval
+    }
+
+    // MARK: - Private
+
+    private func stopInternal() {
+        cancelAllDirectorySources()
+
+        timer?.cancel()
+        timer = nil
+        timerInterval = nil
+
+        watchedFolderURL = nil
+        includesSubfolders = false
+        exclusionMatcher = nil
+        onEvent = nil
+        usesEventSource = false
+        needsDirectorySourceResync = false
+        adaptiveSafetyPollingMultiplier = 1
+        adaptiveSafetyPollingIdleCycles = 0
+        unsignaledVerificationSkipCycles = 0
+        hasPendingFileSystemSignal = false
+    }
+
+    private func synchronizeDirectorySources(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher
+    ) {
+        let usedEventSourcesBeforeSync = usesEventSource
+
+        let watchedDirectoryURLs: [URL]
+        do {
+            watchedDirectoryURLs = try enumerateWatchedDirectories(
+                folderURL: folderURL,
+                includeSubfolders: includeSubfolders,
+                exclusionMatcher: exclusionMatcher
+            )
+        } catch {
+            watchedDirectoryURLs = [folderURL]
+            Self.logger.error(
+                "directory enumeration failed: \(error.localizedDescription, privacy: .private(mask: .hash))"
+            )
+        }
+
+        if includeSubfolders && watchedDirectoryURLs.count > maximumDirectoryEventSourceCount {
+            cancelAllDirectorySources()
+            if usedEventSourcesBeforeSync != usesEventSource {
+                reconfigureTimerIfNeeded()
+            }
+            return
+        }
+
+        let targetURLs = Set(watchedDirectoryURLs)
+
+        for url in directorySources.keys where !targetURLs.contains(url) {
+            directorySources[url]?.cancel()
+            directorySources.removeValue(forKey: url)
+        }
+
+        for url in watchedDirectoryURLs where directorySources[url] == nil {
+            guard let source = makeDirectorySource(for: url) else {
+                continue
+            }
+
+            directorySources[url] = source
+            source.resume()
+        }
+
+        usesEventSource = !directorySources.isEmpty
+        if usedEventSourcesBeforeSync != usesEventSource {
+            reconfigureTimerIfNeeded()
+        }
+    }
+
+    private func reconfigureTimerIfNeeded() {
+        guard let queue else {
+            return
+        }
+
+        let desiredInterval: DispatchTimeInterval
+        if usesEventSource {
+            desiredInterval = includesSubfolders
+                ? resolvedRecursiveEventSourceSafetyPollingInterval()
+                : fallbackPollingInterval
+        } else {
+            desiredInterval = pollingInterval
+        }
+
+        guard timer == nil || timerInterval != desiredInterval else {
+            return
+        }
+
+        timer?.cancel()
+
+        let newTimer = DispatchSource.makeTimerSource(queue: queue)
+        newTimer.schedule(deadline: .now() + desiredInterval, repeating: desiredInterval)
+        newTimer.setEventHandler { [weak self] in
+            self?.onEvent?(nil)
+        }
+        self.timer = newTimer
+        timerInterval = desiredInterval
+        newTimer.resume()
+    }
+
+    private func makeDirectorySource(for directoryURL: URL) -> DispatchSourceFileSystemObject? {
+        guard let queue else {
+            return nil
+        }
+
+        let descriptor = open(directoryURL.path, O_EVTONLY)
+        guard descriptor >= 0 else {
+            return nil
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .rename, .delete, .attrib, .extend, .revoke],
+            queue: queue
+        )
+
+        source.setEventHandler { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let events = source.data
+            self.handleDirectorySourceEvent(events)
+            self.onEvent?(nil)
+        }
+
+        source.setCancelHandler { [descriptor] in
+            close(descriptor)
+        }
+
+        return source
+    }
+
+    private func cancelAllDirectorySources() {
+        for source in directorySources.values {
+            source.cancel()
+        }
+
+        directorySources.removeAll()
+        usesEventSource = false
+    }
+
+    private func handleDirectorySourceEvent(_ events: DispatchSource.FileSystemEvent) {
+        resetAdaptiveSafetyPollingToBaselineIfNeeded()
+        hasPendingFileSystemSignal = true
+        unsignaledVerificationSkipCycles = 0
+
+        let topologyChangeEvents: DispatchSource.FileSystemEvent = [.rename, .delete, .revoke, .write]
+        if !events.intersection(topologyChangeEvents).isEmpty {
+            needsDirectorySourceResync = needsDirectorySourceResync || includesSubfolders
+        }
+    }
+
+    private func resolvedRecursiveEventSourceSafetyPollingInterval() -> DispatchTimeInterval {
+        scaledInterval(recursiveEventSourceSafetyPollingInterval, multiplier: adaptiveSafetyPollingMultiplier)
+    }
+
+    private func adaptRecursiveEventSourceSafetyPollingIfNeeded(
+        changedEventCount: Int,
+        didResynchronizeDirectories: Bool
+    ) {
+        guard usesEventSource, includesSubfolders else {
+            adaptiveSafetyPollingMultiplier = 1
+            adaptiveSafetyPollingIdleCycles = 0
+            return
+        }
+
+        guard changedEventCount == 0, !didResynchronizeDirectories else {
+            resetAdaptiveSafetyPollingToBaselineIfNeeded()
+            return
+        }
+
+        adaptiveSafetyPollingIdleCycles += 1
+        guard adaptiveSafetyPollingIdleCycles >= Self.adaptiveSafetyPollingIdleCyclesPerStep else {
+            return
+        }
+
+        adaptiveSafetyPollingIdleCycles = 0
+        guard adaptiveSafetyPollingMultiplier < Self.adaptiveSafetyPollingMaximumMultiplier else {
+            return
+        }
+
+        adaptiveSafetyPollingMultiplier += 1
+        reconfigureTimerIfNeeded()
+    }
+
+    private func resetAdaptiveSafetyPollingToBaselineIfNeeded() {
+        adaptiveSafetyPollingIdleCycles = 0
+        guard adaptiveSafetyPollingMultiplier != 1 else {
+            return
+        }
+
+        adaptiveSafetyPollingMultiplier = 1
+        reconfigureTimerIfNeeded()
+    }
+
+    private func enumerateWatchedDirectories(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher
+    ) throws -> [URL] {
+        guard folderURL.isFileURL else {
+            throw ReaderError.invalidFileURL
+        }
+
+        let normalizedFolderURL = ReaderFileRouting.normalizedFileURL(folderURL)
+        guard includeSubfolders else {
+            return [normalizedFolderURL]
+        }
+
+        var result: [URL] = [normalizedFolderURL]
+        let fileManager = FileManager.default
+        let rootFolderPathWithSlash = exclusionMatcher.normalizedRootPathWithSlash
+
+        guard let enumerator = fileManager.enumerator(
+            at: normalizedFolderURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [],
+            errorHandler: { _, _ in true }
+        ) else {
+            return result
+        }
+
+        for case let directoryURL as URL in enumerator {
+            let normalizedDirectoryURL = ReaderFileRouting.normalizedFileURL(directoryURL)
+            if FolderSnapshotDiffer.shouldSkipEntryBeyondIncludeSubfolderDepth(
+                normalizedDirectoryURL,
+                rootFolderPathWithSlash: rootFolderPathWithSlash,
+                enumerator: enumerator
+            ) {
+                continue
+            }
+
+            if FolderSnapshotDiffer.shouldSkipDescendants(
+                forNormalizedURL: normalizedDirectoryURL,
+                exclusionMatcher: exclusionMatcher,
+                enumerator: enumerator
+            ) {
+                continue
+            }
+
+            if (try? normalizedDirectoryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+                guard !exclusionMatcher.excludesNormalizedDirectoryPath(normalizedDirectoryURL.path) else {
+                    continue
+                }
+                result.append(normalizedDirectoryURL)
+            }
+        }
+
+        return result
+    }
+
+    private func scaledInterval(_ interval: DispatchTimeInterval, multiplier: Int) -> DispatchTimeInterval {
+        guard multiplier > 1 else {
+            return interval
+        }
+
+        switch interval {
+        case let .seconds(value):
+            return .seconds(value * multiplier)
+        case let .milliseconds(value):
+            return .milliseconds(value * multiplier)
+        case let .microseconds(value):
+            return .microseconds(value * multiplier)
+        case let .nanoseconds(value):
+            return .nanoseconds(value * multiplier)
+        case .never:
+            return .never
+        @unknown default:
+            return interval
+        }
+    }
+}

--- a/minimark/Services/DispatchSourceFolderEventSource.swift
+++ b/minimark/Services/DispatchSourceFolderEventSource.swift
@@ -278,6 +278,7 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
 
             let events = source.data
             self.handleDirectorySourceEvent(events)
+            self.resynchronizeIfNeeded()
             self.onEvent?(nil)
         }
 
@@ -295,6 +296,20 @@ final class DispatchSourceFolderEventSource: FolderEventSource, @unchecked Senda
 
         directorySources.removeAll()
         usesEventSource = false
+    }
+
+    private func resynchronizeIfNeeded() {
+        guard needsDirectorySourceResync,
+              let folderURL = watchedFolderURL,
+              let exclusionMatcher else {
+            return
+        }
+        synchronizeDirectorySources(
+            folderURL: folderURL,
+            includeSubfolders: includesSubfolders,
+            exclusionMatcher: exclusionMatcher
+        )
+        needsDirectorySourceResync = false
     }
 
     private func handleDirectorySourceEvent(_ events: DispatchSource.FileSystemEvent) {

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -38,12 +38,12 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
         queue: DispatchQueue,
         onEvent: @escaping @Sendable (Set<URL>?) -> Void
     ) {
+        stop()
+
         guard includeSubfolders else {
             Self.logger.warning("FSEventStreamFolderEventSource is designed for recursive watches; use DispatchSourceFolderEventSource for flat folders")
             return
         }
-
-        stop()
 
         self.queue = queue
         self.exclusionMatcher = exclusionMatcher
@@ -69,15 +69,17 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
             latency,
             flags
         ) else {
-            Self.logger.error("failed to create FSEventStream for \(folderURL.path, privacy: .private(mask: .hash))")
+            Self.logger.error("failed to create FSEventStream for \(folderURL.path, privacy: .private(mask: .hash)); falling back to safety polling")
+            configureSafetyTimer(queue: queue)
             return
         }
 
         FSEventStreamSetDispatchQueue(newStream, queue)
         guard FSEventStreamStart(newStream) else {
-            Self.logger.error("failed to start FSEventStream for \(folderURL.path, privacy: .private(mask: .hash))")
+            Self.logger.error("failed to start FSEventStream for \(folderURL.path, privacy: .private(mask: .hash)); falling back to safety polling")
             FSEventStreamInvalidate(newStream)
             FSEventStreamRelease(newStream)
+            configureSafetyTimer(queue: queue)
             return
         }
 
@@ -132,7 +134,9 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
             let flags = eventFlags[index]
 
             if (flags & UInt32(kFSEventStreamEventFlagMustScanSubDirs)) != 0 ||
-               (flags & UInt32(kFSEventStreamEventFlagRootChanged)) != 0 {
+               (flags & UInt32(kFSEventStreamEventFlagRootChanged)) != 0 ||
+               (flags & UInt32(kFSEventStreamEventFlagUserDropped)) != 0 ||
+               (flags & UInt32(kFSEventStreamEventFlagKernelDropped)) != 0 {
                 requiresFullScan = true
                 break
             }

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -68,10 +68,15 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
             return
         }
 
-        stream = newStream
         FSEventStreamSetDispatchQueue(newStream, queue)
-        FSEventStreamStart(newStream)
+        guard FSEventStreamStart(newStream) else {
+            Self.logger.error("failed to start FSEventStream for \(folderURL.path, privacy: .private(mask: .hash))")
+            FSEventStreamInvalidate(newStream)
+            FSEventStreamRelease(newStream)
+            return
+        }
 
+        stream = newStream
         configureSafetyTimer(queue: queue)
     }
 

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -119,10 +119,7 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
         eventFlags: UnsafePointer<FSEventStreamEventFlags>,
         eventIds: UnsafePointer<FSEventStreamEventId>
     ) {
-        guard let cfPaths = unsafeBitCast(eventPaths, to: CFArray?.self) else {
-            onEvent?(nil)
-            return
-        }
+        let cfPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
 
         var changedDirectoryURLs = Set<URL>()
         var requiresFullScan = false
@@ -141,24 +138,26 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
             }
 
             let path = unsafeBitCast(cfPath, to: CFString.self) as String
+            let isDirectory = (flags & UInt32(kFSEventStreamEventFlagItemIsDir)) != 0
+            let normalizedEventURL = ReaderFileRouting.normalizedFileURL(
+                URL(fileURLWithPath: path, isDirectory: isDirectory)
+            )
 
-            if let exclusionMatcher, exclusionMatcher.excludesNormalizedFilePath(path) {
+            if let exclusionMatcher,
+               exclusionMatcher.excludesNormalizedFilePath(normalizedEventURL.path) {
                 continue
             }
 
             let directoryURL: URL
-            let isDirectory = (flags & UInt32(kFSEventStreamEventFlagItemIsDir)) != 0
-
             if isDirectory {
-                directoryURL = URL(fileURLWithPath: path, isDirectory: true)
+                directoryURL = normalizedEventURL
             } else {
-                let parentPath = (path as NSString).deletingLastPathComponent
-                directoryURL = URL(fileURLWithPath: parentPath, isDirectory: true)
+                directoryURL = ReaderFileRouting.normalizedFileURL(
+                    normalizedEventURL.deletingLastPathComponent()
+                )
             }
 
-            changedDirectoryURLs.insert(
-                ReaderFileRouting.normalizedFileURL(directoryURL)
-            )
+            changedDirectoryURLs.insert(directoryURL)
         }
 
         if requiresFullScan {

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -17,10 +17,6 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
     private var exclusionMatcher: FolderWatchExclusionMatcher?
     private var onEvent: ((@Sendable (Set<URL>?) -> Void))?
 
-    var recommendedSafetyPollingInterval: DispatchTimeInterval {
-        safetyPollingInterval
-    }
-
     init(
         latency: CFTimeInterval = 0.3,
         safetyPollingInterval: DispatchTimeInterval = .seconds(30)

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -1,0 +1,195 @@
+import CoreServices
+import Foundation
+import OSLog
+
+final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendable {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
+        category: "FSEventStreamFolderEventSource"
+    )
+
+    private let latency: CFTimeInterval
+    private let safetyPollingInterval: DispatchTimeInterval
+
+    private var stream: FSEventStreamRef?
+    private var timer: DispatchSourceTimer?
+    private var queue: DispatchQueue?
+    private var exclusionMatcher: FolderWatchExclusionMatcher?
+    private var onEvent: ((@Sendable (Set<URL>?) -> Void))?
+
+    var recommendedSafetyPollingInterval: DispatchTimeInterval {
+        safetyPollingInterval
+    }
+
+    init(
+        latency: CFTimeInterval = 0.3,
+        safetyPollingInterval: DispatchTimeInterval = .seconds(30)
+    ) {
+        self.latency = latency
+        self.safetyPollingInterval = safetyPollingInterval
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - FolderEventSource
+
+    func start(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher,
+        queue: DispatchQueue,
+        onEvent: @escaping @Sendable (Set<URL>?) -> Void
+    ) {
+        stop()
+
+        self.queue = queue
+        self.exclusionMatcher = exclusionMatcher
+        self.onEvent = onEvent
+
+        let pathToWatch = folderURL.path as CFString
+        let pathsToWatch = [pathToWatch] as CFArray
+
+        var context = FSEventStreamContext()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+
+        let flags: FSEventStreamCreateFlags =
+            UInt32(kFSEventStreamCreateFlagFileEvents) |
+            UInt32(kFSEventStreamCreateFlagUseCFTypes) |
+            UInt32(kFSEventStreamCreateFlagNoDefer)
+
+        guard let newStream = FSEventStreamCreate(
+            nil,
+            fsEventCallback,
+            &context,
+            pathsToWatch,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            latency,
+            flags
+        ) else {
+            Self.logger.error("failed to create FSEventStream for \(folderURL.path, privacy: .private(mask: .hash))")
+            return
+        }
+
+        stream = newStream
+        FSEventStreamSetDispatchQueue(newStream, queue)
+        FSEventStreamStart(newStream)
+
+        configureSafetyTimer(queue: queue)
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+        stream = nil
+
+        queue = nil
+        exclusionMatcher = nil
+        onEvent = nil
+    }
+
+    // MARK: - Private
+
+    private func configureSafetyTimer(queue: DispatchQueue) {
+        timer?.cancel()
+
+        let newTimer = DispatchSource.makeTimerSource(queue: queue)
+        newTimer.schedule(
+            deadline: .now() + safetyPollingInterval,
+            repeating: safetyPollingInterval
+        )
+        newTimer.setEventHandler { [weak self] in
+            self?.onEvent?(nil)
+        }
+        timer = newTimer
+        newTimer.resume()
+    }
+
+    fileprivate func handleEvents(
+        numEvents: Int,
+        eventPaths: UnsafeMutableRawPointer,
+        eventFlags: UnsafePointer<FSEventStreamEventFlags>,
+        eventIds: UnsafePointer<FSEventStreamEventId>
+    ) {
+        guard let cfPaths = unsafeBitCast(eventPaths, to: CFArray?.self) else {
+            onEvent?(nil)
+            return
+        }
+
+        var changedDirectoryURLs = Set<URL>()
+        var requiresFullScan = false
+
+        for index in 0..<numEvents {
+            let flags = eventFlags[index]
+
+            if (flags & UInt32(kFSEventStreamEventFlagMustScanSubDirs)) != 0 ||
+               (flags & UInt32(kFSEventStreamEventFlagRootChanged)) != 0 {
+                requiresFullScan = true
+                break
+            }
+
+            guard let cfPath = CFArrayGetValueAtIndex(cfPaths, index) else {
+                continue
+            }
+
+            let path = unsafeBitCast(cfPath, to: CFString.self) as String
+
+            if let exclusionMatcher, exclusionMatcher.excludesNormalizedFilePath(path) {
+                continue
+            }
+
+            let directoryURL: URL
+            let isDirectory = (flags & UInt32(kFSEventStreamEventFlagItemIsDir)) != 0
+
+            if isDirectory {
+                directoryURL = URL(fileURLWithPath: path, isDirectory: true)
+            } else {
+                let parentPath = (path as NSString).deletingLastPathComponent
+                directoryURL = URL(fileURLWithPath: parentPath, isDirectory: true)
+            }
+
+            changedDirectoryURLs.insert(
+                ReaderFileRouting.normalizedFileURL(directoryURL)
+            )
+        }
+
+        if requiresFullScan {
+            onEvent?(nil)
+        } else if !changedDirectoryURLs.isEmpty {
+            onEvent?(changedDirectoryURLs)
+        }
+    }
+}
+
+// MARK: - FSEventStream C callback
+
+private func fsEventCallback(
+    streamRef: ConstFSEventStreamRef,
+    clientCallBackInfo: UnsafeMutableRawPointer?,
+    numEvents: Int,
+    eventPaths: UnsafeMutableRawPointer,
+    eventFlags: UnsafePointer<FSEventStreamEventFlags>,
+    eventIds: UnsafePointer<FSEventStreamEventId>
+) {
+    guard let clientCallBackInfo else {
+        return
+    }
+
+    let source = Unmanaged<FSEventStreamFolderEventSource>
+        .fromOpaque(clientCallBackInfo)
+        .takeUnretainedValue()
+
+    source.handleEvents(
+        numEvents: numEvents,
+        eventPaths: eventPaths,
+        eventFlags: eventFlags,
+        eventIds: eventIds
+    )
+}

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -38,6 +38,11 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
         queue: DispatchQueue,
         onEvent: @escaping @Sendable (Set<URL>?) -> Void
     ) {
+        guard includeSubfolders else {
+            Self.logger.warning("FSEventStreamFolderEventSource is designed for recursive watches; use DispatchSourceFolderEventSource for flat folders")
+            return
+        }
+
         stop()
 
         self.queue = queue
@@ -116,8 +121,7 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
     fileprivate func handleEvents(
         numEvents: Int,
         eventPaths: UnsafeMutableRawPointer,
-        eventFlags: UnsafePointer<FSEventStreamEventFlags>,
-        eventIds: UnsafePointer<FSEventStreamEventId>
+        eventFlags: UnsafePointer<FSEventStreamEventFlags>
     ) {
         let cfPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
 
@@ -189,7 +193,6 @@ private func fsEventCallback(
     source.handleEvents(
         numEvents: numEvents,
         eventPaths: eventPaths,
-        eventFlags: eventFlags,
-        eventIds: eventIds
+        eventFlags: eventFlags
     )
 }

--- a/minimark/Services/FSEventStreamFolderEventSource.swift
+++ b/minimark/Services/FSEventStreamFolderEventSource.swift
@@ -156,9 +156,9 @@ final class FSEventStreamFolderEventSource: FolderEventSource, @unchecked Sendab
             if isDirectory {
                 directoryURL = normalizedEventURL
             } else {
-                directoryURL = ReaderFileRouting.normalizedFileURL(
-                    normalizedEventURL.deletingLastPathComponent()
-                )
+                // normalizedEventURL is already standardized, so
+                // deletingLastPathComponent produces a normalized parent
+                directoryURL = normalizedEventURL.deletingLastPathComponent()
             }
 
             changedDirectoryURLs.insert(directoryURL)

--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -79,7 +79,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     private let makeEventSource: (_ includeSubfolders: Bool) -> any FolderEventSource
     private let onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)?
     private var eventSource: (any FolderEventSource)?
-    private var safetyTimer: DispatchSourceTimer?
     private var pendingWorkItem: DispatchWorkItem?
 
     private var watchedFolderURL: URL?
@@ -179,9 +178,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.eventSource?.stop()
             self.eventSource = nil
 
-            self.safetyTimer?.cancel()
-            self.safetyTimer = nil
-
             self.watchedFolderURL = nil
             self.includesSubfolders = false
             self.excludedSubdirectoryURLs = []
@@ -247,15 +243,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         ) { [weak self] changedDirectoryURLs in
             self?.scheduleVerification(changedDirectoryURLs: changedDirectoryURLs)
         }
-
-        let safetyInterval = source.recommendedSafetyPollingInterval
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + safetyInterval, repeating: safetyInterval)
-        timer.setEventHandler { [weak self] in
-            self?.scheduleVerification(changedDirectoryURLs: nil)
-        }
-        safetyTimer = timer
-        timer.resume()
 
         didCompleteStartup = true
         scheduleVerification(changedDirectoryURLs: nil)

--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -64,9 +64,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         var isFinished: Bool { completed == total }
     }
 
-    private static let adaptiveSafetyPollingIdleCyclesPerStep = 3
-    private static let adaptiveSafetyPollingMaximumMultiplier = 4
-    private static let adaptiveSafetyPollingMaximumUnsignaledSkips = 2
     private static let queueKey = DispatchSpecificKey<UInt8>()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
@@ -78,22 +75,12 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     )
     private let queue = DispatchQueue(label: "minimark.folderwatcher")
     private let snapshotDiffer: FolderSnapshotDiffing
-    private let pollingInterval: DispatchTimeInterval
-    private let fallbackPollingInterval: DispatchTimeInterval
-    private let recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval
     private let verificationDelay: DispatchTimeInterval
-    private let maximumDirectoryEventSourceCount: Int
+    private let makeEventSource: (_ includeSubfolders: Bool) -> any FolderEventSource
     private let onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)?
-    private var directorySources: [URL: DispatchSourceFileSystemObject] = [:]
-    private var timer: DispatchSourceTimer?
-    private var timerInterval: DispatchTimeInterval?
+    private var eventSource: (any FolderEventSource)?
+    private var safetyTimer: DispatchSourceTimer?
     private var pendingWorkItem: DispatchWorkItem?
-    private var usesEventSource = false
-    private var needsDirectorySourceResync = false
-    private var adaptiveSafetyPollingMultiplier = 1
-    private var adaptiveSafetyPollingIdleCycles = 0
-    private var unsignaledVerificationSkipCycles = 0
-    private var hasPendingFileSystemSignal = false
 
     private var watchedFolderURL: URL?
     private var includesSubfolders = false
@@ -108,42 +95,27 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     private var _scanProgressStream: AsyncStream<ScanProgress>?
 
     convenience init(
-        pollingInterval: DispatchTimeInterval = .seconds(1),
-        fallbackPollingInterval: DispatchTimeInterval = .seconds(3),
-        recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval = .seconds(
-            ReaderFolderWatchPerformancePolicy.recursiveEventSourceSafetyPollingIntervalSeconds
-        ),
         verificationDelay: DispatchTimeInterval = .milliseconds(75),
         onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)? = nil
     ) {
         self.init(
             snapshotDiffer: FolderSnapshotDiffer(),
-            pollingInterval: pollingInterval,
-            fallbackPollingInterval: fallbackPollingInterval,
-            recursiveEventSourceSafetyPollingInterval: recursiveEventSourceSafetyPollingInterval,
             verificationDelay: verificationDelay,
-            maximumDirectoryEventSourceCount: 128,
+            makeEventSource: { FolderEventSourceFactory.makeEventSource(includeSubfolders: $0) },
             onFailure: onFailure
         )
     }
 
     init(
         snapshotDiffer: FolderSnapshotDiffing = FolderSnapshotDiffer(),
-        pollingInterval: DispatchTimeInterval = .seconds(1),
-        fallbackPollingInterval: DispatchTimeInterval = .seconds(3),
-        recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval = .seconds(
-            ReaderFolderWatchPerformancePolicy.recursiveEventSourceSafetyPollingIntervalSeconds
-        ),
         verificationDelay: DispatchTimeInterval = .milliseconds(75),
-        maximumDirectoryEventSourceCount: Int = 128,
+        makeEventSource: @escaping (_ includeSubfolders: Bool) -> any FolderEventSource
+            = { FolderEventSourceFactory.makeEventSource(includeSubfolders: $0) },
         onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)? = nil
     ) {
         self.snapshotDiffer = snapshotDiffer
-        self.pollingInterval = pollingInterval
-        self.fallbackPollingInterval = fallbackPollingInterval
-        self.recursiveEventSourceSafetyPollingInterval = recursiveEventSourceSafetyPollingInterval
         self.verificationDelay = verificationDelay
-        self.maximumDirectoryEventSourceCount = max(1, maximumDirectoryEventSourceCount)
+        self.makeEventSource = makeEventSource
         self.onFailure = onFailure
         queue.setSpecific(key: Self.queueKey, value: 1)
     }
@@ -180,10 +152,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.onMarkdownFilesAddedOrChanged = onMarkdownFilesAddedOrChanged
             lastSnapshot = [:]
             lastReportedFailureByStage = [:]
-            needsDirectorySourceResync = false
             didCompleteStartup = false
-            unsignaledVerificationSkipCycles = 0
-            hasPendingFileSystemSignal = true
 
             let (stream, continuation) = AsyncStream.makeStream(of: ScanProgress.self)
             _scanProgressStream = stream
@@ -207,11 +176,11 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.pendingWorkItem?.cancel()
             self.pendingWorkItem = nil
 
-            self.cancelAllDirectorySources()
+            self.eventSource?.stop()
+            self.eventSource = nil
 
-            self.timer?.cancel()
-            self.timer = nil
-            self.timerInterval = nil
+            self.safetyTimer?.cancel()
+            self.safetyTimer = nil
 
             self.watchedFolderURL = nil
             self.includesSubfolders = false
@@ -220,12 +189,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.onMarkdownFilesAddedOrChanged = nil
             self.lastSnapshot = [:]
             self.lastReportedFailureByStage = [:]
-            self.usesEventSource = false
-            self.needsDirectorySourceResync = false
-            self.adaptiveSafetyPollingMultiplier = 1
-            self.adaptiveSafetyPollingIdleCycles = 0
-            self.unsignaledVerificationSkipCycles = 0
-            self.hasPendingFileSystemSignal = false
             self.didCompleteStartup = false
             self.scanProgressContinuation?.finish()
             self.scanProgressContinuation = nil
@@ -270,15 +233,32 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
 
         lastSnapshot = snapshot
 
-        synchronizeDirectorySources(
+        guard let exclusionMatcher else {
+            return
+        }
+
+        let source = makeEventSource(includeSubfolders)
+        eventSource = source
+        source.start(
             folderURL: folderURL,
             includeSubfolders: includeSubfolders,
-            excludedSubdirectoryURLs: excludedSubdirectoryURLs
-        )
-        needsDirectorySourceResync = false
+            exclusionMatcher: exclusionMatcher,
+            queue: queue
+        ) { [weak self] changedDirectoryURLs in
+            self?.scheduleVerification(changedDirectoryURLs: changedDirectoryURLs)
+        }
+
+        let safetyInterval = source.recommendedSafetyPollingInterval
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + safetyInterval, repeating: safetyInterval)
+        timer.setEventHandler { [weak self] in
+            self?.scheduleVerification(changedDirectoryURLs: nil)
+        }
+        safetyTimer = timer
+        timer.resume()
+
         didCompleteStartup = true
-        reconfigureTimerIfNeeded()
-        scheduleVerification()
+        scheduleVerification(changedDirectoryURLs: nil)
         // populateContentPhase runs synchronously on `queue`, so the
         // verifyChanges work item scheduled above cannot execute until
         // content population is complete.
@@ -306,46 +286,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             guard didCompleteStartup else { return nil }
             return lastSnapshot.keys.sorted(by: { $0.path < $1.path })
         }
-    }
-
-    var isUsingEventSourcesForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return usesEventSource
-        }
-
-        return queue.sync { usesEventSource }
-    }
-
-    var activeDirectorySourceCountForTesting: Int {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return directorySources.count
-        }
-
-        return queue.sync { directorySources.count }
-    }
-
-    var isUsingFallbackPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return timerInterval == fallbackPollingInterval
-        }
-
-        return queue.sync { timerInterval == fallbackPollingInterval }
-    }
-
-    var isUsingRecursiveEventSourceSafetyPollingIntervalForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval()
-        }
-
-        return queue.sync { timerInterval == resolvedRecursiveEventSourceSafetyPollingInterval() }
-    }
-
-    var currentTimerIntervalForTesting: DispatchTimeInterval? {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
-            return timerInterval
-        }
-
-        return queue.sync { timerInterval }
     }
 
     var didCompleteStartupForTesting: Bool {
@@ -414,20 +354,20 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         scanProgressContinuation = nil
     }
 
-    private func scheduleVerification() {
+    private func scheduleVerification(changedDirectoryURLs: Set<URL>?) {
         guard pendingWorkItem == nil else {
             return
         }
 
         let workItem = DispatchWorkItem { [weak self] in
             self?.pendingWorkItem = nil
-            self?.verifyChanges()
+            self?.verifyChanges(changedDirectoryURLs: changedDirectoryURLs)
         }
         pendingWorkItem = workItem
         queue.asyncAfter(deadline: .now() + verificationDelay, execute: workItem)
     }
 
-    private func verifyChanges() {
+    private func verifyChanges(changedDirectoryURLs: Set<URL>?) {
         let verifySignpostID = Self.signposter.makeSignpostID()
         let verifyIntervalState = Self.signposter.beginInterval("verifyChanges", id: verifySignpostID)
         defer {
@@ -442,29 +382,30 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             return
         }
 
-        if shouldSkipIdleVerificationCycle() {
-            adaptRecursiveEventSourceSafetyPollingIfNeeded(
-                changedEventCount: 0,
-                didResynchronizeDirectories: false
-            )
-            return
-        }
-
-        hasPendingFileSystemSignal = false
-        unsignaledVerificationSkipCycles = 0
-
         let currentSnapshot: [URL: FolderFileSnapshot]
         do {
             let snapshotIntervalState = Self.signposter.beginInterval("buildIncrementalSnapshot", id: verifySignpostID)
             defer {
                 Self.signposter.endInterval("buildIncrementalSnapshot", snapshotIntervalState)
             }
-            currentSnapshot = try snapshotDiffer.buildIncrementalSnapshot(
-                folderURL: watchedFolderURL,
-                includeSubfolders: includesSubfolders,
-                exclusionMatcher: exclusionMatcher,
-                previousSnapshot: lastSnapshot
-            )
+
+            if let changedDirectoryURLs, !changedDirectoryURLs.isEmpty {
+                currentSnapshot = try snapshotDiffer.buildTargetedIncrementalSnapshot(
+                    folderURL: watchedFolderURL,
+                    includeSubfolders: includesSubfolders,
+                    exclusionMatcher: exclusionMatcher,
+                    previousSnapshot: lastSnapshot,
+                    changedDirectoryURLs: changedDirectoryURLs
+                )
+            } else {
+                currentSnapshot = try snapshotDiffer.buildIncrementalSnapshot(
+                    folderURL: watchedFolderURL,
+                    includeSubfolders: includesSubfolders,
+                    exclusionMatcher: exclusionMatcher,
+                    previousSnapshot: lastSnapshot
+                )
+            }
+
             Self.signposter.emitEvent(
                 "snapshotCounts",
                 "current \(currentSnapshot.count) previous \(self.lastSnapshot.count) include_subfolders \(self.includesSubfolders ? 1 : 0)"
@@ -475,30 +416,12 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             return
         }
 
-        var didResynchronizeDirectories = false
-        if needsDirectorySourceResync {
-            let resyncIntervalState = Self.signposter.beginInterval("synchronizeDirectorySources", id: verifySignpostID)
-            synchronizeDirectorySources(
-                folderURL: watchedFolderURL,
-                includeSubfolders: includesSubfolders,
-                excludedSubdirectoryURLs: excludedSubdirectoryURLs
-            )
-            Self.signposter.endInterval("synchronizeDirectorySources", resyncIntervalState)
-            needsDirectorySourceResync = false
-            didResynchronizeDirectories = true
-        }
-
         let diffIntervalState = Self.signposter.beginInterval("diffSnapshots", id: verifySignpostID)
         let changedEvents = snapshotDiffer.diff(current: currentSnapshot, previous: lastSnapshot)
         Self.signposter.endInterval("diffSnapshots", diffIntervalState)
         Self.signposter.emitEvent(
             "diffCounts",
             "changed \(changedEvents.count) current \(currentSnapshot.count)"
-        )
-
-        adaptRecursiveEventSourceSafetyPollingIfNeeded(
-            changedEventCount: changedEvents.count,
-            didResynchronizeDirectories: didResynchronizeDirectories
         )
 
         lastSnapshot = currentSnapshot
@@ -511,280 +434,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         DispatchQueue.main.async {
             onMarkdownFilesAddedOrChanged(normalized)
         }
-    }
-
-    private func synchronizeDirectorySources(
-        folderURL: URL,
-        includeSubfolders: Bool,
-        excludedSubdirectoryURLs: [URL]
-    ) {
-        let usedEventSourcesBeforeSync = usesEventSource
-        let exclusionMatcher = FolderWatchExclusionMatcher(
-            rootFolderURL: folderURL,
-            excludedSubdirectoryURLs: excludedSubdirectoryURLs
-        )
-        let watchedDirectoryURLs: [URL]
-        do {
-            watchedDirectoryURLs = try enumerateWatchedDirectories(
-                folderURL: folderURL,
-                includeSubfolders: includeSubfolders,
-                exclusionMatcher: exclusionMatcher
-            )
-            Self.signposter.emitEvent(
-                "watchedDirectoryEnumeration",
-                "directories \(watchedDirectoryURLs.count) include_subfolders \(includeSubfolders ? 1 : 0)"
-            )
-            clearReportedFailure(for: .watchedDirectoryEnumeration)
-        } catch {
-            watchedDirectoryURLs = [folderURL]
-            reportFailure(stage: .watchedDirectoryEnumeration, folderURL: folderURL, error: error)
-        }
-
-        if includeSubfolders && watchedDirectoryURLs.count > maximumDirectoryEventSourceCount {
-            cancelAllDirectorySources()
-            if usedEventSourcesBeforeSync != usesEventSource {
-                reconfigureTimerIfNeeded()
-            }
-            return
-        }
-
-        let targetURLs = Set(watchedDirectoryURLs)
-
-        for url in directorySources.keys where !targetURLs.contains(url) {
-            directorySources[url]?.cancel()
-            directorySources.removeValue(forKey: url)
-        }
-
-        for url in watchedDirectoryURLs where directorySources[url] == nil {
-            guard let source = makeDirectorySource(for: url) else {
-                continue
-            }
-
-            directorySources[url] = source
-            source.resume()
-        }
-
-        usesEventSource = !directorySources.isEmpty
-        Self.signposter.emitEvent(
-            "directorySourceCounts",
-            "sources \(self.directorySources.count) uses_event_sources \(self.usesEventSource ? 1 : 0)"
-        )
-        if usedEventSourcesBeforeSync != usesEventSource {
-            reconfigureTimerIfNeeded()
-        }
-    }
-
-    private func reconfigureTimerIfNeeded() {
-        let desiredInterval: DispatchTimeInterval
-        if usesEventSource {
-            desiredInterval = includesSubfolders
-                ? resolvedRecursiveEventSourceSafetyPollingInterval()
-                : fallbackPollingInterval
-        } else {
-            desiredInterval = pollingInterval
-        }
-
-        guard timer == nil || timerInterval != desiredInterval else {
-            return
-        }
-
-        timer?.cancel()
-
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + desiredInterval, repeating: desiredInterval)
-        timer.setEventHandler { [weak self] in
-            self?.verifyChanges()
-        }
-        self.timer = timer
-        timerInterval = desiredInterval
-        timer.resume()
-    }
-
-    private func makeDirectorySource(for directoryURL: URL) -> DispatchSourceFileSystemObject? {
-        let descriptor = open(directoryURL.path, O_EVTONLY)
-        guard descriptor >= 0 else {
-            return nil
-        }
-
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: descriptor,
-            eventMask: [.write, .rename, .delete, .attrib, .extend, .revoke],
-            queue: queue
-        )
-
-        source.setEventHandler { [weak self] in
-            guard let self else {
-                return
-            }
-
-            let events = source.data
-            self.handleDirectorySourceEvent(events)
-            self.scheduleVerification()
-        }
-
-        source.setCancelHandler { [descriptor] in
-            close(descriptor)
-        }
-
-        return source
-    }
-
-    private func cancelAllDirectorySources() {
-        for source in directorySources.values {
-            source.cancel()
-        }
-
-        directorySources.removeAll()
-        usesEventSource = false
-    }
-
-    private func handleDirectorySourceEvent(_ events: DispatchSource.FileSystemEvent) {
-        resetAdaptiveSafetyPollingToBaselineIfNeeded()
-        hasPendingFileSystemSignal = true
-        unsignaledVerificationSkipCycles = 0
-
-        let topologyChangeEvents: DispatchSource.FileSystemEvent = [.rename, .delete, .revoke, .write]
-        if !events.intersection(topologyChangeEvents).isEmpty {
-            needsDirectorySourceResync = needsDirectorySourceResync || includesSubfolders
-        }
-    }
-
-    private func resolvedRecursiveEventSourceSafetyPollingInterval() -> DispatchTimeInterval {
-        scaledInterval(recursiveEventSourceSafetyPollingInterval, multiplier: adaptiveSafetyPollingMultiplier)
-    }
-
-    private func adaptRecursiveEventSourceSafetyPollingIfNeeded(
-        changedEventCount: Int,
-        didResynchronizeDirectories: Bool
-    ) {
-        guard usesEventSource, includesSubfolders else {
-            adaptiveSafetyPollingMultiplier = 1
-            adaptiveSafetyPollingIdleCycles = 0
-            return
-        }
-
-        guard changedEventCount == 0, !didResynchronizeDirectories else {
-            resetAdaptiveSafetyPollingToBaselineIfNeeded()
-            return
-        }
-
-        adaptiveSafetyPollingIdleCycles += 1
-        guard adaptiveSafetyPollingIdleCycles >= Self.adaptiveSafetyPollingIdleCyclesPerStep else {
-            return
-        }
-
-        adaptiveSafetyPollingIdleCycles = 0
-        guard adaptiveSafetyPollingMultiplier < Self.adaptiveSafetyPollingMaximumMultiplier else {
-            return
-        }
-
-        adaptiveSafetyPollingMultiplier += 1
-        reconfigureTimerIfNeeded()
-    }
-
-    private func resetAdaptiveSafetyPollingToBaselineIfNeeded() {
-        adaptiveSafetyPollingIdleCycles = 0
-        guard adaptiveSafetyPollingMultiplier != 1 else {
-            return
-        }
-
-        adaptiveSafetyPollingMultiplier = 1
-        reconfigureTimerIfNeeded()
-    }
-
-    private func shouldSkipIdleVerificationCycle() -> Bool {
-        guard usesEventSource,
-              includesSubfolders,
-              !needsDirectorySourceResync,
-              !hasPendingFileSystemSignal else {
-            unsignaledVerificationSkipCycles = 0
-            return false
-        }
-
-        guard unsignaledVerificationSkipCycles < Self.adaptiveSafetyPollingMaximumUnsignaledSkips else {
-            unsignaledVerificationSkipCycles = 0
-            return false
-        }
-
-        unsignaledVerificationSkipCycles += 1
-        return true
-    }
-
-    private func scaledInterval(_ interval: DispatchTimeInterval, multiplier: Int) -> DispatchTimeInterval {
-        guard multiplier > 1 else {
-            return interval
-        }
-
-        switch interval {
-        case let .seconds(value):
-            return .seconds(value * multiplier)
-        case let .milliseconds(value):
-            return .milliseconds(value * multiplier)
-        case let .microseconds(value):
-            return .microseconds(value * multiplier)
-        case let .nanoseconds(value):
-            return .nanoseconds(value * multiplier)
-        case .never:
-            return .never
-        @unknown default:
-            return interval
-        }
-    }
-
-    private func enumerateWatchedDirectories(
-        folderURL: URL,
-        includeSubfolders: Bool,
-        exclusionMatcher: FolderWatchExclusionMatcher
-    ) throws -> [URL] {
-        guard folderURL.isFileURL else {
-            throw ReaderError.invalidFileURL
-        }
-
-        let normalizedFolderURL = ReaderFileRouting.normalizedFileURL(folderURL)
-        guard includeSubfolders else {
-            return [normalizedFolderURL]
-        }
-
-        var result: [URL] = [normalizedFolderURL]
-        let fileManager = FileManager.default
-        let rootFolderPathWithSlash = exclusionMatcher.normalizedRootPathWithSlash
-
-        guard let enumerator = fileManager.enumerator(
-            at: normalizedFolderURL,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [],
-            errorHandler: { _, _ in true }
-        ) else {
-            return result
-        }
-
-        for case let directoryURL as URL in enumerator {
-            let normalizedDirectoryURL = ReaderFileRouting.normalizedFileURL(directoryURL)
-            if FolderSnapshotDiffer.shouldSkipEntryBeyondIncludeSubfolderDepth(
-                normalizedDirectoryURL,
-                rootFolderPathWithSlash: rootFolderPathWithSlash,
-                enumerator: enumerator
-               ) {
-                continue
-            }
-
-            if FolderSnapshotDiffer.shouldSkipDescendants(
-                forNormalizedURL: normalizedDirectoryURL,
-                exclusionMatcher: exclusionMatcher,
-                enumerator: enumerator
-            ) {
-                continue
-            }
-
-            if (try? normalizedDirectoryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
-                guard !exclusionMatcher.excludesNormalizedDirectoryPath(normalizedDirectoryURL.path) else {
-                    continue
-                }
-                result.append(normalizedDirectoryURL)
-            }
-        }
-
-        return result
     }
 
     private func reportFailure(stage: FolderChangeWatcherFailure.Stage, folderURL: URL, error: any Error) {

--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -64,7 +64,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         var isFinished: Bool { completed == total }
     }
 
-    private static let queueKey = DispatchSpecificKey<UInt8>()
+    private static let queueKey = DispatchSpecificKey<ObjectIdentifier>()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
         category: "FolderChangeWatcher"
@@ -118,7 +118,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         self.verificationDelay = verificationDelay
         self.makeEventSource = makeEventSource
         self.onFailure = onFailure
-        queue.setSpecific(key: Self.queueKey, value: 1)
+        queue.setSpecific(key: Self.queueKey, value: ObjectIdentifier(self))
     }
 
     deinit {
@@ -196,7 +196,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.startupSequence &+= 1
         }
 
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             stopWork()
         } else {
             queue.sync(execute: stopWork)
@@ -269,7 +269,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     func cachedMarkdownFileURLs() -> [URL]? {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             guard didCompleteStartup else { return nil }
             return lastSnapshot.keys.sorted(by: { $0.path < $1.path })
         }
@@ -280,7 +280,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     var didCompleteStartupForTesting: Bool {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return didCompleteStartup
         }
 
@@ -288,7 +288,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     var scanProgressStream: AsyncStream<ScanProgress> {
-        if DispatchQueue.getSpecific(key: Self.queueKey) != nil {
+        if DispatchQueue.getSpecific(key: Self.queueKey) == ObjectIdentifier(self) {
             return _scanProgressStream ?? emptyFinishedStream()
         }
         return queue.sync { _scanProgressStream ?? emptyFinishedStream() }

--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -80,6 +80,8 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     private let onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)?
     private var eventSource: (any FolderEventSource)?
     private var pendingWorkItem: DispatchWorkItem?
+    private var pendingChangedDirectoryURLs: Set<URL>?
+    private var pendingNeedsFullScan = false
 
     private var watchedFolderURL: URL?
     private var includesSubfolders = false
@@ -174,6 +176,8 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         let stopWork = {
             self.pendingWorkItem?.cancel()
             self.pendingWorkItem = nil
+            self.pendingChangedDirectoryURLs = nil
+            self.pendingNeedsFullScan = false
 
             self.eventSource?.stop()
             self.eventSource = nil
@@ -342,13 +346,29 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     private func scheduleVerification(changedDirectoryURLs: Set<URL>?) {
+        // Accumulate changed directories while a work item is pending.
+        // nil means "full scan needed" — once set, it overrides any targeted set.
+        if changedDirectoryURLs == nil {
+            pendingNeedsFullScan = true
+        } else if !pendingNeedsFullScan, let dirs = changedDirectoryURLs {
+            if pendingChangedDirectoryURLs != nil {
+                pendingChangedDirectoryURLs?.formUnion(dirs)
+            } else {
+                pendingChangedDirectoryURLs = dirs
+            }
+        }
+
         guard pendingWorkItem == nil else {
             return
         }
 
         let workItem = DispatchWorkItem { [weak self] in
-            self?.pendingWorkItem = nil
-            self?.verifyChanges(changedDirectoryURLs: changedDirectoryURLs)
+            guard let self else { return }
+            self.pendingWorkItem = nil
+            let resolvedURLs: Set<URL>? = self.pendingNeedsFullScan ? nil : self.pendingChangedDirectoryURLs
+            self.pendingChangedDirectoryURLs = nil
+            self.pendingNeedsFullScan = false
+            self.verifyChanges(changedDirectoryURLs: resolvedURLs)
         }
         pendingWorkItem = workItem
         queue.asyncAfter(deadline: .now() + verificationDelay, execute: workItem)

--- a/minimark/Services/FolderEventSource.swift
+++ b/minimark/Services/FolderEventSource.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+protocol FolderEventSource: AnyObject, Sendable {
+    var recommendedSafetyPollingInterval: DispatchTimeInterval { get }
+
+    func start(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher,
+        queue: DispatchQueue,
+        onEvent: @escaping @Sendable (_ changedDirectoryURLs: Set<URL>?) -> Void
+    )
+
+    func stop()
+}
+
+enum FolderEventSourceFactory {
+    static func makeEventSource(includeSubfolders: Bool) -> any FolderEventSource {
+        if includeSubfolders {
+            return FSEventStreamFolderEventSource()
+        } else {
+            return DispatchSourceFolderEventSource()
+        }
+    }
+}

--- a/minimark/Services/FolderEventSource.swift
+++ b/minimark/Services/FolderEventSource.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 protocol FolderEventSource: AnyObject, Sendable {
-    var recommendedSafetyPollingInterval: DispatchTimeInterval { get }
-
     func start(
         folderURL: URL,
         includeSubfolders: Bool,

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -116,6 +116,13 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
                 continue
             }
 
+            // If the directory was deleted, treat it as empty (files already
+            // removed from snapshot above). contentsOfDirectory throws for
+            // missing directories.
+            guard FileManager.default.fileExists(atPath: normalizedDirectoryURL.path) else {
+                continue
+            }
+
             let freshURLs = try enumerateMarkdownFilesInSingleDirectory(
                 directoryURL: normalizedDirectoryURL,
                 exclusionMatcher: exclusionMatcher

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -99,21 +99,21 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
     ) throws -> [URL: FolderFileSnapshot] {
         var snapshot = previousSnapshot
 
+        let normalizedChangedDirectories = Set(
+            changedDirectoryURLs.map { ReaderFileRouting.normalizedFileURL($0).path }
+        )
+
+        // Single pass: remove files whose parent directory is in the changed set
+        snapshot = snapshot.filter { url, _ in
+            let parentPath = ReaderFileRouting.normalizedFileURL(url.deletingLastPathComponent()).path
+            return !normalizedChangedDirectories.contains(parentPath)
+        }
+
         for directoryURL in changedDirectoryURLs {
             let normalizedDirectoryURL = ReaderFileRouting.normalizedFileURL(directoryURL)
 
             guard !exclusionMatcher.excludesDirectory(normalizedDirectoryURL) else {
                 continue
-            }
-
-            let directoryPath = normalizedDirectoryURL.path
-            let directoryPathWithSlash = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
-
-            for url in snapshot.keys {
-                let parentPath = url.deletingLastPathComponent().path
-                if parentPath == directoryPath || parentPath + "/" == directoryPathWithSlash {
-                    snapshot.removeValue(forKey: url)
-                }
             }
 
             let freshURLs = try enumerateMarkdownFilesInSingleDirectory(

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -107,7 +107,6 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
             changedDirectoryURLs.map { ReaderFileRouting.normalizedFileURL($0).path }
         )
 
-        // Single pass: remove files whose parent directory is in the changed set
         snapshot = snapshot.filter { url, _ in
             let parentPath = ReaderFileRouting.normalizedFileURL(url.deletingLastPathComponent()).path
             return !normalizedChangedDirectories.contains(parentPath)
@@ -132,17 +131,17 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
                 continue
             }
 
-            // If the directory was deleted, treat it as empty (files already
-            // removed from snapshot above). contentsOfDirectory throws for
-            // missing directories.
-            guard FileManager.default.fileExists(atPath: normalizedDirectoryURL.path) else {
+            let freshURLs: [URL]
+            do {
+                freshURLs = try enumerateMarkdownFilesInSingleDirectory(
+                    directoryURL: normalizedDirectoryURL,
+                    exclusionMatcher: exclusionMatcher
+                )
+            } catch let error as NSError where error.domain == NSCocoaErrorDomain &&
+                (error.code == NSFileReadNoSuchFileError || error.code == NSFileNoSuchFileError) {
+                // Directory was deleted — treat as empty (files already removed above)
                 continue
             }
-
-            let freshURLs = try enumerateMarkdownFilesInSingleDirectory(
-                directoryURL: normalizedDirectoryURL,
-                exclusionMatcher: exclusionMatcher
-            )
 
             for url in freshURLs {
                 let metadata = FolderFileMetadata(url: url)

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -103,13 +103,19 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
 
         var snapshot = previousSnapshot
 
-        let normalizedChangedDirectories = Set(
-            changedDirectoryURLs.map { ReaderFileRouting.normalizedFileURL($0).path }
-        )
+        let normalizedChangedDirectoryPathsWithSlash = changedDirectoryURLs.map {
+            let path = ReaderFileRouting.normalizedFileURL($0).path
+            return path.hasSuffix("/") ? path : path + "/"
+        }
 
         snapshot = snapshot.filter { url, _ in
-            let parentPath = ReaderFileRouting.normalizedFileURL(url.deletingLastPathComponent()).path
-            return !normalizedChangedDirectories.contains(parentPath)
+            let filePath = url.path
+            for dirPath in normalizedChangedDirectoryPathsWithSlash {
+                if filePath.hasPrefix(dirPath) {
+                    return false
+                }
+            }
+            return true
         }
 
         let rootPathWithSlash = exclusionMatcher.normalizedRootPathWithSlash

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -113,8 +113,20 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
             return !normalizedChangedDirectories.contains(parentPath)
         }
 
+        let rootPathWithSlash = exclusionMatcher.normalizedRootPathWithSlash
+
         for directoryURL in changedDirectoryURLs {
             let normalizedDirectoryURL = ReaderFileRouting.normalizedFileURL(directoryURL)
+
+            // Skip directories beyond the configured depth limit
+            let depth = Self.relativePathDepth(
+                forPath: normalizedDirectoryURL.path,
+                relativeToPathWithSlash: rootPathWithSlash,
+                isDirectory: true
+            )
+            guard depth <= ReaderFolderWatchPerformancePolicy.maximumIncludedSubfolderDepth else {
+                continue
+            }
 
             guard !exclusionMatcher.excludesDirectory(normalizedDirectoryURL) else {
                 continue

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -103,19 +103,16 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
 
         var snapshot = previousSnapshot
 
-        let normalizedChangedDirectoryPathsWithSlash = changedDirectoryURLs.map {
-            let path = ReaderFileRouting.normalizedFileURL($0).path
-            return path.hasSuffix("/") ? path : path + "/"
-        }
+        let normalizedChangedDirectoryPaths = Set(
+            changedDirectoryURLs.map { ReaderFileRouting.normalizedFileURL($0).path }
+        )
 
+        // Remove files whose immediate parent is a changed directory.
+        // Deeper descendants are handled by the per-directory enumeration
+        // below (deleted directories produce an empty result via catch).
         snapshot = snapshot.filter { url, _ in
-            let filePath = url.path
-            for dirPath in normalizedChangedDirectoryPathsWithSlash {
-                if filePath.hasPrefix(dirPath) {
-                    return false
-                }
-            }
-            return true
+            let parentPath = url.deletingLastPathComponent().path
+            return !normalizedChangedDirectoryPaths.contains(parentPath)
         }
 
         let rootPathWithSlash = exclusionMatcher.normalizedRootPathWithSlash

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -97,6 +97,10 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
         previousSnapshot: [URL: FolderFileSnapshot],
         changedDirectoryURLs: Set<URL>
     ) throws -> [URL: FolderFileSnapshot] {
+        guard folderURL.isFileURL else {
+            throw ReaderError.invalidFileURL
+        }
+
         var snapshot = previousSnapshot
 
         let normalizedChangedDirectories = Set(

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -15,6 +15,14 @@ protocol FolderSnapshotDiffing: Sendable {
         previousSnapshot: [URL: FolderFileSnapshot]
     ) throws -> [URL: FolderFileSnapshot]
 
+    func buildTargetedIncrementalSnapshot(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher,
+        previousSnapshot: [URL: FolderFileSnapshot],
+        changedDirectoryURLs: Set<URL>
+    ) throws -> [URL: FolderFileSnapshot]
+
     func diff(
         current: [URL: FolderFileSnapshot],
         previous: [URL: FolderFileSnapshot]
@@ -77,6 +85,51 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
             }
 
             snapshot[url] = FolderFileSnapshot(url: url, metadata: metadata)
+        }
+
+        return snapshot
+    }
+
+    func buildTargetedIncrementalSnapshot(
+        folderURL: URL,
+        includeSubfolders: Bool,
+        exclusionMatcher: FolderWatchExclusionMatcher,
+        previousSnapshot: [URL: FolderFileSnapshot],
+        changedDirectoryURLs: Set<URL>
+    ) throws -> [URL: FolderFileSnapshot] {
+        var snapshot = previousSnapshot
+
+        for directoryURL in changedDirectoryURLs {
+            let normalizedDirectoryURL = ReaderFileRouting.normalizedFileURL(directoryURL)
+
+            guard !exclusionMatcher.excludesDirectory(normalizedDirectoryURL) else {
+                continue
+            }
+
+            let directoryPath = normalizedDirectoryURL.path
+            let directoryPathWithSlash = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
+
+            for url in snapshot.keys {
+                let parentPath = url.deletingLastPathComponent().path
+                if parentPath == directoryPath || parentPath + "/" == directoryPathWithSlash {
+                    snapshot.removeValue(forKey: url)
+                }
+            }
+
+            let freshURLs = try enumerateMarkdownFilesInSingleDirectory(
+                directoryURL: normalizedDirectoryURL,
+                exclusionMatcher: exclusionMatcher
+            )
+
+            for url in freshURLs {
+                let metadata = FolderFileMetadata(url: url)
+                if let previous = previousSnapshot[url], previous.matches(metadata: metadata) {
+                    snapshot[url] = previous
+                    continue
+                }
+
+                snapshot[url] = FolderFileSnapshot(url: url, metadata: metadata)
+            }
         }
 
         return snapshot
@@ -186,6 +239,22 @@ struct FolderSnapshotDiffer: FolderSnapshotDiffing {
                 .compactMap(regularMarkdownFileURL(fromNormalized:))
                 .filter { !exclusionMatcher.excludesNormalizedFilePath($0.path) }
         }
+    }
+
+    private func enumerateMarkdownFilesInSingleDirectory(
+        directoryURL: URL,
+        exclusionMatcher: FolderWatchExclusionMatcher
+    ) throws -> [URL] {
+        let fileManager = FileManager.default
+        let urls = try fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: []
+        )
+        return urls
+            .map(ReaderFileRouting.normalizedFileURL)
+            .compactMap(regularMarkdownFileURL(fromNormalized:))
+            .filter { !exclusionMatcher.excludesNormalizedFilePath($0.path) }
     }
 
     private func regularMarkdownFileURL(fromNormalized normalizedFileURL: URL) -> URL? {

--- a/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
+++ b/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
@@ -739,6 +739,63 @@ struct ReaderSettingsAndModelsTests {
         #expect(request.content.body == "This test was scheduled by MarkdownObserver. Switch away from the app before it fires to verify background delivery.")
     }
 
+    @Test func readerSystemNotifierPostsAddedNotificationWithCorrectContent() throws {
+        let notificationCenter = TestUserNotificationCenter()
+        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
+        let fileURL = watchedFolderURL.appendingPathComponent("new-file.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .added,
+            watchedFolderURL: watchedFolderURL
+        )
+
+        let request = try #require(notificationCenter.addedRequests.first)
+        #expect(request.content.title == "🟢 Created")
+        #expect(request.content.subtitle == "new-file.md")
+        #expect(request.content.userInfo["filePath"] as? String == fileURL.path)
+        #expect(request.content.userInfo["watchedFolderPath"] as? String == watchedFolderURL.path)
+    }
+
+    @Test func readerSystemNotifierPostsModifiedNotificationWithCorrectContent() throws {
+        let notificationCenter = TestUserNotificationCenter()
+        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
+        let fileURL = watchedFolderURL.appendingPathComponent("edited.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .modified,
+            watchedFolderURL: watchedFolderURL
+        )
+
+        let request = try #require(notificationCenter.addedRequests.first)
+        #expect(request.content.title == "🟡 Modified")
+        #expect(request.content.subtitle == "edited.md")
+        #expect(request.content.userInfo["filePath"] as? String == fileURL.path)
+        #expect(request.content.userInfo["watchedFolderPath"] as? String == watchedFolderURL.path)
+    }
+
+    @Test func readerSystemNotifierPostsDeletedNotificationWithCorrectContent() throws {
+        let notificationCenter = TestUserNotificationCenter()
+        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
+        let fileURL = watchedFolderURL.appendingPathComponent("removed.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .deleted,
+            watchedFolderURL: watchedFolderURL
+        )
+
+        let request = try #require(notificationCenter.addedRequests.first)
+        #expect(request.content.title == "🔴 Deleted")
+        #expect(request.content.subtitle == "removed.md")
+        #expect(request.content.userInfo["filePath"] as? String == fileURL.path)
+        #expect(request.content.userInfo["watchedFolderPath"] as? String == watchedFolderURL.path)
+    }
+
     @Test @MainActor func readerSettingsStoreDecodesLegacySidebarModeAsSidebarLeftAndDefaultsAppAppearance() {
         let storage = TestSettingsKeyValueStorage()
         let storageKey = "reader.settings.legacy-mode.tests"

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -1037,6 +1037,71 @@ struct FileRoutingAndWatcherTests {
         #expect(changes.first?.fileURL == normalizedDest)
     }
 
+    @Test func folderSnapshotDifferTargetedSnapshotRejectsNonFileURL() {
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: URL(fileURLWithPath: "/tmp"), excludedSubdirectoryURLs: []
+        )
+
+        #expect(throws: ReaderError.self) {
+            _ = try differ.buildTargetedIncrementalSnapshot(
+                folderURL: URL(string: "https://example.com")!,
+                includeSubfolders: true,
+                exclusionMatcher: exclusionMatcher,
+                previousSnapshot: [:],
+                changedDirectoryURLs: []
+            )
+        }
+    }
+
+    @Test func folderSnapshotDifferTargetedSnapshotEnforcesDepthLimit() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        // Create a directory structure 6 levels deep (exceeds the 5-level limit)
+        var deepDir = directoryURL
+        for level in 1...6 {
+            deepDir = deepDir.appendingPathComponent("level\(level)", isDirectory: true)
+        }
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+
+        // Also create a directory at the limit (depth 5)
+        var atLimitDir = directoryURL
+        for level in 1...5 {
+            atLimitDir = atLimitDir.appendingPathComponent("ok\(level)", isDirectory: true)
+        }
+        try FileManager.default.createDirectory(at: atLimitDir, withIntermediateDirectories: true)
+
+        let deepFileURL = deepDir.appendingPathComponent("too-deep.md")
+        let atLimitFileURL = atLimitDir.appendingPathComponent("at-limit.md")
+        try "# Too deep".write(to: deepFileURL, atomically: false, encoding: .utf8)
+        try "# At limit".write(to: atLimitFileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: [:],
+            changedDirectoryURLs: Set([
+                ReaderFileRouting.normalizedFileURL(deepDir),
+                ReaderFileRouting.normalizedFileURL(atLimitDir)
+            ])
+        )
+
+        let normalizedDeepURL = ReaderFileRouting.normalizedFileURL(deepFileURL)
+        let normalizedAtLimitURL = ReaderFileRouting.normalizedFileURL(atLimitFileURL)
+
+        // File beyond depth limit should be excluded
+        #expect(targetedSnapshot[normalizedDeepURL] == nil)
+        // File at the limit should be included
+        #expect(targetedSnapshot[normalizedAtLimitURL] != nil)
+    }
+
     @Test func readerFileActionServiceDeduplicatesApplicationsWithSameBundleIdentifier() throws {
         let temporaryDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("reader-file-action-service-tests-\(UUID().uuidString)", isDirectory: true)

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -591,9 +591,15 @@ struct FileRoutingAndWatcherTests {
 
         try "# Before".write(to: deepFileURL, atomically: false, encoding: .utf8)
 
-        let watcher = makeFolderChangeWatcher(
-            fallbackPollingInterval: .seconds(5),
-            maximumDirectoryEventSourceCount: 2
+        let watcher = FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: .seconds(5),
+                    maximumDirectoryEventSourceCount: 2
+                )
+            }
         )
         var receivedEvents: [ReaderFolderWatchChangeEvent] = []
 
@@ -602,8 +608,9 @@ struct FileRoutingAndWatcherTests {
         }
         defer { watcher.stopWatching() }
 
-        #expect(!watcher.isUsingEventSourcesForTesting)
-        #expect(watcher.activeDirectorySourceCountForTesting == 0)
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            watcher.didCompleteStartupForTesting
+        })
 
         try "# After".write(to: deepFileURL, atomically: false, encoding: .utf8)
 
@@ -625,9 +632,15 @@ struct FileRoutingAndWatcherTests {
 
         try "# Before".write(to: trackedFileURL, atomically: false, encoding: .utf8)
 
-        let watcher = makeFolderChangeWatcher(
-            fallbackPollingInterval: .seconds(5),
-            maximumDirectoryEventSourceCount: 2
+        let watcher = FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: .seconds(5),
+                    maximumDirectoryEventSourceCount: 2
+                )
+            }
         )
         var receivedEvents: [ReaderFolderWatchChangeEvent] = []
 
@@ -640,59 +653,9 @@ struct FileRoutingAndWatcherTests {
             watcher.didCompleteStartupForTesting
         })
 
-        #expect(watcher.isUsingEventSourcesForTesting)
-        #expect(watcher.isUsingRecursiveEventSourceSafetyPollingIntervalForTesting)
-
         let overLimitDirectoryURL = nestedDirectoryURL.appendingPathComponent("level-1", isDirectory: true)
         try FileManager.default.createDirectory(at: overLimitDirectoryURL, withIntermediateDirectories: true)
 
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            !watcher.isUsingEventSourcesForTesting &&
-            !watcher.isUsingFallbackPollingIntervalForTesting &&
-            !watcher.isUsingRecursiveEventSourceSafetyPollingIntervalForTesting
-        })
-
-        try "# After".write(to: trackedFileURL, atomically: false, encoding: .utf8)
-
-        #expect(await waitUntil(timeout: .seconds(1)) {
-            receivedEvents.contains(where: {
-                $0.fileURL == ReaderFileRouting.normalizedFileURL(trackedFileURL) &&
-                $0.kind == .modified &&
-                $0.previousMarkdown == "# Before"
-            })
-        })
-    }
-
-    @Test @MainActor func recursiveEventSourceSafetyPollingBacksOffWhenIdleAndResetsAfterEvent() async throws {
-        let directoryURL = try makeTemporaryDirectory()
-        let nestedDirectoryURL = directoryURL.appendingPathComponent("docs", isDirectory: true)
-        let trackedFileURL = nestedDirectoryURL.appendingPathComponent("tracked.md")
-        try FileManager.default.createDirectory(at: nestedDirectoryURL, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directoryURL) }
-
-        try "# Before".write(to: trackedFileURL, atomically: false, encoding: .utf8)
-
-        let baseSafetyInterval: DispatchTimeInterval = .milliseconds(60)
-        let watcher = makeFolderChangeWatcher(
-            fallbackPollingInterval: .seconds(5),
-            recursiveEventSourceSafetyPollingInterval: baseSafetyInterval
-        )
-        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
-
-        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
-            receivedEvents.append(contentsOf: events)
-        }
-        defer { watcher.stopWatching() }
-
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            watcher.didCompleteStartupForTesting &&
-            watcher.currentTimerIntervalForTesting == baseSafetyInterval
-        })
-
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            watcher.currentTimerIntervalForTesting == .milliseconds(120)
-        })
-
         try "# After".write(to: trackedFileURL, atomically: false, encoding: .utf8)
 
         #expect(await waitUntil(timeout: .seconds(2)) {
@@ -701,10 +664,6 @@ struct FileRoutingAndWatcherTests {
                 $0.kind == .modified &&
                 $0.previousMarkdown == "# Before"
             })
-        })
-
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            watcher.currentTimerIntervalForTesting == baseSafetyInterval
         })
     }
 
@@ -739,7 +698,15 @@ struct FileRoutingAndWatcherTests {
             try "# Startup Profile \(index)".write(to: fileURL, atomically: false, encoding: .utf8)
         }
 
-        let watcher = makeFolderChangeWatcher(fallbackPollingInterval: .seconds(5))
+        let watcher = FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: .seconds(5)
+                )
+            }
+        )
         let clock = ContinuousClock()
         let start = clock.now
 
@@ -971,31 +938,16 @@ private extension FileRoutingAndWatcherTests {
     }
 
     func makeFolderChangeWatcher(
-        fallbackPollingInterval: DispatchTimeInterval = defaultFallbackPollingInterval,
-        recursiveEventSourceSafetyPollingInterval: DispatchTimeInterval? = nil,
-        maximumDirectoryEventSourceCount: Int? = nil,
         onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)? = nil
     ) -> FolderChangeWatcher {
-        guard let maximumDirectoryEventSourceCount else {
-            return FolderChangeWatcher(
-                pollingInterval: Self.defaultPollingInterval,
-                fallbackPollingInterval: fallbackPollingInterval,
-                recursiveEventSourceSafetyPollingInterval: recursiveEventSourceSafetyPollingInterval ?? .seconds(
-                    ReaderFolderWatchPerformancePolicy.recursiveEventSourceSafetyPollingIntervalSeconds
-                ),
-                verificationDelay: Self.defaultVerificationDelay,
-                onFailure: onFailure
-            )
-        }
-
-        return FolderChangeWatcher(
-            pollingInterval: Self.defaultPollingInterval,
-            fallbackPollingInterval: fallbackPollingInterval,
-            recursiveEventSourceSafetyPollingInterval: recursiveEventSourceSafetyPollingInterval ?? .seconds(
-                ReaderFolderWatchPerformancePolicy.recursiveEventSourceSafetyPollingIntervalSeconds
-            ),
+        FolderChangeWatcher(
             verificationDelay: Self.defaultVerificationDelay,
-            maximumDirectoryEventSourceCount: maximumDirectoryEventSourceCount,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: Self.defaultFallbackPollingInterval
+                )
+            },
             onFailure: onFailure
         )
     }
@@ -1015,7 +967,15 @@ private extension FileRoutingAndWatcherTests {
         let nestedFileURL = nestedDirectoryURL.appendingPathComponent(fileName)
         try "# Before".write(to: nestedFileURL, atomically: false, encoding: .utf8)
 
-        let watcher = makeFolderChangeWatcher(fallbackPollingInterval: .seconds(5))
+        let watcher = FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: .seconds(5)
+                )
+            }
+        )
         var receivedEvents: [ReaderFolderWatchChangeEvent] = []
 
         try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
@@ -1023,13 +983,7 @@ private extension FileRoutingAndWatcherTests {
         }
         defer { watcher.stopWatching() }
 
-        let expectedDirectorySourceCount = subdirectoryComponents.count + 1
-        let watcherReady = await waitUntil(timeout: .seconds(3)) {
-            watcher.activeDirectorySourceCountForTesting >= expectedDirectorySourceCount
-        }
-        #expect(watcherReady)
-
-        #expect(await waitUntil(timeout: .seconds(2)) {
+        #expect(await waitUntil(timeout: .seconds(3)) {
             watcher.didCompleteStartupForTesting
         })
 

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -870,6 +870,173 @@ struct FileRoutingAndWatcherTests {
         #expect(changes.first?.kind == .added)
     }
 
+    @Test func folderSnapshotDifferTargetedSnapshotHandlesMultipleChangedDirectories() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let subdirA = directoryURL.appendingPathComponent("alpha", isDirectory: true)
+        let subdirB = directoryURL.appendingPathComponent("bravo", isDirectory: true)
+        let subdirC = directoryURL.appendingPathComponent("charlie", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: subdirB, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: subdirC, withIntermediateDirectories: true)
+
+        let fileA = subdirA.appendingPathComponent("a.md")
+        let fileB = subdirB.appendingPathComponent("b.md")
+        let fileC = subdirC.appendingPathComponent("c.md")
+        try "# A".write(to: fileA, atomically: false, encoding: .utf8)
+        try "# B".write(to: fileB, atomically: false, encoding: .utf8)
+        try "# C".write(to: fileC, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: [:]
+        )
+
+        try "# A modified".write(to: fileA, atomically: false, encoding: .utf8)
+        try FileManager.default.removeItem(at: fileB)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([
+                ReaderFileRouting.normalizedFileURL(subdirA),
+                ReaderFileRouting.normalizedFileURL(subdirB)
+            ])
+        )
+
+        let normalizedA = ReaderFileRouting.normalizedFileURL(fileA)
+        let normalizedB = ReaderFileRouting.normalizedFileURL(fileB)
+        let normalizedC = ReaderFileRouting.normalizedFileURL(fileC)
+
+        #expect(targetedSnapshot[normalizedA]?.markdown == "# A modified")
+        #expect(targetedSnapshot[normalizedB] == nil)
+        #expect(targetedSnapshot[normalizedC] != nil)
+
+        let changes = differ.diff(current: targetedSnapshot, previous: initialSnapshot)
+        #expect(changes.count == 1)
+        #expect(changes.first?.kind == .modified)
+        #expect(changes.first?.fileURL == normalizedA)
+    }
+
+    @Test func folderSnapshotDifferTargetedSnapshotHandlesDeletedDirectory() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let subdir = directoryURL.appendingPathComponent("ephemeral", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let fileURL = subdir.appendingPathComponent("temp.md")
+        try "# Temporary".write(to: fileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: [:]
+        )
+
+        try FileManager.default.removeItem(at: subdir)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([ReaderFileRouting.normalizedFileURL(subdir)])
+        )
+
+        #expect(targetedSnapshot[ReaderFileRouting.normalizedFileURL(fileURL)] == nil)
+    }
+
+    @Test func folderSnapshotDifferTargetedSnapshotIgnoresNonMarkdownFiles() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let subdir = directoryURL.appendingPathComponent("mixed", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let markdownURL = subdir.appendingPathComponent("notes.md")
+        try "# Notes".write(to: markdownURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: [:]
+        )
+
+        let txtURL = subdir.appendingPathComponent("data.txt")
+        let jsonURL = subdir.appendingPathComponent("config.json")
+        try "plain text".write(to: txtURL, atomically: false, encoding: .utf8)
+        try "{}".write(to: jsonURL, atomically: false, encoding: .utf8)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([ReaderFileRouting.normalizedFileURL(subdir)])
+        )
+
+        #expect(targetedSnapshot.count == 1)
+        #expect(targetedSnapshot[ReaderFileRouting.normalizedFileURL(markdownURL)] != nil)
+    }
+
+    @Test func folderSnapshotDifferTargetedSnapshotDetectsFileMoveAcrossDirectories() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let sourceDir = directoryURL.appendingPathComponent("source", isDirectory: true)
+        let destDir = directoryURL.appendingPathComponent("dest", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+
+        let sourceFileURL = sourceDir.appendingPathComponent("moved.md")
+        try "# Moved".write(to: sourceFileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: [:]
+        )
+
+        let destFileURL = destDir.appendingPathComponent("moved.md")
+        try FileManager.default.moveItem(at: sourceFileURL, to: destFileURL)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([
+                ReaderFileRouting.normalizedFileURL(sourceDir),
+                ReaderFileRouting.normalizedFileURL(destDir)
+            ])
+        )
+
+        let normalizedSource = ReaderFileRouting.normalizedFileURL(sourceFileURL)
+        let normalizedDest = ReaderFileRouting.normalizedFileURL(destFileURL)
+
+        #expect(targetedSnapshot[normalizedSource] == nil)
+        #expect(targetedSnapshot[normalizedDest] != nil)
+        #expect(targetedSnapshot[normalizedDest]?.markdown == "# Moved")
+
+        let changes = differ.diff(current: targetedSnapshot, previous: initialSnapshot)
+        #expect(changes.count == 1)
+        #expect(changes.first?.kind == .added)
+        #expect(changes.first?.fileURL == normalizedDest)
+    }
+
     @Test func readerFileActionServiceDeduplicatesApplicationsWithSameBundleIdentifier() throws {
         let temporaryDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("reader-file-action-service-tests-\(UUID().uuidString)", isDirectory: true)

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -823,6 +823,53 @@ struct FileRoutingAndWatcherTests {
         #expect(targetedSnapshot[normalizedFileURL] == nil)
     }
 
+    @Test func folderSnapshotDifferTargetedSnapshotDetectsCreatedFileInChangedDirectory() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let subdir = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let existingFileURL = subdir.appendingPathComponent("existing.md")
+        try "# Existing".write(to: existingFileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL,
+            excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: [:]
+        )
+
+        let newFileURL = subdir.appendingPathComponent("brand-new.md")
+        try "# Brand New".write(to: newFileURL, atomically: false, encoding: .utf8)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([ReaderFileRouting.normalizedFileURL(subdir)])
+        )
+
+        let normalizedExistingURL = ReaderFileRouting.normalizedFileURL(existingFileURL)
+        let normalizedNewURL = ReaderFileRouting.normalizedFileURL(newFileURL)
+
+        #expect(targetedSnapshot[normalizedExistingURL] != nil)
+        #expect(targetedSnapshot[normalizedNewURL] != nil)
+        #expect(targetedSnapshot[normalizedNewURL]?.markdown == "# Brand New")
+
+        let changes = differ.diff(current: targetedSnapshot, previous: initialSnapshot)
+        #expect(changes.count == 1)
+        #expect(changes.first?.fileURL == normalizedNewURL)
+        #expect(changes.first?.kind == .added)
+    }
+
     @Test func readerFileActionServiceDeduplicatesApplicationsWithSameBundleIdentifier() throws {
         let temporaryDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("reader-file-action-service-tests-\(UUID().uuidString)", isDirectory: true)

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -766,6 +766,96 @@ struct FileRoutingAndWatcherTests {
         }
     }
 
+    @Test func folderSnapshotDifferBuildsTargetedIncrementalSnapshotForChangedDirectoriesOnly() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let unchangedSubdir = directoryURL.appendingPathComponent("unchanged", isDirectory: true)
+        let changedSubdir = directoryURL.appendingPathComponent("changed", isDirectory: true)
+        try FileManager.default.createDirectory(at: unchangedSubdir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: changedSubdir, withIntermediateDirectories: true)
+
+        let unchangedFileURL = unchangedSubdir.appendingPathComponent("stable.md")
+        let changedFileURL = changedSubdir.appendingPathComponent("modified.md")
+        try "# Unchanged".write(to: unchangedFileURL, atomically: false, encoding: .utf8)
+        try "# Before".write(to: changedFileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL,
+            excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: [:]
+        )
+
+        try "# After".write(to: changedFileURL, atomically: false, encoding: .utf8)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([ReaderFileRouting.normalizedFileURL(changedSubdir)])
+        )
+
+        let normalizedUnchangedURL = ReaderFileRouting.normalizedFileURL(unchangedFileURL)
+        let normalizedChangedURL = ReaderFileRouting.normalizedFileURL(changedFileURL)
+
+        #expect(targetedSnapshot[normalizedUnchangedURL] != nil)
+        #expect(targetedSnapshot[normalizedChangedURL] != nil)
+        #expect(targetedSnapshot[normalizedUnchangedURL]?.markdown == initialSnapshot[normalizedUnchangedURL]?.markdown)
+        #expect(targetedSnapshot[normalizedChangedURL]?.markdown == "# After")
+
+        let changes = differ.diff(current: targetedSnapshot, previous: initialSnapshot)
+        #expect(changes.count == 1)
+        #expect(changes.first?.fileURL == normalizedChangedURL)
+        #expect(changes.first?.kind == .modified)
+    }
+
+    @Test func folderSnapshotDifferTargetedSnapshotDetectsDeletedFileInChangedDirectory() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let subdir = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let fileURL = subdir.appendingPathComponent("doomed.md")
+        try "# Doomed".write(to: fileURL, atomically: false, encoding: .utf8)
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL,
+            excludedSubdirectoryURLs: []
+        )
+
+        let initialSnapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: [:]
+        )
+
+        let normalizedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
+        #expect(initialSnapshot[normalizedFileURL] != nil)
+
+        try FileManager.default.removeItem(at: fileURL)
+
+        let targetedSnapshot = try differ.buildTargetedIncrementalSnapshot(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher,
+            previousSnapshot: initialSnapshot,
+            changedDirectoryURLs: Set([ReaderFileRouting.normalizedFileURL(subdir)])
+        )
+
+        #expect(targetedSnapshot[normalizedFileURL] == nil)
+    }
+
     @Test func readerFileActionServiceDeduplicatesApplicationsWithSameBundleIdentifier() throws {
         let temporaryDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("reader-file-action-service-tests-\(UUID().uuidString)", isDirectory: true)

--- a/minimarkTests/Infrastructure/FolderChangeWatcherScanProgressTests.swift
+++ b/minimarkTests/Infrastructure/FolderChangeWatcherScanProgressTests.swift
@@ -125,9 +125,13 @@ struct FolderChangeWatcherScanProgressTests {
 
     private func makeFolderChangeWatcher() -> FolderChangeWatcher {
         FolderChangeWatcher(
-            pollingInterval: Self.defaultPollingInterval,
-            fallbackPollingInterval: Self.defaultFallbackPollingInterval,
-            verificationDelay: Self.defaultVerificationDelay
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: Self.defaultPollingInterval,
+                    fallbackPollingInterval: Self.defaultFallbackPollingInterval
+                )
+            }
         )
     }
 }

--- a/minimarkTests/Infrastructure/FolderEventSourceTests.swift
+++ b/minimarkTests/Infrastructure/FolderEventSourceTests.swift
@@ -342,6 +342,122 @@ struct FolderEventSourceTests {
         })
     }
 
+    // MARK: - Accumulated directory URL merging
+
+    @Test @MainActor func fsEventStreamAccumulatesChangedDirectoriesAcrossRapidEvents() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let subdirA = directoryURL.appendingPathComponent("alpha", isDirectory: true)
+        let subdirB = directoryURL.appendingPathComponent("bravo", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: subdirB, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileA = subdirA.appendingPathComponent("a.md")
+        let fileB = subdirB.appendingPathComponent("b.md")
+        try "# A".write(to: fileA, atomically: true, encoding: .utf8)
+        try "# B".write(to: fileB, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        // Write to both subdirectories in rapid succession — both should be detected
+        // even though the verification delay may coalesce them
+        try "# A modified".write(to: fileA, atomically: true, encoding: .utf8)
+        try "# B modified".write(to: fileB, atomically: true, encoding: .utf8)
+
+        let normalizedA = ReaderFileRouting.normalizedFileURL(fileA)
+        let normalizedB = ReaderFileRouting.normalizedFileURL(fileB)
+
+        #expect(await waitUntil(timeout: .seconds(5)) {
+            receivedEvents.contains(where: { $0.fileURL == normalizedA && $0.kind == .modified }) &&
+            receivedEvents.contains(where: { $0.fileURL == normalizedB && $0.kind == .modified })
+        })
+    }
+
+    // MARK: - New subdirectory detection (directory resync)
+
+    @Test @MainActor func dispatchSourceDetectsChangesInNewlyCreatedSubdirectory() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let existingFileURL = directoryURL.appendingPathComponent("existing.md")
+        try "# Existing".write(to: existingFileURL, atomically: true, encoding: .utf8)
+
+        let watcher = FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                DispatchSourceFolderEventSource(
+                    pollingInterval: .milliseconds(50),
+                    fallbackPollingInterval: .milliseconds(80),
+                    maximumDirectoryEventSourceCount: 128
+                )
+            }
+        )
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        // Create a new subdirectory and add a file — should be detected after resync
+        let newSubdir = directoryURL.appendingPathComponent("new-subdir", isDirectory: true)
+        try FileManager.default.createDirectory(at: newSubdir, withIntermediateDirectories: true)
+        let newFileURL = newSubdir.appendingPathComponent("new.md")
+        try "# New".write(to: newFileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(newFileURL) &&
+                $0.kind == .added
+            })
+        })
+    }
+
+    // MARK: - FSEvents non-recursive guard
+
+    @Test func fsEventStreamSourceRejectsNonRecursiveWatch() {
+        let source = FSEventStreamFolderEventSource(latency: 0.1, safetyPollingInterval: .seconds(30))
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: URL(fileURLWithPath: "/tmp"), excludedSubdirectoryURLs: []
+        )
+        let queue = DispatchQueue(label: "test.fsevents.guard")
+        var eventCount = 0
+
+        source.start(
+            folderURL: URL(fileURLWithPath: "/tmp"),
+            includeSubfolders: false,
+            exclusionMatcher: exclusionMatcher,
+            queue: queue
+        ) { _ in
+            eventCount += 1
+        }
+        defer { source.stop() }
+
+        // Should not have started — no events should be delivered
+        queue.sync {
+            // If the source started, it would have scheduled a safety timer.
+            // Give it a moment then verify no events fired.
+        }
+
+        // The source should not be active (no stream, no timer)
+        // We verify by checking that stop() is safe to call (no crash)
+        source.stop()
+    }
+
     // MARK: - Factory selection
 
     @Test func factorySelectsFSEventsForRecursiveAndDispatchSourceForFlat() {

--- a/minimarkTests/Infrastructure/FolderEventSourceTests.swift
+++ b/minimarkTests/Infrastructure/FolderEventSourceTests.swift
@@ -147,6 +147,201 @@ struct FolderEventSourceTests {
         })
     }
 
+    @Test @MainActor func fsEventStreamDetectsRapidSuccessiveWritesToSameFile() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let subdirURL = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileURL = subdirURL.appendingPathComponent("rapid.md")
+        try "# Version 0".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        for version in 1...5 {
+            try "# Version \(version)".write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+
+        let normalizedURL = ReaderFileRouting.normalizedFileURL(fileURL)
+        #expect(await waitUntil(timeout: .seconds(5)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == normalizedURL && $0.kind == .modified
+            })
+        })
+
+        // Final snapshot should reflect the last write
+        if let cached = watcher.cachedMarkdownFileURLs() {
+            #expect(cached.contains(normalizedURL))
+        }
+    }
+
+    @Test @MainActor func fsEventStreamDetectsDeeplyNestedSubdirectoryChange() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let deepURL = directoryURL
+            .appendingPathComponent("level1", isDirectory: true)
+            .appendingPathComponent("level2", isDirectory: true)
+            .appendingPathComponent("level3", isDirectory: true)
+        try FileManager.default.createDirectory(at: deepURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        let deepFileURL = deepURL.appendingPathComponent("deep.md")
+        try "# Deep".write(to: deepFileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(deepFileURL) &&
+                $0.kind == .added
+            })
+        })
+    }
+
+    @Test @MainActor func fsEventStreamDoesNotEmitEventForEphemeralFile() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let subdirURL = directoryURL.appendingPathComponent("temp", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let stableFileURL = subdirURL.appendingPathComponent("stable.md")
+        try "# Stable".write(to: stableFileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        // Create and immediately delete a file
+        let ephemeralURL = subdirURL.appendingPathComponent("ephemeral.md")
+        try "# Gone".write(to: ephemeralURL, atomically: true, encoding: .utf8)
+        try FileManager.default.removeItem(at: ephemeralURL)
+
+        // Wait for any events to settle
+        try? await Task.sleep(for: .seconds(1))
+
+        let normalizedEphemeral = ReaderFileRouting.normalizedFileURL(ephemeralURL)
+        let hasEphemeralEvent = receivedEvents.contains(where: {
+            $0.fileURL == normalizedEphemeral && $0.kind == .added
+        })
+        // The ephemeral file should NOT appear as added since it doesn't exist at verification time
+        #expect(!hasEphemeralEvent)
+    }
+
+    @Test @MainActor func fsEventStreamDetectsMultipleFilesInDifferentSubdirectories() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let subdirA = directoryURL.appendingPathComponent("alpha", isDirectory: true)
+        let subdirB = directoryURL.appendingPathComponent("bravo", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: subdirB, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        let fileA = subdirA.appendingPathComponent("alpha.md")
+        let fileB = subdirB.appendingPathComponent("bravo.md")
+        try "# Alpha".write(to: fileA, atomically: true, encoding: .utf8)
+        try "# Bravo".write(to: fileB, atomically: true, encoding: .utf8)
+
+        let normalizedA = ReaderFileRouting.normalizedFileURL(fileA)
+        let normalizedB = ReaderFileRouting.normalizedFileURL(fileB)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: { $0.fileURL == normalizedA && $0.kind == .added }) &&
+            receivedEvents.contains(where: { $0.fileURL == normalizedB && $0.kind == .added })
+        })
+    }
+
+    @Test @MainActor func fsEventStreamWatcherHandlesStopAndRestart() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let subdirURL = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileURL = subdirURL.appendingPathComponent("persistent.md")
+        try "# Round 1".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var firstRoundEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            firstRoundEvents.append(contentsOf: events)
+        }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        try "# Round 1 modified".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            firstRoundEvents.contains(where: { $0.kind == .modified })
+        })
+
+        watcher.stopWatching()
+
+        // Modify while stopped — should not be detected
+        try "# Round 2".write(to: fileURL, atomically: true, encoding: .utf8)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        var secondRoundEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            secondRoundEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        // Modify again after restart
+        try "# Round 2 modified".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            secondRoundEvents.contains(where: {
+                $0.kind == .modified &&
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(fileURL)
+            })
+        })
+    }
+
     // MARK: - Factory selection
 
     @Test func factorySelectsFSEventsForRecursiveAndDispatchSourceForFlat() {

--- a/minimarkTests/Infrastructure/FolderEventSourceTests.swift
+++ b/minimarkTests/Infrastructure/FolderEventSourceTests.swift
@@ -1,0 +1,154 @@
+//
+//  FolderEventSourceTests.swift
+//  minimarkTests
+//
+
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct FolderEventSourceTests {
+
+    // MARK: - FSEvents integration
+
+    @Test @MainActor func fsEventStreamDetectsFileCreationInRecursiveWatch() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let docsURL = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: docsURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        let newFileURL = docsURL.appendingPathComponent("new-file.md")
+        try "# New File".write(to: newFileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(newFileURL) &&
+                $0.kind == .added
+            })
+        })
+    }
+
+    @Test @MainActor func fsEventStreamDetectsFileModificationInRecursiveWatch() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let notesURL = directoryURL.appendingPathComponent("notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: notesURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let existingFileURL = notesURL.appendingPathComponent("existing.md")
+        try "# Before".write(to: existingFileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        try "# After".write(to: existingFileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(existingFileURL) &&
+                $0.kind == .modified &&
+                $0.previousMarkdown == "# Before"
+            })
+        })
+    }
+
+    @Test @MainActor func fsEventStreamRespectsExcludedSubdirectories() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let excludedURL = directoryURL.appendingPathComponent("excluded", isDirectory: true)
+        let includedURL = directoryURL.appendingPathComponent("included", isDirectory: true)
+        try FileManager.default.createDirectory(at: excludedURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: includedURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let excludedFileURL = excludedURL.appendingPathComponent("ignored.md")
+        let includedFileURL = includedURL.appendingPathComponent("tracked.md")
+        try "# Before".write(to: excludedFileURL, atomically: true, encoding: .utf8)
+        try "# Before".write(to: includedFileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+        var receivedEvents: [ReaderFolderWatchChangeEvent] = []
+
+        try watcher.startWatching(
+            folderURL: directoryURL,
+            includeSubfolders: true,
+            excludedSubdirectoryURLs: [excludedURL]
+        ) { events in
+            receivedEvents.append(contentsOf: events)
+        }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        try "# After excluded".write(to: excludedFileURL, atomically: true, encoding: .utf8)
+        try "# After included".write(to: includedFileURL, atomically: true, encoding: .utf8)
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            receivedEvents.contains(where: {
+                $0.fileURL == ReaderFileRouting.normalizedFileURL(includedFileURL) &&
+                $0.kind == .modified
+            })
+        })
+
+        #expect(!receivedEvents.contains(where: {
+            $0.fileURL == ReaderFileRouting.normalizedFileURL(excludedFileURL)
+        }))
+    }
+
+    // MARK: - Factory selection
+
+    @Test func factorySelectsFSEventsForRecursiveAndDispatchSourceForFlat() {
+        let recursiveSource = FolderEventSourceFactory.makeEventSource(includeSubfolders: true)
+        #expect(recursiveSource is FSEventStreamFolderEventSource)
+
+        let flatSource = FolderEventSourceFactory.makeEventSource(includeSubfolders: false)
+        #expect(flatSource is DispatchSourceFolderEventSource)
+    }
+}
+
+// MARK: - Helpers
+
+private extension FolderEventSourceTests {
+    nonisolated static let defaultVerificationDelay: DispatchTimeInterval = .milliseconds(20)
+
+    func makeTemporaryDirectory() throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return directoryURL
+    }
+
+    func makeFSEventsWatcher() -> FolderChangeWatcher {
+        FolderChangeWatcher(
+            verificationDelay: Self.defaultVerificationDelay,
+            makeEventSource: { _ in
+                FSEventStreamFolderEventSource(
+                    latency: 0.1,
+                    safetyPollingInterval: .seconds(30)
+                )
+            }
+        )
+    }
+}

--- a/minimarkTests/Infrastructure/FolderEventSourceTests.swift
+++ b/minimarkTests/Infrastructure/FolderEventSourceTests.swift
@@ -117,6 +117,36 @@ struct FolderEventSourceTests {
         }))
     }
 
+    @Test @MainActor func fsEventStreamDetectsFileDeletionInRecursiveWatch() async throws {
+        let directoryURL = try makeTemporaryDirectory()
+        let docsURL = directoryURL.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: docsURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileURL = docsURL.appendingPathComponent("will-be-deleted.md")
+        try "# Delete me".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let watcher = makeFSEventsWatcher()
+
+        try watcher.startWatching(folderURL: directoryURL, includeSubfolders: true) { _ in }
+        defer { watcher.stopWatching() }
+
+        #expect(await waitUntil(timeout: .seconds(3)) {
+            watcher.didCompleteStartupForTesting
+        })
+
+        let normalizedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
+        let cachedBefore = watcher.cachedMarkdownFileURLs() ?? []
+        #expect(cachedBefore.contains(normalizedFileURL))
+
+        try FileManager.default.removeItem(at: fileURL)
+
+        #expect(await waitUntil(timeout: .seconds(5)) {
+            let cached = watcher.cachedMarkdownFileURLs() ?? []
+            return !cached.contains(normalizedFileURL)
+        })
+    }
+
     // MARK: - Factory selection
 
     @Test func factorySelectsFSEventsForRecursiveAndDispatchSourceForFlat() {

--- a/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
+++ b/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
@@ -14,7 +14,7 @@ import Testing
 import UserNotifications
 @testable import minimark
 
-@Suite(.serialized)
+@Suite(.serialized, .enabled(if: ProcessInfo.processInfo.environment["RUN_E2E_NOTIFICATION_TESTS"] != nil))
 struct SystemNotificationEndToEndTests {
 
     @Test func notificationPostedForCreatedFile() async throws {

--- a/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
+++ b/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
@@ -14,7 +14,7 @@ import Testing
 import UserNotifications
 @testable import minimark
 
-@Suite(.serialized, .enabled(if: ProcessInfo.processInfo.environment["RUN_E2E_NOTIFICATION_TESTS"] != nil))
+@Suite(.serialized, .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil, "Skipped in CI — requires notification permissions"))
 struct SystemNotificationEndToEndTests {
 
     @Test func notificationPostedForCreatedFile() async throws {

--- a/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
+++ b/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
@@ -1,0 +1,74 @@
+//
+//  SystemNotificationEndToEndTests.swift
+//  minimarkTests
+//
+//  End-to-end tests that post real macOS notifications through
+//  UNUserNotificationCenter. These tests verify that notification
+//  content is correct for all three change kinds (added, modified, deleted).
+//
+//  NOTE: These tests require notification permissions for the test host app.
+//  Run manually to see the notifications appear on your desktop.
+
+import Foundation
+import Testing
+import UserNotifications
+@testable import minimark
+
+@Suite(.serialized)
+struct SystemNotificationEndToEndTests {
+
+    @Test func notificationPostedForCreatedFile() async throws {
+        let notifier = ReaderSystemNotifier(
+            notificationCenter: UNUserNotificationCenter.current()
+        )
+        notifier.configure()
+
+        let folderURL = URL(fileURLWithPath: "/tmp/e2e-notification-test", isDirectory: true)
+        let fileURL = folderURL.appendingPathComponent("created-file.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .added,
+            watchedFolderURL: folderURL
+        )
+
+        // Allow time for the async authorization + delivery flow
+        try await Task.sleep(for: .seconds(1))
+    }
+
+    @Test func notificationPostedForModifiedFile() async throws {
+        let notifier = ReaderSystemNotifier(
+            notificationCenter: UNUserNotificationCenter.current()
+        )
+        notifier.configure()
+
+        let folderURL = URL(fileURLWithPath: "/tmp/e2e-notification-test", isDirectory: true)
+        let fileURL = folderURL.appendingPathComponent("modified-file.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .modified,
+            watchedFolderURL: folderURL
+        )
+
+        try await Task.sleep(for: .seconds(1))
+    }
+
+    @Test func notificationPostedForDeletedFile() async throws {
+        let notifier = ReaderSystemNotifier(
+            notificationCenter: UNUserNotificationCenter.current()
+        )
+        notifier.configure()
+
+        let folderURL = URL(fileURLWithPath: "/tmp/e2e-notification-test", isDirectory: true)
+        let fileURL = folderURL.appendingPathComponent("deleted-file.md")
+
+        notifier.notifyFileChanged(
+            fileURL,
+            changeKind: .deleted,
+            watchedFolderURL: folderURL
+        )
+
+        try await Task.sleep(for: .seconds(1))
+    }
+}

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -54,6 +54,88 @@ struct ReaderStoreExternalChangeTests {
         ])
     }
 
+    @Test @MainActor func handleObservedFileChangePostsDeletedNotificationWhenFileMissing() throws {
+        let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
+        defer { fixture.cleanup() }
+
+        fixture.store.openFile(at: fixture.primaryFileURL)
+        fixture.delete(fixture.primaryFileURL)
+        fixture.store.handleObservedFileChange()
+
+        #expect(fixture.notifier.fileChangeNotifications == [
+            TestReaderSystemNotifier.FileChangeNotification(
+                fileURL: ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL),
+                changeKind: .deleted,
+                watchedFolderURL: nil
+            )
+        ])
+    }
+
+    @Test @MainActor func folderWatchAutoOpenPostsAddedNotification() throws {
+        let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
+        defer { fixture.cleanup() }
+
+        let folderURL = fixture.temporaryDirectoryURL
+        let options = ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
+        let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
+        fixture.store.setActiveFolderWatchSession(session)
+
+        fixture.store.openFile(at: fixture.primaryFileURL, origin: .folderWatchAutoOpen)
+
+        #expect(fixture.notifier.fileChangeNotifications == [
+            TestReaderSystemNotifier.FileChangeNotification(
+                fileURL: ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL),
+                changeKind: .added,
+                watchedFolderURL: ReaderFileRouting.normalizedFileURL(folderURL)
+            )
+        ])
+    }
+
+    @Test @MainActor func folderWatchAutoOpenPostsModifiedNotificationWhenBaselineProvided() throws {
+        let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
+        defer { fixture.cleanup() }
+
+        let folderURL = fixture.temporaryDirectoryURL
+        let options = ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
+        let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
+        fixture.store.setActiveFolderWatchSession(session)
+
+        fixture.store.openFile(
+            at: fixture.primaryFileURL,
+            origin: .folderWatchAutoOpen,
+            initialDiffBaselineMarkdown: "# Old content"
+        )
+
+        #expect(fixture.notifier.fileChangeNotifications == [
+            TestReaderSystemNotifier.FileChangeNotification(
+                fileURL: ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL),
+                changeKind: .modified,
+                watchedFolderURL: ReaderFileRouting.normalizedFileURL(folderURL)
+            )
+        ])
+    }
+
+    @Test @MainActor func handleObservedFileChangePostsModifiedNotificationWithWatchedFolderURL() throws {
+        let fixture = try ReaderStoreTestFixture(autoRefreshOnExternalChange: false)
+        defer { fixture.cleanup() }
+
+        let folderURL = fixture.temporaryDirectoryURL
+        let options = ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
+        let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
+        fixture.store.setActiveFolderWatchSession(session)
+
+        fixture.store.openFile(at: fixture.primaryFileURL)
+        fixture.store.handleObservedFileChange()
+
+        #expect(fixture.notifier.fileChangeNotifications == [
+            TestReaderSystemNotifier.FileChangeNotification(
+                fileURL: ReaderFileRouting.normalizedFileURL(fixture.primaryFileURL),
+                changeKind: .modified,
+                watchedFolderURL: ReaderFileRouting.normalizedFileURL(folderURL)
+            )
+        ])
+    }
+
     @Test @MainActor func handleObservedFileChangeSkipsSystemNotificationWhenDisabled() throws {
         let fixture = try ReaderStoreTestFixture(
             autoRefreshOnExternalChange: false,

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -281,9 +281,13 @@ struct ReaderSidebarDocumentControllerTests {
             makeFolderWatchController: {
                 ReaderFolderWatchController(
                     folderWatcher: FolderChangeWatcher(
-                        pollingInterval: .milliseconds(50),
-                        fallbackPollingInterval: .milliseconds(80),
-                        verificationDelay: .milliseconds(20)
+                        verificationDelay: .milliseconds(20),
+                        makeEventSource: { _ in
+                            DispatchSourceFolderEventSource(
+                                pollingInterval: .milliseconds(50),
+                                fallbackPollingInterval: .milliseconds(80)
+                            )
+                        }
                     ),
                     settingsStore: settingsStore,
                     securityScope: TestSecurityScopeAccess(),


### PR DESCRIPTION
## Summary

- Extract event detection from `FolderChangeWatcher` into a `FolderEventSource` protocol with two implementations: `DispatchSourceFolderEventSource` (flat/small trees) and `FSEventStreamFolderEventSource` (recursive watches using CoreServices FSEvents API)
- Add targeted snapshot scanning to `FolderSnapshotDiffer` so only FSEvents-reported directories are re-scanned instead of the full tree
- Slim `FolderChangeWatcher` from ~830 lines to a ~200-line orchestrator

Fixes #236

## Motivation

When watching a folder tree with >128 subdirectories, `FolderChangeWatcher` abandoned `DispatchSourceFileSystemObject` (FD limit) and fell back to polling the entire tree every 1 second. This burned ~10% CPU on an M2 Pro with ~1000 subdirectories. FSEvents uses a single kernel-level watcher with near-zero idle CPU.

## Architecture

```
FolderChangeWatcher (orchestrator)
├── FolderEventSource (protocol)
│   ├── DispatchSourceFolderEventSource (flat folders, <128 dirs)
│   └── FSEventStreamFolderEventSource (recursive, any size)
└── FolderSnapshotDiffer (snapshot + targeted scanning)
```

## Test plan

- [ ] All existing watcher tests pass (updated for new constructor)
- [ ] FSEvents integration tests: creation, modification, deletion, exclusion, deep nesting, rapid writes, ephemeral files, multi-directory, stop/restart
- [ ] Targeted snapshot tests: multi-directory batch, deleted directory, non-markdown filtering, cross-directory file moves, file creation
- [ ] Notification tests: all three change kinds (added, modified, deleted) through `ReaderSystemNotifier`
- [ ] E2E notification tests with real `UNUserNotificationCenter`