### PR TITLE
Improve change pill navigation

### DIFF
--- a/Config/OpenSourceDefaults.xcconfig
+++ b/Config/OpenSourceDefaults.xcconfig
@@ -9,5 +9,9 @@ UITESTS_BUNDLE_IDENTIFIER = $(APP_BUNDLE_IDENTIFIER).uitests
 CODE_SIGNING_ALLOWED = NO
 CODE_SIGNING_REQUIRED = NO
 
+// Layout tuning — gap (in points) between overlay controls and where
+// change-navigation scrolls to. Increase for more breathing room.
+SCROLL_LANDING_GAP = 36
+
 // Optional local overrides (gitignored), for distribution signing.
 #include? "Signing.local.xcconfig"

--- a/minimark/App/Info.plist
+++ b/minimark/App/Info.plist
@@ -51,6 +51,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
+	<key>ScrollLandingGap</key>
+	<string>$(SCROLL_LANDING_GAP)</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>UTImportedTypeDeclarations</key>

--- a/minimark/App/Resources/markdownobserver-runtime.js
+++ b/minimark/App/Resources/markdownobserver-runtime.js
@@ -1,7 +1,7 @@
 (function () {
   var payload = decodePayload("__MINIMARK_PAYLOAD_BASE64__");
   var runtimeCSSBase64 = "__MINIMARK_CSS_BASE64__";
-  var overlayTopInset = 56;
+  var overlayTopInset = __MINIMARK_OVERLAY_TOP_INSET__;
 
   function setOverlayTopInset(value) {
     var numericValue = Number(value);
@@ -1164,8 +1164,9 @@
     }
 
     var targetRow = markers[targetIndex];
+    var scrolled = scrollToChangedRegion(targetRow, root);
 
-    return scrollToChangedRegion(targetRow, root);
+    return scrolled ? { index: targetIndex, count: markers.length } : null;
   }
 
   window.__minimarkNavigateChangedRegion = navigateChangedRegion;

--- a/minimark/App/Resources/markdownobserver-runtime.js
+++ b/minimark/App/Resources/markdownobserver-runtime.js
@@ -1152,7 +1152,7 @@
 
     var currentTop = Math.max(0, (scrollContainer.scrollTop || 0) - getRootDocumentTop(root));
     var activeIndex = findMarkerIndexByKey(markers, activeNavigatedChangedRegionKey);
-    if (activeIndex < 0) {
+    if (activeIndex < 0 && activeNavigatedChangedRegionKey) {
       activeIndex = findMarkerIndexNearScrollPosition(markers, currentTop);
     }
 

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -64,6 +64,7 @@ struct ContentView: View {
         let onDroppedFileURLs: ([URL]) -> Void
         let onDropTargetedChange: (DropTargetingUpdate) -> Void
         let canAcceptDroppedFileURLs: ([URL]) -> Bool
+        let onChangedRegionNavigationResult: (Int, Int) -> Void
         let onRetryFallback: () -> Void
     }
 
@@ -772,6 +773,9 @@ struct ContentView: View {
                     updateDropTargetState(for: surface, update: update)
                 },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
+                onChangedRegionNavigationResult: { index, _ in
+                    currentChangedRegionIndex = index
+                },
                 onRetryFallback: {
                     previewReloadToken += 1
                     previewMode = .web
@@ -815,6 +819,7 @@ struct ContentView: View {
                     updateDropTargetState(for: surface, update: update)
                 },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
+                onChangedRegionNavigationResult: { _, _ in },
                 onRetryFallback: {
                     sourceReloadToken += 1
                     sourceMode = .web
@@ -846,17 +851,6 @@ struct ContentView: View {
     private func requestChangedRegionNavigation(_ direction: ReaderChangedRegionNavigationDirection) {
         guard canNavigateChangedRegions else {
             return
-        }
-
-        let count = readerStore.changedRegions.count
-        if let current = currentChangedRegionIndex {
-            if direction == .next {
-                currentChangedRegionIndex = (current + 1) % count
-            } else {
-                currentChangedRegionIndex = (current - 1 + count) % count
-            }
-        } else {
-            currentChangedRegionIndex = direction == .next ? 0 : count - 1
         }
 
         lastChangedRegionNavigationDirection = direction
@@ -999,7 +993,8 @@ private struct DocumentSurfaceHost: View {
                     onTOCHeadingsExtracted: configuration.onTOCHeadingsExtracted,
                     onDroppedFileURLs: configuration.onDroppedFileURLs,
                     onDropTargetedChange: configuration.onDropTargetedChange,
-                    canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs
+                    canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs,
+                    onChangedRegionNavigationResult: configuration.onChangedRegionNavigationResult
                 )
             } else {
                 fallbackSurface

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -105,7 +105,7 @@ struct ReaderCSSFactory {
         let escapedCSS = cssBase64.replacingOccurrences(of: "\"", with: "\\\"")
 
         let inlineDiffJS = ReaderJavaScriptLoader.loadBundledJS(named: "markdownobserver-inline-diff")
-        let defaultInset = String(format: "%.0f", ReaderOverlayInsetCalculator.defaultScrollTargetTopInset)
+        let defaultInset = "\(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded()))"
         let runtimeJS = ReaderJavaScriptLoader.loadBundledJS(named: "markdownobserver-runtime")
             .replacingOccurrences(of: "__MINIMARK_PAYLOAD_BASE64__", with: escapedPayload)
             .replacingOccurrences(of: "__MINIMARK_CSS_BASE64__", with: escapedCSS)

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -105,9 +105,11 @@ struct ReaderCSSFactory {
         let escapedCSS = cssBase64.replacingOccurrences(of: "\"", with: "\\\"")
 
         let inlineDiffJS = ReaderJavaScriptLoader.loadBundledJS(named: "markdownobserver-inline-diff")
+        let defaultInset = String(format: "%.0f", ReaderOverlayInsetCalculator.defaultScrollTargetTopInset)
         let runtimeJS = ReaderJavaScriptLoader.loadBundledJS(named: "markdownobserver-runtime")
             .replacingOccurrences(of: "__MINIMARK_PAYLOAD_BASE64__", with: escapedPayload)
             .replacingOccurrences(of: "__MINIMARK_CSS_BASE64__", with: escapedCSS)
+            .replacingOccurrences(of: "__MINIMARK_OVERLAY_TOP_INSET__", with: defaultInset)
 
         return """
         <script>

--- a/minimark/Support/ReaderCSSThemeGenerator.swift
+++ b/minimark/Support/ReaderCSSThemeGenerator.swift
@@ -56,7 +56,7 @@ enum ReaderCSSThemeGenerator {
           box-sizing: border-box;
           width: 100%;
           margin: 0;
-          padding: 52px 12px 24px calc(var(--reader-gutter-width) + var(--reader-gutter-gap));
+          padding: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset))px 12px 24px calc(var(--reader-gutter-width) + var(--reader-gutter-gap));
           color: var(--reader-fg);
           overflow-wrap: anywhere;
         }

--- a/minimark/Support/ReaderCSSThemeGenerator.swift
+++ b/minimark/Support/ReaderCSSThemeGenerator.swift
@@ -56,7 +56,7 @@ enum ReaderCSSThemeGenerator {
           box-sizing: border-box;
           width: 100%;
           margin: 0;
-          padding: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset))px 12px 24px calc(var(--reader-gutter-width) + var(--reader-gutter-gap));
+          padding: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded()))px 12px 24px calc(var(--reader-gutter-width) + var(--reader-gutter-gap));
           color: var(--reader-fg);
           overflow-wrap: anywhere;
         }

--- a/minimark/Support/ReaderOverlayInsetCalculator.swift
+++ b/minimark/Support/ReaderOverlayInsetCalculator.swift
@@ -17,7 +17,7 @@ enum ReaderOverlayInsetCalculator {
            let value = Double(raw), value >= 0 {
             return CGFloat(value)
         }
-        return 16
+        return 8
     }()
 
     static let defaultScrollTargetTopInset: CGFloat =

--- a/minimark/Support/ReaderOverlayInsetCalculator.swift
+++ b/minimark/Support/ReaderOverlayInsetCalculator.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 
 struct ReaderOverlayInsetValues: Equatable {
     let railTopPadding: CGFloat
@@ -10,7 +11,17 @@ enum ReaderOverlayInsetCalculator {
     static let overlayBaseGap: CGFloat = 8
     static let leadingOverlayAlignmentAdjustment: CGFloat = 8
     static let overlayControlHeight: CGFloat = 30
-    static let scrollLandingGap: CGFloat = 8
+
+    static let scrollLandingGap: CGFloat = {
+        if let raw = Bundle.main.object(forInfoDictionaryKey: "ScrollLandingGap") as? String,
+           let value = Double(raw), value >= 0 {
+            return CGFloat(value)
+        }
+        return 16
+    }()
+
+    static let defaultScrollTargetTopInset: CGFloat =
+        overlayBaseGap + leadingOverlayAlignmentAdjustment + overlayControlHeight + scrollLandingGap
 
     static func statusBannerTopPadding(topBarInset: CGFloat) -> CGFloat {
         max(0, topBarInset)

--- a/minimark/Views/Content/ChangeNavigationPill.swift
+++ b/minimark/Views/Content/ChangeNavigationPill.swift
@@ -16,6 +16,11 @@ struct ChangeNavigationPill: View {
         totalCount > 0
     }
 
+    static func counterText(currentIndex: Int?, totalCount: Int) -> String {
+        let position = currentIndex.map { "\(min($0, max(0, totalCount - 1)) + 1)" } ?? "\u{2014}"
+        return "\(position) / \(totalCount)"
+    }
+
     fileprivate enum Metrics {
         static let pillHeight: CGFloat = 30
         static let horizontalPadding: CGFloat = 10
@@ -37,10 +42,7 @@ struct ChangeNavigationPill: View {
                 onNavigate: onNavigate
             )
 
-            (
-                Text(currentIndex.map { "\(min($0, max(0, totalCount - 1)) + 1)" } ?? "\u{2014}")
-                + Text(" / \(totalCount)")
-            )
+            Text(Self.counterText(currentIndex: currentIndex, totalCount: totalCount))
                 .font(.system(size: 10, weight: .bold))
                 .foregroundStyle(.secondary)
                 .monospacedDigit()

--- a/minimark/Views/Content/ChangeNavigationPill.swift
+++ b/minimark/Views/Content/ChangeNavigationPill.swift
@@ -17,7 +17,9 @@ struct ChangeNavigationPill: View {
     }
 
     static func counterText(currentIndex: Int?, totalCount: Int) -> String {
-        let position = currentIndex.map { "\(min($0, max(0, totalCount - 1)) + 1)" } ?? "\u{2014}"
+        let position = currentIndex.map {
+            "\(min(max($0, 0), max(0, totalCount - 1)) + 1)"
+        } ?? "\u{2014}"
         return "\(position) / \(totalCount)"
     }
 

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -581,9 +581,11 @@ struct MarkdownWebView: NSViewRepresentable {
                 }
 
                 if let dict = result as? [String: Any],
-                   let index = dict["index"] as? Int,
-                   let count = dict["count"] as? Int {
-                    self.onChangedRegionNavigationResult(index, count)
+                   let index = (dict["index"] as? NSNumber)?.intValue,
+                   let count = (dict["count"] as? NSNumber)?.intValue {
+                    let clampedCount = max(0, count)
+                    let clampedIndex = clampedCount > 0 ? min(max(0, index), clampedCount - 1) : 0
+                    self.onChangedRegionNavigationResult(clampedIndex, clampedCount)
                 }
             }
         }

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -22,7 +22,7 @@ struct MarkdownWebView: NSViewRepresentable {
         var scrollSyncRequest: ScrollSyncRequest?
     var tocScrollRequest: TOCScrollRequest?
     var supportsInPlaceContentUpdates: Bool = false
-    var overlayTopInset: CGFloat = 56
+    var overlayTopInset: CGFloat = ReaderOverlayInsetCalculator.defaultScrollTargetTopInset
     var reloadAnchorProgress: Double?
     var onFatalCrash: () -> Void = {}
     var onPostLoadStatus: (String?) -> Void = { _ in }
@@ -32,6 +32,7 @@ struct MarkdownWebView: NSViewRepresentable {
     var onDroppedFileURLs: ([URL]) -> Void = { _ in }
         var onDropTargetedChange: (DropTargetingUpdate) -> Void = { _ in }
         var canAcceptDroppedFileURLs: ([URL]) -> Bool = { _ in true }
+    var onChangedRegionNavigationResult: (Int, Int) -> Void = { _, _ in }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -84,6 +85,7 @@ struct MarkdownWebView: NSViewRepresentable {
         context.coordinator.onDroppedFileURLs = onDroppedFileURLs
         context.coordinator.onDropTargetedChange = onDropTargetedChange
         context.coordinator.canAcceptDroppedFileURLs = canAcceptDroppedFileURLs
+        context.coordinator.onChangedRegionNavigationResult = onChangedRegionNavigationResult
         context.coordinator.reloadAnchorProgress = reloadAnchorProgress
         context.coordinator.supportsInPlaceContentUpdates = supportsInPlaceContentUpdates
         context.coordinator.overlayTopInset = max(0, overlayTopInset)
@@ -147,8 +149,9 @@ struct MarkdownWebView: NSViewRepresentable {
         var onDroppedFileURLs: ([URL]) -> Void = { _ in }
         var onDropTargetedChange: (DropTargetingUpdate) -> Void = { _ in }
         var canAcceptDroppedFileURLs: ([URL]) -> Bool = { _ in true }
+        var onChangedRegionNavigationResult: (Int, Int) -> Void = { _, _ in }
         var supportsInPlaceContentUpdates = false
-        var overlayTopInset: CGFloat = 56
+        var overlayTopInset: CGFloat = ReaderOverlayInsetCalculator.defaultScrollTargetTopInset
         var reloadAnchorProgress: Double?
         private var lastAppliedOverlayTopInset: CGFloat?
 
@@ -569,12 +572,19 @@ struct MarkdownWebView: NSViewRepresentable {
             in webView: WKWebView
         ) {
             let script = "window.__minimarkNavigateChangedRegion && window.__minimarkNavigateChangedRegion('\(request.direction.rawValue)');"
-            webView.evaluateJavaScript(script) { [weak self] _, error in
-                guard let self, let error else {
+            webView.evaluateJavaScript(script) { [weak self] result, error in
+                guard let self else { return }
+
+                if let error {
+                    self.logError("changed-region navigation failed: \(error.localizedDescription)")
                     return
                 }
 
-                self.logError("changed-region navigation failed: \(error.localizedDescription)")
+                if let dict = result as? [String: Any],
+                   let index = dict["index"] as? Int,
+                   let count = dict["count"] as? Int {
+                    self.onChangedRegionNavigationResult(index, count)
+                }
             }
         }
 

--- a/minimarkTests/Core/ChangeNavigationPillTests.swift
+++ b/minimarkTests/Core/ChangeNavigationPillTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import minimark
+
+@Suite
+struct ChangeNavigationPillTests {
+
+    // MARK: - Counter text
+
+    @Test func counterShowsDashBeforeFirstNavigation() {
+        let text = ChangeNavigationPill.counterText(currentIndex: nil, totalCount: 3)
+        #expect(text == "\u{2014} / 3")
+    }
+
+    @Test func counterShowsOneBasedIndex() {
+        #expect(ChangeNavigationPill.counterText(currentIndex: 0, totalCount: 3) == "1 / 3")
+        #expect(ChangeNavigationPill.counterText(currentIndex: 1, totalCount: 3) == "2 / 3")
+        #expect(ChangeNavigationPill.counterText(currentIndex: 2, totalCount: 3) == "3 / 3")
+    }
+
+    @Test func counterClampsIndexToValidRange() {
+        #expect(ChangeNavigationPill.counterText(currentIndex: 5, totalCount: 3) == "3 / 3")
+    }
+
+    @Test func counterHandlesSingleChange() {
+        #expect(ChangeNavigationPill.counterText(currentIndex: nil, totalCount: 1) == "\u{2014} / 1")
+        #expect(ChangeNavigationPill.counterText(currentIndex: 0, totalCount: 1) == "1 / 1")
+    }
+
+    // MARK: - Wrap-around navigation index
+
+    @Test func nextFromLastWrapsToFirst() {
+        let index = wrappedIndex(current: 2, count: 3, direction: .next)
+        #expect(index == 0)
+    }
+
+    @Test func previousFromFirstWrapsToLast() {
+        let index = wrappedIndex(current: 0, count: 3, direction: .previous)
+        #expect(index == 2)
+    }
+
+    @Test func nextAdvancesNormally() {
+        #expect(wrappedIndex(current: 0, count: 3, direction: .next) == 1)
+        #expect(wrappedIndex(current: 1, count: 3, direction: .next) == 2)
+    }
+
+    @Test func previousRetreatNormally() {
+        #expect(wrappedIndex(current: 2, count: 3, direction: .previous) == 1)
+        #expect(wrappedIndex(current: 1, count: 3, direction: .previous) == 0)
+    }
+
+    @Test func singleChangeAlwaysWrapsToZero() {
+        #expect(wrappedIndex(current: 0, count: 1, direction: .next) == 0)
+        #expect(wrappedIndex(current: 0, count: 1, direction: .previous) == 0)
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors the wrap-around logic in the JS navigateChangedRegion function.
+    private func wrappedIndex(
+        current: Int,
+        count: Int,
+        direction: ReaderChangedRegionNavigationDirection
+    ) -> Int {
+        switch direction {
+        case .previous:
+            return current <= 0 ? count - 1 : current - 1
+        case .next:
+            return current >= count - 1 ? 0 : current + 1
+        }
+    }
+}

--- a/minimarkTests/Core/ChangeNavigationPillTests.swift
+++ b/minimarkTests/Core/ChangeNavigationPillTests.swift
@@ -17,8 +17,12 @@ struct ChangeNavigationPillTests {
         #expect(ChangeNavigationPill.counterText(currentIndex: 2, totalCount: 3) == "3 / 3")
     }
 
-    @Test func counterClampsIndexToValidRange() {
+    @Test func counterClampsIndexAboveRange() {
         #expect(ChangeNavigationPill.counterText(currentIndex: 5, totalCount: 3) == "3 / 3")
+    }
+
+    @Test func counterClampsNegativeIndex() {
+        #expect(ChangeNavigationPill.counterText(currentIndex: -1, totalCount: 3) == "1 / 3")
     }
 
     @Test func counterHandlesSingleChange() {

--- a/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
+++ b/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
@@ -4,6 +4,8 @@ import Testing
 
 @Suite
 struct ReaderOverlayInsetCalculatorTests {
+    private var gap: CGFloat { ReaderOverlayInsetCalculator.scrollLandingGap }
+
     @Test func computesInsetsForTopBarOnly() {
         let result = ReaderOverlayInsetCalculator.compute(
             topBarInset: 44,
@@ -12,7 +14,7 @@ struct ReaderOverlayInsetCalculatorTests {
 
         #expect(result.railTopPadding == 52)
         #expect(result.leadingOverlayTopPadding == 60)
-        #expect(result.scrollTargetTopInset == 98)
+        #expect(result.scrollTargetTopInset == 60 + 30 + gap)
     }
 
     @Test func computesInsetsWhenSourceEditBarAndWarningBarAreVisible() {
@@ -23,7 +25,7 @@ struct ReaderOverlayInsetCalculatorTests {
 
         #expect(result.railTopPadding == 8)
         #expect(result.leadingOverlayTopPadding == 16)
-        #expect(result.scrollTargetTopInset == 54)
+        #expect(result.scrollTargetTopInset == 16 + 30 + gap)
     }
 
     @Test func clampsNegativeBannerHeightToZero() {
@@ -34,7 +36,7 @@ struct ReaderOverlayInsetCalculatorTests {
 
         #expect(result.railTopPadding == 52)
         #expect(result.leadingOverlayTopPadding == 60)
-        #expect(result.scrollTargetTopInset == 98)
+        #expect(result.scrollTargetTopInset == 60 + 30 + gap)
     }
 
     @Test func ignoresTopBarInsetWhenStatusBannerIsVisible() {
@@ -45,7 +47,7 @@ struct ReaderOverlayInsetCalculatorTests {
 
         #expect(result.railTopPadding == 8)
         #expect(result.leadingOverlayTopPadding == 16)
-        #expect(result.scrollTargetTopInset == 54)
+        #expect(result.scrollTargetTopInset == 16 + 30 + gap)
     }
 
     @Test func statusBannerTopPaddingMatchesTopBarInset() {


### PR DESCRIPTION
## Summary
- Always-active up/down buttons with wrap-around navigation (next on last → first, previous on first → last)
- Fix counter showing wrong index by letting JS report the actual navigated index back to Swift
- Fix first "next" jumping to 2/N instead of 1/N
- Make scroll landing gap configurable via `SCROLL_LANDING_GAP` Xcode build setting (xcconfig → Info.plist → runtime)
- Single-source `defaultScrollTargetTopInset` for CSS content padding, JS overlay inset, and Swift defaults
- Extract and test counter text formatting and wrap-around index logic

## Test plan
- [ ] Open a file, make external changes at multiple locations, verify pill shows "— / N"
- [ ] Click next → should show "1/N" and scroll to first change
- [ ] Step through all changes → counter increments correctly
- [ ] At last change, click next → wraps to "1/N"
- [ ] At first change, click previous → wraps to "N/N"
- [ ] Change `SCROLL_LANDING_GAP` in Build Settings, rebuild → verify content start and scroll target both shift
- [ ] Run `minimarkTests/ChangeNavigationPillTests` and `minimarkTests/ReaderOverlayInsetCalculatorTests`