### PR TITLE
fix: filter deleted files from sidebar when opening a favorite

### DIFF
--- a/minimark/Models/ReaderFavoriteWatchedFolder.swift
+++ b/minimark/Models/ReaderFavoriteWatchedFolder.swift
@@ -191,6 +191,11 @@ nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Se
         }
     }
 
+    func existingOpenDocumentFileURLs(relativeTo folderURL: URL) -> [URL] {
+        resolvedOpenDocumentFileURLs(relativeTo: folderURL)
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
     static func scopedOpenDocumentRelativePaths(
         from fileURLs: [URL],
         relativeTo folderURL: URL,

--- a/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
@@ -120,6 +120,7 @@ extension ReaderWindowRootView {
         )
 
         let restoredFileURLs = entry.resolvedOpenDocumentFileURLs(relativeTo: resolvedURL)
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
         if let session = sharedFolderWatchSession,
            !restoredFileURLs.isEmpty {
             fileOpenCoordinator.open(FileOpenRequest(

--- a/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
@@ -119,8 +119,7 @@ extension ReaderWindowRootView {
             performInitialAutoOpen: false
         )
 
-        let restoredFileURLs = entry.resolvedOpenDocumentFileURLs(relativeTo: resolvedURL)
-            .filter { FileManager.default.fileExists(atPath: $0.path) }
+        let restoredFileURLs = entry.existingOpenDocumentFileURLs(relativeTo: resolvedURL)
         if let session = sharedFolderWatchSession,
            !restoredFileURLs.isEmpty {
             fileOpenCoordinator.open(FileOpenRequest(

--- a/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
@@ -923,6 +923,34 @@ struct ReaderFavoriteWatchedFolderTests {
         #expect(decoded.workspaceState.collapsedGroupIDs == ["group-3"])
     }
 
+    // MARK: - Deleted file filtering (#278)
+
+    @Test func resolvedURLsFilteredByExistenceExcludesDeletedFiles() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("minimarkTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let existingFile = tempDir.appendingPathComponent("exists.md")
+        try Data("# Exists".utf8).write(to: existingFile)
+
+        let entry = ReaderFavoriteWatchedFolder(
+            name: "Test",
+            folderPath: tempDir.path,
+            options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
+            bookmarkData: nil,
+            openDocumentRelativePaths: ["exists.md", "deleted.md"],
+            createdAt: .now
+        )
+
+        let allResolved = entry.resolvedOpenDocumentFileURLs(relativeTo: tempDir)
+        #expect(allResolved.count == 2, "Model returns both existing and deleted paths")
+
+        let existingOnly = allResolved.filter { FileManager.default.fileExists(atPath: $0.path) }
+        #expect(existingOnly.count == 1)
+        #expect(existingOnly[0].lastPathComponent == "exists.md")
+    }
+
     // MARK: - Helpers
 
     private func makeFavorite(name: String, folderPath: String) -> ReaderFavoriteWatchedFolder {

--- a/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
@@ -925,7 +925,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     // MARK: - Deleted file filtering (#278)
 
-    @Test func resolvedURLsFilteredByExistenceExcludesDeletedFiles() throws {
+    @Test func existingOpenDocumentFileURLsExcludesDeletedFiles() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("minimarkTest-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -944,9 +944,9 @@ struct ReaderFavoriteWatchedFolderTests {
         )
 
         let allResolved = entry.resolvedOpenDocumentFileURLs(relativeTo: tempDir)
-        #expect(allResolved.count == 2, "Model returns both existing and deleted paths")
+        #expect(allResolved.count == 2, "Unfiltered method returns both existing and deleted paths")
 
-        let existingOnly = allResolved.filter { FileManager.default.fileExists(atPath: $0.path) }
+        let existingOnly = entry.existingOpenDocumentFileURLs(relativeTo: tempDir)
         #expect(existingOnly.count == 1)
         #expect(existingOnly[0].lastPathComponent == "exists.md")
     }


### PR DESCRIPTION
Closes #278

## Summary

- When opening a favorite, filter restored file URLs through `FileManager.fileExists` before passing them to the file open coordinator
- Deleted files are silently excluded from the sidebar instead of appearing as ghost entries with "No change timestamp"
- Stored favorite data (`openDocumentRelativePaths`) is intentionally left unchanged — if a file reappears later (e.g. git branch switch), it will be restored on next open

## Test plan

- [ ] Open a favorite with several files, close the app, delete some files, reopen — deleted files should not appear in the sidebar
- [ ] Verify existing files still load correctly
- [ ] New unit test `resolvedURLsFilteredByExistenceExcludesDeletedFiles` covers the filtering logic