### PR TITLE
Convert first-use hints to popover bubbles

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -555,19 +555,12 @@ struct ContentView: View {
             }
             .overlay(alignment: .topLeading) {
                 if canNavigateChangedRegions {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ChangeNavigationPill(
-                            currentIndex: currentChangedRegionIndex,
-                            totalCount: readerStore.changedRegions.count,
-                            onNavigate: requestChangedRegionNavigation
-                        )
-
-                        FirstUseHintView(
-                            hint: .changeNavigation,
-                            message: "Use the arrows to step through changes",
-                            settingsStore: settingsStore
-                        )
-                    }
+                    ChangeNavigationPill(
+                        currentIndex: currentChangedRegionIndex,
+                        totalCount: readerStore.changedRegions.count,
+                        onNavigate: requestChangedRegionNavigation
+                    )
+                    .firstUseHint(.changeNavigation, message: "Use the arrows to step through changes", settingsStore: settingsStore)
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
                     .padding(.leading, 8)
                     .environment(\.colorScheme, overlayColorScheme)

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -142,25 +142,13 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
     private var sidebarToolbar: some View {
         HStack(spacing: 6) {
             sidebarGroupSortMenu
-
-            if groupState.sortMode == .manualOrder {
-                FirstUseHintView(
-                    hint: .manualGroupReorder,
-                    message: "Drag groups to reorder",
-                    settingsStore: settingsStore
-                )
-            }
+                .firstUseHint(.manualGroupReorder, message: "Drag groups to reorder", settingsStore: settingsStore, isActive: groupState.sortMode == .manualOrder)
 
             sidebarFileSortMenu
 
             if selectedDocumentIDs.count > 1 {
                 selectionCountBadge
-
-                FirstUseHintView(
-                    hint: .multiSelect,
-                    message: "⌘-click to select multiple files",
-                    settingsStore: settingsStore
-                )
+                    .firstUseHint(.multiSelect, message: "⌘-click to select multiple files", settingsStore: settingsStore)
             }
 
             Spacer(minLength: 0)

--- a/minimark/Views/Support/FirstUseHintView.swift
+++ b/minimark/Views/Support/FirstUseHintView.swift
@@ -1,33 +1,62 @@
 import SwiftUI
 
-struct FirstUseHintView: View {
+struct FirstUseHintModifier: ViewModifier {
     let hint: FirstUseHint
     let message: String
     let settingsStore: ReaderSettingsStore
+    let isActive: Bool
 
-    var body: some View {
-        if !settingsStore.isHintDismissed(hint) {
-            HStack(spacing: 4) {
-                Text(message)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+    @State private var isPresented = false
 
-                Button {
-                    withAnimation {
-                        settingsStore.dismissHint(hint)
+    func body(content: Content) -> some View {
+        content
+            .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+                HStack(spacing: 6) {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        isPresented = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                            .frame(width: 16, height: 16)
+                            .contentShape(Rectangle())
                     }
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .semibold))
-                        .foregroundStyle(.tertiary)
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss hint")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss hint")
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
             }
-            .fixedSize()
-            .transition(.opacity)
-        }
+            .onChange(of: isActive) { _, active in
+                if active && !settingsStore.isHintDismissed(hint) {
+                    isPresented = true
+                }
+            }
+            .onChange(of: isPresented) { _, newValue in
+                if !newValue {
+                    settingsStore.dismissHint(hint)
+                }
+            }
+            .onAppear {
+                if isActive && !settingsStore.isHintDismissed(hint) {
+                    isPresented = true
+                }
+            }
     }
 }
+
+extension View {
+    func firstUseHint(
+        _ hint: FirstUseHint,
+        message: String,
+        settingsStore: ReaderSettingsStore,
+        isActive: Bool = true
+    ) -> some View {
+        modifier(FirstUseHintModifier(hint: hint, message: message, settingsStore: settingsStore, isActive: isActive))
+    }
+}
+


### PR DESCRIPTION
## Summary

Closes #222

- Replace inline `FirstUseHintView` with a `.popover()` ViewModifier (`FirstUseHintModifier`) so hints float over the UI without shifting layout elements
- Attach `.firstUseHint()` modifier to anchor controls: group sort menu (sidebar), selection count badge (sidebar), and change navigation pill (content area)
- Add `isActive` parameter so the manual-reorder hint only triggers when manual sort mode is selected
- Hint persistence (UserDefaults, `dismissedHints` set) unchanged

## Test plan

- [ ] Build succeeds
- [ ] Existing `dismissedHintsPersistAcrossReload` test passes
- [ ] Manual: select Manual sort → popover appears on group sort menu with "Drag groups to reorder"
- [ ] Manual: Cmd-click multiple files → popover appears on selection badge with "⌘-click to select multiple files"
- [ ] Manual: open a changed file → popover appears on change navigation pill with "Use the arrows to step through changes"
- [ ] Manual: dismiss popover → hint doesn't reappear on next trigger
- [ ] Manual: toolbar layout doesn't shift when popovers appear/disappear