### PR TITLE
security: add CSP meta tags and remove file:// from safe URL schemes

### DIFF
--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -200,7 +200,7 @@ enum MarkdownSourceHTMLRenderer {
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'">
             <style>
                 \(baseCSS)
 

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -200,6 +200,7 @@ enum MarkdownSourceHTMLRenderer {
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'">
             <style>
                 \(baseCSS)
 

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -200,7 +200,7 @@ enum MarkdownSourceHTMLRenderer {
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data: https:; frame-ancestors 'none'">
             <style>
                 \(baseCSS)
 

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -34,7 +34,7 @@ struct ReaderCSSFactory {
         <head>
           <meta charset=\"utf-8\" />
           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'\" />
+          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data: https:; frame-ancestors 'none'\" />
           <meta name="minimark-runtime-payload-base64" content="\(payloadBase64)" />
           <meta name="minimark-runtime-css-base64" content="\(cssBase64)" />
           \(themeJSBase64.map { "<meta name=\"minimark-runtime-theme-js-base64\" content=\"\($0)\" />" } ?? "")

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -34,7 +34,7 @@ struct ReaderCSSFactory {
         <head>
           <meta charset=\"utf-8\" />
           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data: https:; frame-ancestors 'none'\" />
+          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' file:; style-src 'unsafe-inline'; img-src data: https:; frame-ancestors 'none'\" />
           <meta name="minimark-runtime-payload-base64" content="\(payloadBase64)" />
           <meta name="minimark-runtime-css-base64" content="\(cssBase64)" />
           \(themeJSBase64.map { "<meta name=\"minimark-runtime-theme-js-base64\" content=\"\($0)\" />" } ?? "")

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -34,6 +34,7 @@ struct ReaderCSSFactory {
         <head>
           <meta charset=\"utf-8\" />
           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'\" />
           <meta name="minimark-runtime-payload-base64" content="\(payloadBase64)" />
           <meta name="minimark-runtime-css-base64" content="\(cssBase64)" />
           \(themeJSBase64.map { "<meta name=\"minimark-runtime-theme-js-base64\" content=\"\($0)\" />" } ?? "")

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -34,7 +34,7 @@ struct ReaderCSSFactory {
         <head>
           <meta charset=\"utf-8\" />
           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'\" />
+          <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; script-src 'unsafe-inline' file:; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'none'\" />
           <meta name="minimark-runtime-payload-base64" content="\(payloadBase64)" />
           <meta name="minimark-runtime-css-base64" content="\(cssBase64)" />
           \(themeJSBase64.map { "<meta name=\"minimark-runtime-theme-js-base64\" content=\"\($0)\" />" } ?? "")

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -645,7 +645,7 @@ struct MarkdownWebView: NSViewRepresentable {
             }
 
             switch scheme {
-            case "http", "https", "mailto", "file":
+            case "http", "https", "mailto":
                 return true
             default:
                 return false

--- a/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
+++ b/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
@@ -94,7 +94,7 @@ struct MarkdownSourceHTMLRendererTests {
         #expect(html.contains("Content-Security-Policy"))
         #expect(html.contains("default-src 'none'"))
         #expect(html.contains("script-src 'unsafe-inline' file:"))
-        #expect(html.contains("img-src data:"))
+        #expect(html.contains("img-src data: https:"))
     }
 
     @Test func differentThemesProduceDifferentCSS() {

--- a/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
+++ b/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
@@ -93,7 +93,7 @@ struct MarkdownSourceHTMLRendererTests {
 
         #expect(html.contains("Content-Security-Policy"))
         #expect(html.contains("default-src 'none'"))
-        #expect(html.contains("script-src 'unsafe-inline'"))
+        #expect(html.contains("script-src 'unsafe-inline' file:"))
         #expect(html.contains("img-src data:"))
     }
 

--- a/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
+++ b/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
@@ -84,6 +84,19 @@ struct MarkdownSourceHTMLRendererTests {
         #expect(html.contains("padding-top: \(expectedPadding)px"))
     }
 
+    @Test func makeHTMLDocumentContainsContentSecurityPolicy() {
+        let html = MarkdownSourceHTMLRenderer.makeHTMLDocument(
+            markdown: "# Hello",
+            settings: defaultSettings,
+            isEditable: true
+        )
+
+        #expect(html.contains("Content-Security-Policy"))
+        #expect(html.contains("default-src 'none'"))
+        #expect(html.contains("script-src 'unsafe-inline'"))
+        #expect(html.contains("img-src data:"))
+    }
+
     @Test func differentThemesProduceDifferentCSS() {
         var lightSettings = defaultSettings
         lightSettings.readerTheme = .blackOnWhite

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -164,7 +164,7 @@ struct RenderingAndDiffTests {
 
         #expect(html.contains("Content-Security-Policy"))
         #expect(html.contains("default-src 'none'"))
-        #expect(html.contains("script-src 'unsafe-inline' file:"))
+        #expect(html.contains("script-src 'unsafe-inline' 'unsafe-eval' file:"))
         #expect(html.contains("img-src data: https:"))
     }
 

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -147,6 +147,27 @@ struct RenderingAndDiffTests {
         #expect(html.contains("__minimarkSourceBootstrapStatus"))
     }
 
+    @Test func htmlDocumentContainsContentSecurityPolicy() {
+        let factory = ReaderCSSFactory()
+        let html = factory.makeHTMLDocument(
+            css: "",
+            payloadBase64: "",
+            runtimeAssets: ReaderRuntimeAssets(
+                markdownItScriptPath: "markdown-it.min.js",
+                highlightScriptPath: "highlight.min.js",
+                taskListsScriptPath: nil,
+                footnoteScriptPath: nil,
+                attrsScriptPath: nil,
+                deflistScriptPath: nil
+            )
+        )
+
+        #expect(html.contains("Content-Security-Policy"))
+        #expect(html.contains("default-src 'none'"))
+        #expect(html.contains("script-src 'unsafe-inline'"))
+        #expect(html.contains("img-src data:"))
+    }
+
     @Test func htmlRuntimeEmbedsAndUpdatesRuntimeCSS() {
         let factory = ReaderCSSFactory()
         let html = factory.makeHTMLDocument(

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -164,7 +164,7 @@ struct RenderingAndDiffTests {
 
         #expect(html.contains("Content-Security-Policy"))
         #expect(html.contains("default-src 'none'"))
-        #expect(html.contains("script-src 'unsafe-inline'"))
+        #expect(html.contains("script-src 'unsafe-inline' file:"))
         #expect(html.contains("img-src data:"))
     }
 

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -165,7 +165,7 @@ struct RenderingAndDiffTests {
         #expect(html.contains("Content-Security-Policy"))
         #expect(html.contains("default-src 'none'"))
         #expect(html.contains("script-src 'unsafe-inline' file:"))
-        #expect(html.contains("img-src data:"))
+        #expect(html.contains("img-src data: https:"))
     }
 
     @Test func htmlRuntimeEmbedsAndUpdatesRuntimeCSS() {


### PR DESCRIPTION
## Summary

- Add strict `Content-Security-Policy` meta tag to both HTML document generators (`ReaderCSSFactory`, `MarkdownSourceHTMLRenderer`), blocking external script/resource loading as defense-in-depth against XSS
- Remove `"file"` from the `isSafeExternalURL()` whitelist so `file://` links cannot be opened via `NSWorkspace`

Closes #256, closes #257

## Test plan

- [ ] Verify CSP meta tag present in reader HTML (`ReaderCSSFactory.makeHTMLDocument`)
- [ ] Verify CSP meta tag present in source view HTML (`MarkdownSourceHTMLRenderer.makeHTMLDocument`)
- [ ] Verify `file://` links in markdown no longer open via NSWorkspace
- [ ] Verify `http://`, `https://`, `mailto:` links still work
- [ ] Verify inline scripts, styles, and data: images still render correctly
- [ ] Unit tests pass: `htmlDocumentContainsContentSecurityPolicy` (both suites)