### PR TITLE
perf: use adaptive timestamp intervals in sidebar rows

### DIFF
--- a/minimark/Support/AdaptiveTimestampSchedule.swift
+++ b/minimark/Support/AdaptiveTimestampSchedule.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// A `TimelineSchedule` that adapts its update frequency based on the age of a timestamp.
+///
+/// Recently-changed documents update every 5 seconds; older ones progressively less often.
+/// Documents with no timestamp or deleted files never trigger updates.
+struct AdaptiveTimestampSchedule: TimelineSchedule {
+
+    let lastModified: Date?
+
+    func entries(from startDate: Date, mode: TimelineScheduleMode) -> Entries {
+        Entries(lastModified: lastModified, startDate: startDate)
+    }
+
+    struct Entries: Sequence, IteratorProtocol {
+
+        let lastModified: Date?
+        var nextDate: Date
+
+        init(lastModified: Date?, startDate: Date) {
+            self.lastModified = lastModified
+            self.nextDate = startDate
+        }
+
+        mutating func next() -> Date? {
+            let current = nextDate
+            nextDate = current.addingTimeInterval(interval(at: current))
+            return current
+        }
+
+        private func interval(at date: Date) -> TimeInterval {
+            guard let lastModified else { return 86_400 }
+
+            let age = date.timeIntervalSince(lastModified)
+
+            switch age {
+            case ..<60:          return 5        // < 1 minute → every 5s
+            case ..<600:         return 30       // 1–10 minutes → every 30s
+            case ..<3_600:       return 120      // 10–60 minutes → every 2 min
+            case ..<86_400:      return 900      // 1–24 hours → every 15 min
+            default:             return 3_600    // > 24 hours → every 1 hour
+            }
+        }
+    }
+}

