### PR TITLE
Exclude macOS system metadata dirs from FSEvents watching

### DIFF
--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -472,7 +472,7 @@ struct FolderWatchExclusionMatcher {
     /// file watching. Spotlight writes to `.Spotlight-V100` inside watched
     /// trees, generating FSEvents that trigger verification cycles and
     /// create a feedback loop with `mdworker_shared`.
-    static let systemExcludedDirectoryNames: Set<String> = [
+    private static let systemExcludedDirectoryNames: Set<String> = [
         ".Spotlight-V100",
         ".fseventsd",
         ".Trashes",
@@ -516,7 +516,7 @@ struct FolderWatchExclusionMatcher {
         Self.containsSystemExcludedComponent(inPath: normalizedPath) || excludesPath(normalizedPath)
     }
 
-    static func containsSystemExcludedComponent(inPath path: String) -> Bool {
+    private static func containsSystemExcludedComponent(inPath path: String) -> Bool {
         for name in systemExcludedDirectoryNames {
             if path.contains("/" + name + "/") || path.hasSuffix("/" + name) {
                 return true

--- a/minimark/Services/FolderSnapshotDiffer.swift
+++ b/minimark/Services/FolderSnapshotDiffer.swift
@@ -468,6 +468,18 @@ struct FolderFileMetadata: Equatable {
 // MARK: - Exclusion matcher
 
 struct FolderWatchExclusionMatcher {
+    /// macOS system metadata directory names that are always excluded from
+    /// file watching. Spotlight writes to `.Spotlight-V100` inside watched
+    /// trees, generating FSEvents that trigger verification cycles and
+    /// create a feedback loop with `mdworker_shared`.
+    static let systemExcludedDirectoryNames: Set<String> = [
+        ".Spotlight-V100",
+        ".fseventsd",
+        ".Trashes",
+        ".DocumentRevisions-V100",
+        ".TemporaryItems",
+    ]
+
     private let rootFolderPathWithSlash: String
     private let excludedDirectoryPaths: [String]
 
@@ -497,11 +509,20 @@ struct FolderWatchExclusionMatcher {
     }
 
     func excludesNormalizedDirectoryPath(_ normalizedPath: String) -> Bool {
-        excludesPath(normalizedPath)
+        Self.containsSystemExcludedComponent(inPath: normalizedPath) || excludesPath(normalizedPath)
     }
 
     func excludesNormalizedFilePath(_ normalizedPath: String) -> Bool {
-        excludesPath(normalizedPath)
+        Self.containsSystemExcludedComponent(inPath: normalizedPath) || excludesPath(normalizedPath)
+    }
+
+    static func containsSystemExcludedComponent(inPath path: String) -> Bool {
+        for name in systemExcludedDirectoryNames {
+            if path.contains("/" + name + "/") || path.hasSuffix("/" + name) {
+                return true
+            }
+        }
+        return false
     }
 
     private func excludesPath(_ path: String) -> Bool {

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -1102,6 +1102,77 @@ struct FileRoutingAndWatcherTests {
         #expect(targetedSnapshot[normalizedAtLimitURL] != nil)
     }
 
+    // MARK: - System-excluded directory filtering
+
+    @Test func exclusionMatcherExcludesSpotlightDirectory() {
+        let matcher = FolderWatchExclusionMatcher(
+            rootFolderURL: URL(fileURLWithPath: "/Users/test/docs"),
+            excludedSubdirectoryURLs: []
+        )
+
+        #expect(matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.Spotlight-V100"))
+        #expect(matcher.excludesNormalizedFilePath("/Users/test/docs/.Spotlight-V100/store.db"))
+        #expect(matcher.excludesNormalizedFilePath("/Users/test/docs/.fseventsd/00000001"))
+        #expect(matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.Trashes"))
+        #expect(matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.DocumentRevisions-V100"))
+        #expect(matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.TemporaryItems"))
+    }
+
+    @Test func exclusionMatcherAllowsNonSystemHiddenDirectories() {
+        let matcher = FolderWatchExclusionMatcher(
+            rootFolderURL: URL(fileURLWithPath: "/Users/test/docs"),
+            excludedSubdirectoryURLs: []
+        )
+
+        #expect(!matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.github"))
+        #expect(!matcher.excludesNormalizedFilePath("/Users/test/docs/.github/README.md"))
+        #expect(!matcher.excludesNormalizedDirectoryPath("/Users/test/docs/.claude"))
+        #expect(!matcher.excludesNormalizedFilePath("/Users/test/docs/.obsidian/config.md"))
+    }
+
+    @Test func exclusionMatcherExcludesNestedSystemDirectories() {
+        let matcher = FolderWatchExclusionMatcher(
+            rootFolderURL: URL(fileURLWithPath: "/Users/test/docs"),
+            excludedSubdirectoryURLs: []
+        )
+
+        #expect(matcher.excludesNormalizedFilePath("/Users/test/docs/subdir/.Spotlight-V100/store.db"))
+        #expect(matcher.excludesNormalizedDirectoryPath("/Users/test/docs/deep/nested/.fseventsd"))
+    }
+
+    @Test func snapshotDifferExcludesFilesInSystemDirectories() throws {
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let spotlightDir = directoryURL.appendingPathComponent(".Spotlight-V100", isDirectory: true)
+        try FileManager.default.createDirectory(at: spotlightDir, withIntermediateDirectories: true)
+        try "spotlight data".write(
+            to: spotlightDir.appendingPathComponent("notes.md"),
+            atomically: false, encoding: .utf8
+        )
+
+        let realDir = directoryURL.appendingPathComponent("notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: realDir, withIntermediateDirectories: true)
+        try "# Real".write(
+            to: realDir.appendingPathComponent("real.md"),
+            atomically: false, encoding: .utf8
+        )
+
+        let differ = FolderSnapshotDiffer()
+        let exclusionMatcher = FolderWatchExclusionMatcher(
+            rootFolderURL: directoryURL, excludedSubdirectoryURLs: []
+        )
+
+        let snapshot = try differ.buildIncrementalSnapshot(
+            folderURL: directoryURL, includeSubfolders: true,
+            exclusionMatcher: exclusionMatcher, previousSnapshot: [:]
+        )
+
+        #expect(snapshot.count == 1)
+        let realURL = ReaderFileRouting.normalizedFileURL(realDir.appendingPathComponent("real.md"))
+        #expect(snapshot[realURL] != nil)
+    }
+
     @Test func readerFileActionServiceDeduplicatesApplicationsWithSameBundleIdentifier() throws {
         let temporaryDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("reader-file-action-service-tests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

- Adds targeted exclusion for macOS system metadata directories (`.Spotlight-V100`, `.fseventsd`, `.Trashes`, `.DocumentRevisions-V100`, `.TemporaryItems`) in `FolderWatchExclusionMatcher`
- Breaks the feedback loop between FSEvents file-level watching and Spotlight indexing (`mdworker_shared` pegging CPU at ~100%)
- User-visible hidden directories (`.github`, `.claude`, `.obsidian`, etc.) remain fully watched

## Test plan

- [x] Unit tests for system directory exclusion
- [x] Unit tests confirming non-system hidden dirs are still allowed
- [x] End-to-end snapshot differ test with `.Spotlight-V100` content
- [x] Full test suite passes