### PR TITLE
fix: use overlay-aware top padding in source view

### DIFF
--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -226,7 +226,7 @@ enum MarkdownSourceHTMLRenderer {
                     width: 100%;
                     min-height: 100vh;
                     box-sizing: border-box;
-                    padding: 14px 16px 32px;
+                    padding: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded()))px 16px 32px;
                     border: 0;
                     outline: none;
                     resize: none;

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -219,6 +219,7 @@ enum MarkdownSourceHTMLRenderer {
 
                 #minimark-source-root {
                     min-height: 100vh;
+                    padding-top: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded()))px;
                 }
 
                 .minimark-source-editor {
@@ -226,7 +227,7 @@ enum MarkdownSourceHTMLRenderer {
                     width: 100%;
                     min-height: 100vh;
                     box-sizing: border-box;
-                    padding: \(Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded()))px 16px 32px;
+                    padding: 0 16px 32px;
                     border: 0;
                     outline: none;
                     resize: none;

--- a/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
+++ b/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
@@ -73,6 +73,17 @@ struct MarkdownSourceHTMLRendererTests {
         #expect(html.contains("</html>"))
     }
 
+    @Test func sourceRootIncludesOverlayAwareTopPadding() {
+        let html = MarkdownSourceHTMLRenderer.makeHTMLDocument(
+            markdown: "# Hello",
+            settings: defaultSettings,
+            isEditable: true
+        )
+
+        let expectedPadding = Int(ReaderOverlayInsetCalculator.defaultScrollTargetTopInset.rounded())
+        #expect(html.contains("padding-top: \(expectedPadding)px"))
+    }
+
     @Test func differentThemesProduceDifferentCSS() {
         var lightSettings = defaultSettings
         lightSettings.readerTheme = .blackOnWhite


### PR DESCRIPTION
Closes #270

## Summary

- Replace hardcoded 14px top padding on `.minimark-source-editor` with `defaultScrollTargetTopInset` (~82px), matching how the preview view's `.markdown-body` already handles this

## Context

The source view textarea started content too high, partially hidden behind the floating overlay controls. The preview view correctly used `ReaderOverlayInsetCalculator.defaultScrollTargetTopInset` for its top padding — the source view now does the same.

## Test plan

- [ ] Open a file in source view — content should start below the overlay controls
- [ ] Open a file in split mode — source panel content should also clear the overlay
- [ ] Verify preview mode is unaffected