--- a/minimark/Support/AdaptiveTimestampSchedule.swift
+++ b/minimark/Support/AdaptiveTimestampSchedule.swift
@@ -15,7 +15,7 @@ struct AdaptiveTimestampSchedule: TimelineSchedule {
     struct Entries: Sequence, IteratorProtocol {
 
         let lastModified: Date?
-        var nextDate: Date
+        var nextDate: Date?
 
         init(lastModified: Date?, startDate: Date) {
             self.lastModified = lastModified
@@ -23,16 +23,20 @@ struct AdaptiveTimestampSchedule: TimelineSchedule {
         }
 
         mutating func next() -> Date? {
-            let current = nextDate
-            nextDate = current.addingTimeInterval(interval(at: current))
+            guard let current = nextDate else { return nil }
+
+            if let lastModified {
+                let age = current.timeIntervalSince(lastModified)
+                nextDate = current.addingTimeInterval(interval(forAge: age))
+            } else {
+                // No timestamp — render once, then stop.
+                nextDate = nil
+            }
+
             return current
         }
 
-        private func interval(at date: Date) -> TimeInterval {
-            guard let lastModified else { return 86_400 }
-
-            let age = date.timeIntervalSince(lastModified)
-
+        private func interval(forAge age: TimeInterval) -> TimeInterval {
             switch age {
             case ..<60:          return 5        // < 1 minute → every 5s
             case ..<600:         return 30       // 1–10 minutes → every 30s

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -417,7 +417,7 @@ private struct ReaderSidebarDocumentRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
 
-                TimelineView(.periodic(from: .now, by: 5)) { context in
+                TimelineView(AdaptiveTimestampSchedule(lastModified: state.lastModified)) { context in
                     Text(lastChangedText(currentDate: context.date))
                         .font(.system(size: 10, weight: .regular))
                         .foregroundStyle(lastChangedTextColor)

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -417,7 +417,7 @@ private struct ReaderSidebarDocumentRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
 
-                TimelineView(AdaptiveTimestampSchedule(lastModified: state.lastModified)) { context in
+                TimelineView(AdaptiveTimestampSchedule(lastModified: state.isFileMissing ? nil : state.lastModified)) { context in
                     Text(lastChangedText(currentDate: context.date))
                         .font(.system(size: 10, weight: .regular))
                         .foregroundStyle(lastChangedTextColor)

--- a/minimarkTests/Infrastructure/AdaptiveTimestampScheduleTests.swift
+++ b/minimarkTests/Infrastructure/AdaptiveTimestampScheduleTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import minimark
+
+@Suite
+struct AdaptiveTimestampScheduleTests {
+
+    private func intervals(
+        lastModified: Date?,
+        startDate: Date,
+        count: Int
+    ) -> [TimeInterval] {
+        let schedule = AdaptiveTimestampSchedule(lastModified: lastModified)
+        var entries = schedule.entries(from: startDate, mode: .normal)
+        var dates: [Date] = []
+        for _ in 0..<count {
+            guard let date = entries.next() else { break }
+            dates.append(date)
+        }
+        return zip(dates, dates.dropFirst()).map { $1.timeIntervalSince($0) }
+    }
+
+    // MARK: - Tier boundaries
+
+    @Test func recentDocumentUpdatesEvery5Seconds() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-10) // 10s ago
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 4)
+
+        for gap in gaps {
+            #expect(gap == 5)
+        }
+    }
+
+    @Test func oneToTenMinutesUpdatesEvery30Seconds() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-120) // 2 min ago
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 4)
+
+        for gap in gaps {
+            #expect(gap == 30)
+        }
+    }
+
+    @Test func tenToSixtyMinutesUpdatesEvery2Minutes() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-1800) // 30 min ago
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 4)
+
+        for gap in gaps {
+            #expect(gap == 120)
+        }
+    }
+
+    @Test func oneToTwentyFourHoursUpdatesEvery15Minutes() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-7200) // 2 hours ago
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 4)
+
+        for gap in gaps {
+            #expect(gap == 900)
+        }
+    }
+
+    @Test func olderThan24HoursUpdatesEveryHour() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-172_800) // 2 days ago
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 4)
+
+        for gap in gaps {
+            #expect(gap == 3600)
+        }
+    }
+
+    // MARK: - Tier transitions
+
+    @Test func transitionsFromFastToSlowerTier() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(-55) // 55s ago, just under 1 min
+        let schedule = AdaptiveTimestampSchedule(lastModified: lastModified)
+        var entries = schedule.entries(from: now, mode: .normal)
+
+        let first = entries.next()!
+        let second = entries.next()!
+        let firstGap = second.timeIntervalSince(first)
+        #expect(firstGap == 5) // still in <1min tier
+
+        // After the 5s tick, age is 60s → transitions to 30s tier
+        let third = entries.next()!
+        let secondGap = third.timeIntervalSince(second)
+        #expect(secondGap == 30)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func nilLastModifiedUsesLargeInterval() {
+        let now = Date()
+        let gaps = intervals(lastModified: nil, startDate: now, count: 3)
+
+        for gap in gaps {
+            #expect(gap == 86_400)
+        }
+    }
+
+    @Test func futureLastModifiedTreatedAsRecent() {
+        let now = Date()
+        let lastModified = now.addingTimeInterval(10) // 10s in the future
+        let gaps = intervals(lastModified: lastModified, startDate: now, count: 3)
+
+        // Negative age falls into ..<60 tier
+        for gap in gaps {
+            #expect(gap == 5)
+        }
+    }
+
+    @Test func firstEntryIsStartDate() {
+        let now = Date()
+        let schedule = AdaptiveTimestampSchedule(lastModified: now)
+        var entries = schedule.entries(from: now, mode: .normal)
+
+        let first = entries.next()!
+        #expect(first == now)
+    }
+}

--- a/minimarkTests/Infrastructure/AdaptiveTimestampScheduleTests.swift
+++ b/minimarkTests/Infrastructure/AdaptiveTimestampScheduleTests.swift
@@ -94,13 +94,16 @@ struct AdaptiveTimestampScheduleTests {
 
     // MARK: - Edge cases
 
-    @Test func nilLastModifiedUsesLargeInterval() {
+    @Test func nilLastModifiedStopsAfterFirstEntry() {
         let now = Date()
-        let gaps = intervals(lastModified: nil, startDate: now, count: 3)
+        let schedule = AdaptiveTimestampSchedule(lastModified: nil)
+        var entries = schedule.entries(from: now, mode: .normal)
 
-        for gap in gaps {
-            #expect(gap == 86_400)
-        }
+        let first = entries.next()
+        #expect(first == now)
+
+        let second = entries.next()
+        #expect(second == nil)
     }
 
     @Test func futureLastModifiedTreatedAsRecent() {


### PR DESCRIPTION
## Summary

- Replaces the fixed 5-second `TimelineView` in each sidebar document row with `AdaptiveTimestampSchedule` that tiers the update interval based on document age
- Tier table: 5s (<1min), 30s (1–10min), 2min (10–60min), 15min (1–24h), 1h (>24h); nil timestamps never wake up
- Dramatically reduces idle CPU when many documents are open — only recently-changed files poll at the fast rate

Closes #241

## Test plan

- [x] 9 unit tests covering all tier boundaries, transitions, nil/future edge cases
- [ ] Manual: open 10+ documents, observe CPU usage in Activity Monitor stays flat when idle
- [ ] Manual: edit a file, verify sidebar timestamp updates every 5s for the first minute, then slows down