### PR TITLE
Refactor: Extract business logic from ContentView

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+# Build (debug, no signing required)
+xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build
+
+# Run unit tests
+xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests
+
+# Resolve Swift package dependencies
+xcodebuild -resolvePackageDependencies -project minimark.xcodeproj -scheme minimark
+
+# Clean build
+xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug clean
+```
+
+If Xcode MCP is configured for the session, prefer it for scheme-aware build and test work.
+
+## Architecture
+
+Native macOS app (SwiftUI + Combine). The shipped app name is **MarkdownObserver** — use that in user-visible copy, not "minimark" (which is the internal/repo identifier).
+
+### Layer structure
+
+- **Views** (`minimark/Views/`, `minimark/ContentView.swift`) — SwiftUI views. Keep business logic out of views.
+- **Stores** (`minimark/Stores/`) — Observable state and coordination. Each store or controller owns a single responsibility (e.g. `ReaderSettingsStore` owns user settings, `WindowAppearanceController` owns window chrome, `SidebarGroupStateController` owns sidebar expand/collapse). `ReaderStore` holds per-document observable state and wires dependencies — it should not grow new responsibilities. Legacy coordination extensions exist under `Stores/Coordination/` but new behavior belongs in dedicated controllers or coordinators, not in more `ReaderStore` extensions.
+- **Services** (`minimark/Services/`) — Focused business logic: markdown rendering, file/folder watching, security-scoped resource access, change diffing.
+- **Models** (`minimark/Models/`) — Data types (themes, display modes, window seeds, etc.).
+- **Support** (`minimark/Support/`) — Utilities: CSS generation, file routing, window registry, bundled assets, error types.
+
+### Single external dependency
+
+**Differ** (v1.4.6+) — used in `ChangedRegionDiffer` for tracking changed markdown regions.
+
+## Conventions
+
+- Preserve entitlements at `minimark/App/minimark.entitlements`.
+- Prefer small, focused changes matching the existing layer split.
+- Apply SOLID pragmatically — keep responsibilities narrow, avoid god objects. When adding behavior, create a new controller or coordinator with a single responsibility rather than extending an existing store.
+- When incremental changes start to bloat a type or blur responsibilities, suggest a focused refactoring instead of layering more patches.
+- Do not add new `ReaderStore` extensions. Extract new behavior into a standalone type that ReaderStore can delegate to or that views can observe independently.
+- Internal APIs are allowed to change when it leads to better architecture. Do not treat internal type signatures as immutable — refactor them alongside their callers when the result is cleaner.
+- Preserve public behavior and APIs unless the task explicitly calls for refactoring.
+- Use targeted tests instead of broad suite changes when only a small behavior changed.
+
+## Tests
+
+Tests live in `minimarkTests/` grouped by domain: `Core/`, `ReaderStore/`, `Rendering/`, `Sidebar/`, `FolderWatch/`, `Infrastructure/`. Test doubles are in `TestSupport/`. UI tests are in `minimarkUITests/`.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on `macOS-latest`: resolve packages → build-for-testing → run unit tests. Code signing is disabled for CI.
+
+
+

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -508,15 +508,8 @@ struct DocumentSurfaceHost: View {
                     supportsInPlaceContentUpdates: configuration.supportsInPlaceContentUpdates,
                     overlayTopInset: configuration.overlayTopInset,
                     reloadAnchorProgress: configuration.reloadAnchorProgress,
-                    onFatalCrash: { configuration.onAction(.fatalCrash) },
-                    onPostLoadStatus: { status in configuration.onAction(.postLoadStatus(status)) },
-                    onScrollSyncObservation: { obs in configuration.onAction(.scrollSyncObservation(obs)) },
-                    onSourceEdit: { md in configuration.onAction(.sourceEdit(md)) },
-                    onTOCHeadingsExtracted: { headings in configuration.onAction(.tocHeadingsExtracted(headings)) },
-                    onDroppedFileURLs: { urls in configuration.onAction(.droppedFileURLs(urls)) },
-                    onDropTargetedChange: { update in configuration.onAction(.dropTargetedChange(update)) },
                     canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs,
-                    onChangedRegionNavigationResult: { index, total in configuration.onAction(.changedRegionNavigationResult(index: index, total: total)) }
+                    onAction: configuration.onAction
                 )
             } else {
                 fallbackSurface

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -33,12 +33,6 @@ struct ContentView: View {
         }
     }
 
-    private struct SourceHTMLInputs: Equatable {
-        let markdown: String
-        let settings: ReaderSettings
-        let isEditable: Bool
-    }
-
     fileprivate struct DocumentSurfaceConfiguration {
         let role: DocumentSurfaceRole
         let usesWebSurface: Bool
@@ -92,8 +86,7 @@ struct ContentView: View {
     @State private var changedRegionNavigationRequestID = 0
     @State private var lastChangedRegionNavigationDirection: ReaderChangedRegionNavigationDirection?
     @State private var currentChangedRegionIndex: Int?
-    @State private var cachedSourceHTMLInputs: SourceHTMLInputs?
-    @State private var cachedSourceHTMLDocument = ""
+    @State private var sourceHTMLCache = SourceHTMLDocumentCache()
 
     var body: some View {
         interactionAwareView(baseBody)
@@ -145,8 +138,14 @@ struct ContentView: View {
             .onChange(of: readerStore.documentViewMode) { _, newValue in
                 handleDocumentViewModeChange(newValue)
             }
-            .onChange(of: sourceHTMLInputs) { _, _ in
-                handleSourceHTMLInputsChange()
+            .onChange(of: readerStore.sourceEditorSeedMarkdown) { _, _ in
+                refreshSourceHTML()
+            }
+            .onChange(of: readerStore.currentSettings) { _, _ in
+                refreshSourceHTML()
+            }
+            .onChange(of: readerStore.isSourceEditing) { _, _ in
+                refreshSourceHTML()
             }
             .onChange(of: folderWatchState.activeFolderWatch?.folderURL.standardizedFileURL.path) { _, _ in
                 clearDropTargetState()
@@ -389,12 +388,8 @@ struct ContentView: View {
         splitScrollCoordinator.reset()
     }
 
-    private func handleSourceHTMLInputsChange() {
-        refreshSourceHTMLDocumentIfNeeded()
-    }
-
     private func handleSurfaceAppear() {
-        refreshSourceHTMLDocumentIfNeeded()
+        refreshSourceHTML()
 
         if previewMode == .nativeFallback, !readerStore.renderedHTMLDocument.isEmpty {
             previewReloadToken += 1
@@ -720,14 +715,6 @@ struct ContentView: View {
         readerStore.documentViewMode == .split ? Metrics.splitPaneMinimumWidth : nil
     }
 
-    private var sourceHTMLInputs: SourceHTMLInputs {
-        SourceHTMLInputs(
-            markdown: readerStore.sourceEditorSeedMarkdown,
-            settings: readerStore.currentSettings,
-            isEditable: readerStore.isSourceEditing
-        )
-    }
-
     private func documentSurfacePane(for surface: DocumentSurfaceRole) -> some View {
         DocumentSurfaceHost(
             configuration: documentSurfaceConfiguration(for: surface),
@@ -785,7 +772,7 @@ struct ContentView: View {
             return DocumentSurfaceConfiguration(
                 role: surface,
                 usesWebSurface: sourceMode == .web,
-                htmlDocument: cachedSourceHTMLDocument,
+                htmlDocument: sourceHTMLCache.document,
                 documentIdentity: sourceDocumentIdentity,
                 accessibilityIdentifier: "reader-source",
                 accessibilityValue: sourceAccessibilityValue,
@@ -889,17 +876,11 @@ struct ContentView: View {
         Self.logger.debug("source bootstrap completed successfully")
     }
 
-    private func refreshSourceHTMLDocumentIfNeeded() {
-        let inputs = sourceHTMLInputs
-        guard cachedSourceHTMLInputs != inputs else {
-            return
-        }
-
-        cachedSourceHTMLInputs = inputs
-        cachedSourceHTMLDocument = MarkdownSourceHTMLRenderer.makeHTMLDocument(
-            markdown: inputs.markdown,
-            settings: inputs.settings,
-            isEditable: inputs.isEditable
+    private func refreshSourceHTML() {
+        sourceHTMLCache.refreshIfNeeded(
+            markdown: readerStore.sourceEditorSeedMarkdown,
+            settings: readerStore.currentSettings,
+            isEditable: readerStore.isSourceEditing
         )
     }
 

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -43,7 +43,20 @@ struct ContentView: View {
     @State private var sourceHTMLCache = SourceHTMLDocumentCache()
 
     var body: some View {
-        interactionAwareView(baseBody)
+        baseBody.modifier(ContentViewFocusedValues(
+            readerStore: readerStore,
+            folderWatchState: folderWatchState,
+            callbacks: callbacks,
+            canNavigateChangedRegions: canNavigateChangedRegions,
+            onNavigateChangedRegion: { direction in
+                changeNavigation.requestNavigation(direction)
+                splitScrollCoordinator.suppressPreviewBounceBack()
+            },
+            isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
+            pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
+            pendingFolderWatchScope: $pendingFolderWatchScope,
+            pendingFolderWatchExcludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths
+        ))
     }
 
     private var baseBody: some View {
@@ -164,147 +177,6 @@ struct ContentView: View {
         .contentShape(Rectangle())
     }
 
-    private func interactionAwareView<Content: View>(_ view: Content) -> some View {
-        view
-        .focusedValue(
-            \.readerOpenDocumentInCurrentWindow,
-            ReaderOpenDocumentInCurrentWindowAction { fileURL in
-                let normalizedURL = ReaderFileRouting.normalizedFileURL(fileURL)
-                let currentURL = readerStore.fileURL.map(ReaderFileRouting.normalizedFileURL)
-                if readerStore.hasUnsavedDraftChanges, currentURL != normalizedURL {
-                    readerStore.presentError(ReaderError.unsavedDraftRequiresResolution)
-                    return
-                }
-                callbacks.onRequestFileOpen(FileOpenRequest(
-                    fileURLs: [fileURL],
-                    origin: .manual,
-                    slotStrategy: .replaceSelectedSlot
-                ))
-            }
-        )
-        .focusedValue(
-            \.readerOpenDocument,
-            ReaderOpenDocumentAction { fileURL in
-                if readerStore.fileURL == nil {
-                    callbacks.onRequestFileOpen(FileOpenRequest(
-                        fileURLs: [fileURL],
-                        origin: .manual,
-                        slotStrategy: .replaceSelectedSlot
-                    ))
-                } else {
-                    callbacks.onRequestFileOpen(FileOpenRequest(
-                        fileURLs: [fileURL],
-                        origin: .manual,
-                        slotStrategy: .alwaysAppend
-                    ))
-                }
-            }
-        )
-        .focusedValue(
-            \.readerOpenAdditionalDocument,
-            ReaderOpenAdditionalDocumentAction { fileURL in
-                if readerStore.fileURL == nil {
-                    callbacks.onRequestFileOpen(FileOpenRequest(
-                        fileURLs: [fileURL],
-                        origin: .manual,
-                        slotStrategy: .replaceSelectedSlot
-                    ))
-                } else {
-                    callbacks.onRequestFileOpen(FileOpenRequest(
-                        fileURLs: [fileURL],
-                        origin: .manual,
-                        slotStrategy: .alwaysAppend
-                    ))
-                }
-            }
-        )
-        .focusedValue(
-            \.readerWatchFolder,
-            ReaderWatchFolderAction { folderURL in
-                callbacks.onRequestFolderWatch(folderURL)
-            }
-        )
-        .focusedValue(
-            \.readerStartRecentFolderWatch,
-            ReaderStartRecentFolderWatchAction { entry in
-                callbacks.onStartRecentFolderWatch(entry)
-            }
-        )
-        .focusedValue(
-            \.readerStopFolderWatch,
-            ReaderStopFolderWatchAction {
-                guard folderWatchState.canStopFolderWatch else {
-                    return
-                }
-                callbacks.onStopFolderWatch()
-            }
-        )
-        .focusedValue(
-            \.readerHasActiveFolderWatch,
-            folderWatchState.canStopFolderWatch
-        )
-        .focusedValue(
-            \.readerDocumentViewModeContext,
-            ReaderDocumentViewModeContext(
-                currentMode: readerStore.documentViewMode,
-                canSetMode: readerStore.hasOpenDocument,
-                setMode: { mode in
-                    readerStore.setDocumentViewMode(mode)
-                },
-                toggleMode: {
-                    readerStore.toggleDocumentViewMode()
-                }
-            )
-        )
-        .focusedValue(
-            \.readerSourceEditingContext,
-            ReaderSourceEditingContext(
-                canStartEditing: readerStore.canStartSourceEditing,
-                canSave: readerStore.canSaveSourceDraft,
-                canDiscard: readerStore.canDiscardSourceDraft,
-                startEditing: {
-                    readerStore.startEditingSource()
-                },
-                save: {
-                    readerStore.saveSourceDraft()
-                },
-                discard: {
-                    readerStore.discardSourceDraft()
-                }
-            )
-        )
-        .focusedValue(
-            \.readerChangedRegionNavigation,
-            ReaderChangedRegionNavigationAction(
-                canNavigate: canNavigateChangedRegions,
-                navigate: { direction in
-                    changeNavigation.requestNavigation(direction)
-                    splitScrollCoordinator.suppressPreviewBounceBack()
-                }
-            )
-        )
-        .focusedValue(
-            \.readerToggleTOC,
-            ReaderToggleTOCAction(
-                canToggle: !readerStore.tocHeadings.isEmpty,
-                toggle: { readerStore.toggleTOC() }
-            )
-        )
-        .onChange(of: isFolderWatchOptionsPresented) { _, isPresented in
-            handleFolderWatchOptionsPresentationChange(isPresented)
-        }
-        .sheet(isPresented: $isFolderWatchOptionsPresented) {
-            FolderWatchOptionsSheet(
-                folderURL: folderWatchState.pendingFolderWatchURL,
-                openMode: $pendingFolderWatchOpenMode,
-                scope: $pendingFolderWatchScope,
-                excludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths,
-                onCancel: callbacks.onCancelFolderWatch,
-                onConfirm: callbacks.onConfirmFolderWatch
-            )
-        }
-    }
-
     private func handleFileIdentityChange() {
         changeNavigation.reset()
         if previewMode == .nativeFallback {
@@ -357,14 +229,6 @@ struct ContentView: View {
             sourceReloadToken += 1
             sourceMode = .web
         }
-    }
-
-    private func handleFolderWatchOptionsPresentationChange(_ isPresented: Bool) {
-        guard !isPresented else {
-            return
-        }
-
-        callbacks.onCancelFolderWatch()
     }
 
     private func promptForImageDirectoryAccess() {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
         case plainTextFallback
     }
 
-    fileprivate enum DocumentSurfaceRole: Hashable {
+    enum DocumentSurfaceRole: Hashable {
         case preview
         case source
 
@@ -77,8 +77,7 @@ struct ContentView: View {
     @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
 
     @StateObject private var splitScrollCoordinator = SplitScrollCoordinator()
-    @State private var dragTargetedSurfaces: Set<DocumentSurfaceRole> = []
-    @State private var blockedFolderDropTargetedSurfaces: Set<DocumentSurfaceRole> = []
+    @State private var dropTargeting = DropTargetingCoordinator()
     @State private var previewMode: PreviewMode = .web
     @State private var previewReloadToken = 0
     @State private var sourceMode: SourceMode = .web
@@ -110,11 +109,11 @@ struct ContentView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay {
-                if isBlockedFolderDropTargeted {
+                if dropTargeting.isBlockedFolderDropTargeted {
                     FolderDropBlockedOverlayView()
                         .padding(10)
                         .allowsHitTesting(false)
-                } else if isDragTargeted {
+                } else if dropTargeting.isDragTargeted {
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .strokeBorder(Color.accentColor.opacity(0.65), lineWidth: 2)
                         .padding(10)
@@ -146,7 +145,7 @@ struct ContentView: View {
                 refreshSourceHTML()
             }
             .onChange(of: folderWatchState.activeFolderWatch?.folderURL.standardizedFileURL.path) { _, _ in
-                clearDropTargetState()
+                dropTargeting.clearAll()
             }
             .onAppear {
                 handleSurfaceAppear()
@@ -359,7 +358,7 @@ struct ContentView: View {
             sourceReloadToken += 1
             sourceMode = .web
         }
-        clearDropTargetState()
+        dropTargeting.clearAll()
         splitScrollCoordinator.reset()
     }
 
@@ -368,7 +367,7 @@ struct ContentView: View {
             return
         }
 
-        clearDropTargetState(for: .preview)
+        dropTargeting.clear(for: .preview)
         splitScrollCoordinator.reset()
     }
 
@@ -377,7 +376,7 @@ struct ContentView: View {
             return
         }
 
-        clearDropTargetState(for: .source)
+        dropTargeting.clear(for: .source)
         splitScrollCoordinator.reset()
     }
 
@@ -707,14 +706,6 @@ struct ContentView: View {
         }
     }
 
-    private var isDragTargeted: Bool {
-        !dragTargetedSurfaces.isEmpty
-    }
-
-    private var isBlockedFolderDropTargeted: Bool {
-        !blockedFolderDropTargetedSurfaces.isEmpty
-    }
-
     private var minimumSurfaceWidth: CGFloat? {
         readerStore.documentViewMode == .split ? Metrics.splitPaneMinimumWidth : nil
     }
@@ -761,7 +752,7 @@ struct ContentView: View {
                 },
                 onDroppedFileURLs: handleDroppedFileURLs,
                 onDropTargetedChange: { update in
-                    updateDropTargetState(for: surface, update: update)
+                    dropTargeting.update(for: surface, update: update)
                 },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
                 onChangedRegionNavigationResult: { index, total in
@@ -807,7 +798,7 @@ struct ContentView: View {
                 },
                 onDroppedFileURLs: handleDroppedFileURLs,
                 onDropTargetedChange: { update in
-                    updateDropTargetState(for: surface, update: update)
+                    dropTargeting.update(for: surface, update: update)
                 },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
                 onChangedRegionNavigationResult: { _, _ in },
@@ -865,32 +856,6 @@ struct ContentView: View {
             settings: readerStore.currentSettings,
             isEditable: readerStore.isSourceEditing
         )
-    }
-
-    private func updateDropTargetState(for surface: DocumentSurfaceRole, update: DropTargetingUpdate) {
-        if update.isTargeted {
-            dragTargetedSurfaces.insert(surface)
-        } else {
-            dragTargetedSurfaces.remove(surface)
-        }
-
-        let isBlockedFolderDrop = update.isTargeted && !update.canDrop && update.containsDirectoryHint
-        if isBlockedFolderDrop {
-            blockedFolderDropTargetedSurfaces.insert(surface)
-        } else {
-            blockedFolderDropTargetedSurfaces.remove(surface)
-        }
-    }
-
-    private func clearDropTargetState(for surface: DocumentSurfaceRole? = nil) {
-        guard let surface else {
-            dragTargetedSurfaces.removeAll()
-            blockedFolderDropTargetedSurfaces.removeAll()
-            return
-        }
-
-        dragTargetedSurfaces.remove(surface)
-        blockedFolderDropTargetedSurfaces.remove(surface)
     }
 
     private func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -1,6 +1,6 @@
 import AppKit
-import Foundation
 import Combine
+import Foundation
 import OSLog
 import SwiftUI
 
@@ -411,7 +411,7 @@ struct ContentView: View {
                 TOCPopoverView(
                     headings: readerStore.tocHeadings,
                     onSelect: { heading in
-                        handleTOCHeadingSelection(heading)
+                        readerStore.scrollToTOCHeading(heading)
                     }
                 )
                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -427,9 +427,6 @@ struct ContentView: View {
         }
     }
 
-    private func handleTOCHeadingSelection(_ heading: TOCHeading) {
-        readerStore.scrollToTOCHeading(heading)
-    }
 
     var canNavigateChangedRegions: Bool {
         readerStore.documentViewMode != .source &&

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -483,7 +483,7 @@ struct ContentView: View {
     }
 
     private var isUITestModeEnabled: Bool {
-        ProcessInfo.processInfo.arguments.contains("-minimark-ui-test")
+        ReaderUITestLaunchConfiguration.current.isUITestModeEnabled
     }
 }
 

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -83,9 +83,7 @@ struct ContentView: View {
     @State private var previewReloadToken = 0
     @State private var sourceMode: SourceMode = .web
     @State private var sourceReloadToken = 0
-    @State private var changedRegionNavigationRequestID = 0
-    @State private var lastChangedRegionNavigationDirection: ReaderChangedRegionNavigationDirection?
-    @State private var currentChangedRegionIndex: Int?
+    @State private var changeNavigation = ChangedRegionNavigationCoordinator()
     @State private var sourceHTMLCache = SourceHTMLDocumentCache()
 
     var body: some View {
@@ -127,7 +125,7 @@ struct ContentView: View {
                 handleFileIdentityChange()
             }
             .onChange(of: readerStore.changedRegions) { _, _ in
-                currentChangedRegionIndex = nil
+                changeNavigation.resetForNewRegions()
             }
             .onChange(of: previewMode) { _, newValue in
                 handlePreviewModeChange(newValue)
@@ -323,7 +321,10 @@ struct ContentView: View {
             \.readerChangedRegionNavigation,
             ReaderChangedRegionNavigationAction(
                 canNavigate: canNavigateChangedRegions,
-                navigate: requestChangedRegionNavigation
+                navigate: { direction in
+                    changeNavigation.requestNavigation(direction)
+                    splitScrollCoordinator.suppressPreviewBounceBack()
+                }
             )
         )
         .focusedValue(
@@ -349,7 +350,7 @@ struct ContentView: View {
     }
 
     private func handleFileIdentityChange() {
-        currentChangedRegionIndex = nil
+        changeNavigation.reset()
         if previewMode == .nativeFallback {
             previewReloadToken += 1
             previewMode = .web
@@ -552,9 +553,12 @@ struct ContentView: View {
             .overlay(alignment: .topLeading) {
                 if canNavigateChangedRegions {
                     ChangeNavigationPill(
-                        currentIndex: currentChangedRegionIndex,
+                        currentIndex: changeNavigation.currentIndex,
                         totalCount: readerStore.changedRegions.count,
-                        onNavigate: requestChangedRegionNavigation
+                        onNavigate: { direction in
+                            changeNavigation.requestNavigation(direction)
+                            splitScrollCoordinator.suppressPreviewBounceBack()
+                        }
                     )
                     .firstUseHint(.changeNavigation, message: "Use the arrows to step through changes", settingsStore: settingsStore)
                     .padding(.top, overlayInsets.leadingOverlayTopPadding)
@@ -735,7 +739,7 @@ struct ContentView: View {
                 reloadToken: previewReloadToken,
                 diagnosticName: "reader-preview",
                 postLoadStatusScript: nil,
-                changedRegionNavigationRequest: previewChangedRegionNavigationRequest,
+                changedRegionNavigationRequest: canNavigateChangedRegions ? changeNavigation.currentRequest : nil,
                 scrollSyncRequest: splitScrollRequest(for: surface),
                 tocScrollRequest: readerStore.tocScrollRequest,
                 supportsInPlaceContentUpdates: true,
@@ -760,8 +764,8 @@ struct ContentView: View {
                     updateDropTargetState(for: surface, update: update)
                 },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onChangedRegionNavigationResult: { index, _ in
-                    currentChangedRegionIndex = index
+                onChangedRegionNavigationResult: { index, total in
+                    changeNavigation.handleNavigationResult(index: index, total: total)
                 },
                 onRetryFallback: {
                     previewReloadToken += 1
@@ -823,27 +827,6 @@ struct ContentView: View {
         return "\(path)|source"
     }
 
-    private var previewChangedRegionNavigationRequest: ChangedRegionNavigationRequest? {
-        guard canNavigateChangedRegions,
-              let lastChangedRegionNavigationDirection else {
-            return nil
-        }
-
-        return ChangedRegionNavigationRequest(
-            id: changedRegionNavigationRequestID,
-            direction: lastChangedRegionNavigationDirection
-        )
-    }
-
-    private func requestChangedRegionNavigation(_ direction: ReaderChangedRegionNavigationDirection) {
-        guard canNavigateChangedRegions else {
-            return
-        }
-
-        lastChangedRegionNavigationDirection = direction
-        changedRegionNavigationRequestID += 1
-        splitScrollCoordinator.suppressPreviewBounceBack()
-    }
 
     private func handleFatalCrash(for surface: DocumentSurfaceRole) {
         switch surface {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -738,11 +738,10 @@ struct ContentView: View {
                 reloadAnchorProgress: previewReloadAnchorProgress,
                 minimumWidth: minimumSurfaceWidth,
                 onFatalCrash: {
-                    handleFatalCrash(for: surface)
+                    Self.logger.error("preview web surface hit fatal crash and fell back to native text")
+                    previewMode = .nativeFallback
                 },
-                onPostLoadStatus: { status in
-                    handlePostLoadStatus(status, for: surface)
-                },
+                onPostLoadStatus: { _ in },
                 onScrollSyncObservation: { observation in
                     handleScrollSyncObservation(observation, from: surface)
                 },
@@ -782,10 +781,21 @@ struct ContentView: View {
                 reloadAnchorProgress: nil,
                 minimumWidth: minimumSurfaceWidth,
                 onFatalCrash: {
-                    handleFatalCrash(for: surface)
+                    Self.logger.error("source web surface hit fatal crash and fell back to plain text")
+                    sourceMode = .plainTextFallback
                 },
                 onPostLoadStatus: { status in
-                    handlePostLoadStatus(status, for: surface)
+                    guard let status else {
+                        Self.logger.error("source post-load status probe returned no status")
+                        sourceMode = .plainTextFallback
+                        return
+                    }
+                    guard status == "ready" else {
+                        Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
+                        sourceMode = .plainTextFallback
+                        return
+                    }
+                    Self.logger.debug("source bootstrap completed successfully")
                 },
                 onScrollSyncObservation: { observation in
                     handleScrollSyncObservation(observation, from: surface)
@@ -818,37 +828,6 @@ struct ContentView: View {
         return "\(path)|source"
     }
 
-
-    private func handleFatalCrash(for surface: DocumentSurfaceRole) {
-        switch surface {
-        case .preview:
-            Self.logger.error("preview web surface hit fatal crash and fell back to native text")
-            previewMode = .nativeFallback
-        case .source:
-            Self.logger.error("source web surface hit fatal crash and fell back to plain text")
-            sourceMode = .plainTextFallback
-        }
-    }
-
-    private func handlePostLoadStatus(_ status: String?, for surface: DocumentSurfaceRole) {
-        guard surface == .source else {
-            return
-        }
-
-        guard let status else {
-            Self.logger.error("source post-load status probe returned no status")
-            sourceMode = .plainTextFallback
-            return
-        }
-
-        guard status == "ready" else {
-            Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
-            sourceMode = .plainTextFallback
-            return
-        }
-
-        Self.logger.debug("source bootstrap completed successfully")
-    }
 
     private func refreshSourceHTML() {
         sourceHTMLCache.refreshIfNeeded(

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -9,17 +9,17 @@ struct ContentView: View {
         static let splitPaneMinimumWidth: CGFloat = 320
     }
 
-    private enum PreviewMode {
+    enum PreviewMode {
         case web
         case nativeFallback
     }
 
-    private enum SourceMode {
+    enum SourceMode {
         case web
         case plainTextFallback
     }
 
-    private static let logger = Logger(
+    static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
         category: "ContentView"
     )
@@ -33,14 +33,18 @@ struct ContentView: View {
     @Binding var pendingFolderWatchScope: ReaderFolderWatchScope
     @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
 
-    @StateObject private var splitScrollCoordinator = SplitScrollCoordinator()
-    @State private var dropTargeting = DropTargetingCoordinator()
-    @State private var previewMode: PreviewMode = .web
-    @State private var previewReloadToken = 0
-    @State private var sourceMode: SourceMode = .web
-    @State private var sourceReloadToken = 0
-    @State private var changeNavigation = ChangedRegionNavigationCoordinator()
-    @State private var sourceHTMLCache = SourceHTMLDocumentCache()
+    // MARK: - Internal: accessible to factory extension in ContentViewConfigurationFactory.swift
+    // These properties must be at least `internal` because Swift extensions in separate files
+    // cannot see `private` members.
+
+    @StateObject var splitScrollCoordinator = SplitScrollCoordinator()
+    @State var dropTargeting = DropTargetingCoordinator()
+    @State var previewMode: PreviewMode = .web
+    @State var previewReloadToken = 0
+    @State var sourceMode: SourceMode = .web
+    @State var sourceReloadToken = 0
+    @State var changeNavigation = ChangedRegionNavigationCoordinator()
+    @State var sourceHTMLCache = SourceHTMLDocumentCache()
 
     var body: some View {
         baseBody.modifier(ContentViewFocusedValues(
@@ -253,68 +257,12 @@ struct ContentView: View {
         readerStore.grantImageDirectoryAccess(folderURL: selectedURL)
     }
 
-    private func handleDroppedFileURLs(_ fileURLs: [URL]) {
-        if let droppedFolderURL = ReaderFileRouting.firstDroppedDirectoryURL(from: fileURLs) {
-            guard folderWatchState.activeFolderWatch == nil else {
-                return
-            }
-
-            callbacks.onRequestFolderWatch(droppedFolderURL)
-            return
-        }
-
-        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
-        guard !markdownURLs.isEmpty else {
-            return
-        }
-
-        let slotStrategy: FileOpenRequest.SlotStrategy =
-            readerStore.fileURL == nil ? .reuseEmptySlotForFirst : .alwaysAppend
-        callbacks.onRequestFileOpen(FileOpenRequest(
-            fileURLs: markdownURLs,
-            origin: .manual,
-            slotStrategy: slotStrategy
-        ))
-    }
-
-    private func handlePickedFileURLs(_ fileURLs: [URL]) {
-        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
-        guard !markdownURLs.isEmpty else {
-            return
-        }
-
-        let normalizedIncomingURL = ReaderFileRouting.normalizedFileURL(markdownURLs[0])
-        let currentURL = readerStore.fileURL.map(ReaderFileRouting.normalizedFileURL)
-        if readerStore.hasUnsavedDraftChanges,
-           currentURL != normalizedIncomingURL {
-            readerStore.presentError(ReaderError.unsavedDraftRequiresResolution)
-            return
-        }
-
-        callbacks.onRequestFileOpen(FileOpenRequest(
-            fileURLs: [markdownURLs[0]],
-            origin: .manual,
-            slotStrategy: .replaceSelectedSlot
-        ))
-
-        let additionalMarkdownURLs = Array(markdownURLs.dropFirst())
-        guard !additionalMarkdownURLs.isEmpty else {
-            return
-        }
-
-        callbacks.onRequestFileOpen(FileOpenRequest(
-            fileURLs: additionalMarkdownURLs,
-            origin: .manual,
-            slotStrategy: .alwaysAppend
-        ))
-    }
-
-    private var previewAccessibilityValue: String {
+    var previewAccessibilityValue: String {
         let fileName = readerStore.fileURL?.lastPathComponent ?? "none"
         return "file=\(fileName)|regions=\(readerStore.changedRegions.count)|mode=\(readerStore.documentViewMode.rawValue)|surface=preview"
     }
 
-    private var sourceAccessibilityValue: String {
+    var sourceAccessibilityValue: String {
         let fileName = readerStore.fileURL?.lastPathComponent ?? "none"
         return "file=\(fileName)|mode=\(readerStore.documentViewMode.rawValue)|surface=source"
     }
@@ -350,7 +298,7 @@ struct ContentView: View {
         readerStore.isCurrentFileMissing || readerStore.needsImageDirectoryAccess
     }
 
-    private var overlayInsets: ReaderOverlayInsetValues {
+    var overlayInsets: ReaderOverlayInsetValues {
         ReaderOverlayInsetCalculator.compute(
             topBarInset: overlayTopInset,
             hasStatusBanner: isStatusBannerVisible
@@ -370,54 +318,60 @@ struct ContentView: View {
                     tocOverlay(buttonAnchor: anchor)
                 }
             }
-            .overlay(alignment: .topLeading) {
-                if canNavigateChangedRegions {
-                    ChangeNavigationPill(
-                        currentIndex: changeNavigation.currentIndex,
-                        totalCount: readerStore.changedRegions.count,
-                        onNavigate: { direction in
-                            changeNavigation.requestNavigation(direction)
-                            splitScrollCoordinator.suppressPreviewBounceBack()
-                        }
-                    )
-                    .firstUseHint(.changeNavigation, message: "Use the arrows to step through changes", settingsStore: settingsStore)
-                    .padding(.top, overlayInsets.leadingOverlayTopPadding)
-                    .padding(.leading, 8)
-                    .environment(\.colorScheme, overlayColorScheme)
-                    .transition(.asymmetric(
-                        insertion: .opacity.combined(with: .move(edge: .top)),
-                        removal: .opacity
-                    ))
-                }
-            }
+            .overlay(alignment: .topLeading) { changeNavigationOverlay }
             .animation(.easeOut(duration: 0.25), value: canNavigateChangedRegions)
-            .overlay(alignment: .top) {
-                if let activeWatch = folderWatchState.activeFolderWatch {
-                    WatchPill(
-                        activeFolderWatch: activeWatch,
-                        isCurrentWatchAFavorite: folderWatchState.isCurrentWatchAFavorite,
-                        canStop: folderWatchState.canStopFolderWatch,
-                        onStop: callbacks.onStopFolderWatch,
-                        onSaveFavorite: callbacks.onSaveFolderWatchAsFavorite,
-                        onRemoveFavorite: callbacks.onRemoveCurrentWatchFromFavorites,
-                        onRevealInFinder: {
-                            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: activeWatch.folderURL.path)
-                        },
-                        isAppearanceLocked: folderWatchState.isAppearanceLocked,
-                        onToggleAppearanceLock: callbacks.onToggleAppearanceLock,
-                        onEditSubfolders: callbacks.onEditSubfolders
-                    )
-                    .padding(.top, overlayInsets.leadingOverlayTopPadding)
-                    .padding(.leading, canNavigateChangedRegions ? 150 : 60)
-                    .padding(.trailing, 70)
-                    .environment(\.colorScheme, overlayColorScheme)
-                    .transition(.asymmetric(
-                        insertion: .opacity.combined(with: .move(edge: .top)),
-                        removal: .opacity
-                    ))
-                }
-            }
+            .overlay(alignment: .top) { watchPillOverlay }
             .animation(.easeOut(duration: 0.25), value: folderWatchState.activeFolderWatch != nil)
+    }
+
+    @ViewBuilder
+    private var changeNavigationOverlay: some View {
+        if canNavigateChangedRegions {
+            ChangeNavigationPill(
+                currentIndex: changeNavigation.currentIndex,
+                totalCount: readerStore.changedRegions.count,
+                onNavigate: { direction in
+                    changeNavigation.requestNavigation(direction)
+                    splitScrollCoordinator.suppressPreviewBounceBack()
+                }
+            )
+            .firstUseHint(.changeNavigation, message: "Use the arrows to step through changes", settingsStore: settingsStore)
+            .padding(.top, overlayInsets.leadingOverlayTopPadding)
+            .padding(.leading, 8)
+            .environment(\.colorScheme, overlayColorScheme)
+            .transition(.asymmetric(
+                insertion: .opacity.combined(with: .move(edge: .top)),
+                removal: .opacity
+            ))
+        }
+    }
+
+    @ViewBuilder
+    private var watchPillOverlay: some View {
+        if let activeWatch = folderWatchState.activeFolderWatch {
+            WatchPill(
+                activeFolderWatch: activeWatch,
+                isCurrentWatchAFavorite: folderWatchState.isCurrentWatchAFavorite,
+                canStop: folderWatchState.canStopFolderWatch,
+                onStop: callbacks.onStopFolderWatch,
+                onSaveFavorite: callbacks.onSaveFolderWatchAsFavorite,
+                onRemoveFavorite: callbacks.onRemoveCurrentWatchFromFavorites,
+                onRevealInFinder: {
+                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: activeWatch.folderURL.path)
+                },
+                isAppearanceLocked: folderWatchState.isAppearanceLocked,
+                onToggleAppearanceLock: callbacks.onToggleAppearanceLock,
+                onEditSubfolders: callbacks.onEditSubfolders
+            )
+            .padding(.top, overlayInsets.leadingOverlayTopPadding)
+            .padding(.leading, canNavigateChangedRegions ? 150 : 60)
+            .padding(.trailing, 70)
+            .environment(\.colorScheme, overlayColorScheme)
+            .transition(.asymmetric(
+                insertion: .opacity.combined(with: .move(edge: .top)),
+                removal: .opacity
+            ))
+        }
     }
 
     private var contentUtilityRail: some View {
@@ -477,7 +431,7 @@ struct ContentView: View {
         readerStore.scrollToTOCHeading(heading)
     }
 
-    private var canNavigateChangedRegions: Bool {
+    var canNavigateChangedRegions: Bool {
         readerStore.documentViewMode != .source &&
             previewMode == .web &&
             !readerStore.changedRegions.isEmpty
@@ -488,7 +442,7 @@ struct ContentView: View {
             (readerStore.documentViewMode != .preview || readerStore.isSourceEditing)
     }
 
-    private var canSynchronizeSplitScroll: Bool {
+    var canSynchronizeSplitScroll: Bool {
         readerStore.documentViewMode == .split &&
             previewMode == .web &&
             sourceMode == .web
@@ -527,167 +481,8 @@ struct ContentView: View {
         }
     }
 
-    private var minimumSurfaceWidth: CGFloat? {
+    var minimumSurfaceWidth: CGFloat? {
         readerStore.documentViewMode == .split ? Metrics.splitPaneMinimumWidth : nil
-    }
-
-    private func documentSurfacePane(for surface: DocumentSurfaceRole) -> some View {
-        DocumentSurfaceHost(
-            configuration: documentSurfaceConfiguration(for: surface),
-            fallbackMarkdown: readerStore.sourceMarkdown
-        )
-    }
-
-    private func documentSurfaceConfiguration(for surface: DocumentSurfaceRole) -> DocumentSurfaceConfiguration {
-        switch surface {
-        case .preview:
-            return DocumentSurfaceConfiguration(
-                role: surface,
-                usesWebSurface: previewMode == .web,
-                htmlDocument: readerStore.renderedHTMLDocument,
-                documentIdentity: readerStore.fileURL?.standardizedFileURL.path,
-                accessibilityIdentifier: "reader-preview",
-                accessibilityValue: previewAccessibilityValue,
-                reloadToken: previewReloadToken,
-                diagnosticName: "reader-preview",
-                postLoadStatusScript: nil,
-                changedRegionNavigationRequest: canNavigateChangedRegions ? changeNavigation.currentRequest : nil,
-                scrollSyncRequest: splitScrollRequest(for: surface),
-                tocScrollRequest: readerStore.tocScrollRequest,
-                supportsInPlaceContentUpdates: true,
-                overlayTopInset: overlayInsets.scrollTargetTopInset,
-                reloadAnchorProgress: previewReloadAnchorProgress,
-                minimumWidth: minimumSurfaceWidth,
-                canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onAction: { action in
-                    switch action {
-                    case .fatalCrash:
-                        Self.logger.error("preview web surface hit fatal crash and fell back to native text")
-                        previewMode = .nativeFallback
-                    case .postLoadStatus:
-                        break
-                    case .scrollSyncObservation(let observation):
-                        handleScrollSyncObservation(observation, from: .preview)
-                    case .sourceEdit:
-                        break
-                    case .tocHeadingsExtracted(let headings):
-                        readerStore.updateTOCHeadings(headings)
-                    case .droppedFileURLs(let urls):
-                        handleDroppedFileURLs(urls)
-                    case .dropTargetedChange(let update):
-                        dropTargeting.update(for: .preview, update: update)
-                    case .changedRegionNavigationResult(let index, let total):
-                        changeNavigation.handleNavigationResult(index: index, total: total)
-                    case .retryFallback:
-                        previewReloadToken += 1
-                        previewMode = .web
-                    }
-                }
-            )
-        case .source:
-            return DocumentSurfaceConfiguration(
-                role: surface,
-                usesWebSurface: sourceMode == .web,
-                htmlDocument: sourceHTMLCache.document,
-                documentIdentity: sourceDocumentIdentity,
-                accessibilityIdentifier: "reader-source",
-                accessibilityValue: sourceAccessibilityValue,
-                reloadToken: sourceReloadToken,
-                diagnosticName: "reader-source",
-                postLoadStatusScript: "window.__minimarkSourceBootstrapStatus || null",
-                changedRegionNavigationRequest: nil,
-                scrollSyncRequest: splitScrollRequest(for: surface),
-                tocScrollRequest: readerStore.tocScrollRequest,
-                supportsInPlaceContentUpdates: false,
-                overlayTopInset: overlayInsets.scrollTargetTopInset,
-                reloadAnchorProgress: nil,
-                minimumWidth: minimumSurfaceWidth,
-                canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onAction: { action in
-                    switch action {
-                    case .fatalCrash:
-                        Self.logger.error("source web surface hit fatal crash and fell back to plain text")
-                        sourceMode = .plainTextFallback
-                    case .postLoadStatus(let status):
-                        guard let status else {
-                            Self.logger.error("source post-load status probe returned no status")
-                            sourceMode = .plainTextFallback
-                            return
-                        }
-                        guard status == "ready" else {
-                            Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
-                            sourceMode = .plainTextFallback
-                            return
-                        }
-                        Self.logger.debug("source bootstrap completed successfully")
-                    case .scrollSyncObservation(let observation):
-                        handleScrollSyncObservation(observation, from: .source)
-                    case .sourceEdit(let markdown):
-                        readerStore.updateSourceDraft(markdown)
-                    case .tocHeadingsExtracted(let headings):
-                        readerStore.updateTOCHeadings(headings)
-                    case .droppedFileURLs(let urls):
-                        handleDroppedFileURLs(urls)
-                    case .dropTargetedChange(let update):
-                        dropTargeting.update(for: .source, update: update)
-                    case .changedRegionNavigationResult:
-                        break
-                    case .retryFallback:
-                        sourceReloadToken += 1
-                        sourceMode = .web
-                    }
-                }
-            )
-        }
-    }
-
-    private var sourceDocumentIdentity: String? {
-        guard let path = readerStore.fileURL?.standardizedFileURL.path else {
-            return nil
-        }
-
-        return "\(path)|source"
-    }
-
-
-    private func refreshSourceHTML() {
-        sourceHTMLCache.refreshIfNeeded(
-            markdown: readerStore.sourceEditorSeedMarkdown,
-            settings: readerStore.currentSettings,
-            isEditable: readerStore.isSourceEditing
-        )
-    }
-
-    private func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {
-        !ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs) || folderWatchState.activeFolderWatch == nil
-    }
-
-    private func splitScrollRequest(for surface: DocumentSurfaceRole) -> ScrollSyncRequest? {
-        guard canSynchronizeSplitScroll else {
-            return nil
-        }
-
-        return splitScrollCoordinator.request(for: surface)
-    }
-
-    private var previewReloadAnchorProgress: Double? {
-        guard canSynchronizeSplitScroll,
-              readerStore.isSourceEditing else {
-            return nil
-        }
-
-        return splitScrollCoordinator.latestObservedProgress(for: .source)
-    }
-
-    private func handleScrollSyncObservation(
-        _ observation: ScrollSyncObservation,
-        from surface: DocumentSurfaceRole
-    ) {
-        splitScrollCoordinator.handleObservation(
-            observation,
-            from: surface,
-            shouldSync: canSynchronizeSplitScroll
-        )
     }
 
     private var isUITestModeEnabled: Bool {
@@ -695,7 +490,7 @@ struct ContentView: View {
     }
 }
 
-private struct DocumentSurfaceHost: View {
+struct DocumentSurfaceHost: View {
     let configuration: DocumentSurfaceConfiguration
     let fallbackMarkdown: String
 
@@ -831,7 +626,7 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
 }
 
 @MainActor
-private final class SplitScrollCoordinator: ObservableObject {
+final class SplitScrollCoordinator: ObservableObject {
     @Published private var previewRequest: ScrollSyncRequest?
     @Published private var sourceRequest: ScrollSyncRequest?
 

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -19,49 +19,6 @@ struct ContentView: View {
         case plainTextFallback
     }
 
-    enum DocumentSurfaceRole: Hashable {
-        case preview
-        case source
-
-        var counterpart: DocumentSurfaceRole {
-            switch self {
-            case .preview:
-                return .source
-            case .source:
-                return .preview
-            }
-        }
-    }
-
-    fileprivate struct DocumentSurfaceConfiguration {
-        let role: DocumentSurfaceRole
-        let usesWebSurface: Bool
-        let htmlDocument: String
-        let documentIdentity: String?
-        let accessibilityIdentifier: String
-        let accessibilityValue: String
-        let reloadToken: Int
-        let diagnosticName: String
-        let postLoadStatusScript: String?
-        let changedRegionNavigationRequest: ChangedRegionNavigationRequest?
-        let scrollSyncRequest: ScrollSyncRequest?
-        let tocScrollRequest: TOCScrollRequest?
-        let supportsInPlaceContentUpdates: Bool
-        let overlayTopInset: CGFloat
-        let reloadAnchorProgress: Double?
-        let minimumWidth: CGFloat?
-        let onFatalCrash: () -> Void
-        let onPostLoadStatus: (String?) -> Void
-        let onScrollSyncObservation: (ScrollSyncObservation) -> Void
-        let onSourceEdit: (String) -> Void
-        let onTOCHeadingsExtracted: ([TOCHeading]) -> Void
-        let onDroppedFileURLs: ([URL]) -> Void
-        let onDropTargetedChange: (DropTargetingUpdate) -> Void
-        let canAcceptDroppedFileURLs: ([URL]) -> Bool
-        let onChangedRegionNavigationResult: (Int, Int) -> Void
-        let onRetryFallback: () -> Void
-    }
-
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
         category: "ContentView"
@@ -737,29 +694,30 @@ struct ContentView: View {
                 overlayTopInset: overlayInsets.scrollTargetTopInset,
                 reloadAnchorProgress: previewReloadAnchorProgress,
                 minimumWidth: minimumSurfaceWidth,
-                onFatalCrash: {
-                    Self.logger.error("preview web surface hit fatal crash and fell back to native text")
-                    previewMode = .nativeFallback
-                },
-                onPostLoadStatus: { _ in },
-                onScrollSyncObservation: { observation in
-                    handleScrollSyncObservation(observation, from: surface)
-                },
-                onSourceEdit: { _ in },
-                onTOCHeadingsExtracted: { headings in
-                    readerStore.updateTOCHeadings(headings)
-                },
-                onDroppedFileURLs: handleDroppedFileURLs,
-                onDropTargetedChange: { update in
-                    dropTargeting.update(for: surface, update: update)
-                },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onChangedRegionNavigationResult: { index, total in
-                    changeNavigation.handleNavigationResult(index: index, total: total)
-                },
-                onRetryFallback: {
-                    previewReloadToken += 1
-                    previewMode = .web
+                onAction: { action in
+                    switch action {
+                    case .fatalCrash:
+                        Self.logger.error("preview web surface hit fatal crash and fell back to native text")
+                        previewMode = .nativeFallback
+                    case .postLoadStatus:
+                        break
+                    case .scrollSyncObservation(let observation):
+                        handleScrollSyncObservation(observation, from: .preview)
+                    case .sourceEdit:
+                        break
+                    case .tocHeadingsExtracted(let headings):
+                        readerStore.updateTOCHeadings(headings)
+                    case .droppedFileURLs(let urls):
+                        handleDroppedFileURLs(urls)
+                    case .dropTargetedChange(let update):
+                        dropTargeting.update(for: .preview, update: update)
+                    case .changedRegionNavigationResult(let index, let total):
+                        changeNavigation.handleNavigationResult(index: index, total: total)
+                    case .retryFallback:
+                        previewReloadToken += 1
+                        previewMode = .web
+                    }
                 }
             )
         case .source:
@@ -780,41 +738,40 @@ struct ContentView: View {
                 overlayTopInset: overlayInsets.scrollTargetTopInset,
                 reloadAnchorProgress: nil,
                 minimumWidth: minimumSurfaceWidth,
-                onFatalCrash: {
-                    Self.logger.error("source web surface hit fatal crash and fell back to plain text")
-                    sourceMode = .plainTextFallback
-                },
-                onPostLoadStatus: { status in
-                    guard let status else {
-                        Self.logger.error("source post-load status probe returned no status")
-                        sourceMode = .plainTextFallback
-                        return
-                    }
-                    guard status == "ready" else {
-                        Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
-                        sourceMode = .plainTextFallback
-                        return
-                    }
-                    Self.logger.debug("source bootstrap completed successfully")
-                },
-                onScrollSyncObservation: { observation in
-                    handleScrollSyncObservation(observation, from: surface)
-                },
-                onSourceEdit: { markdown in
-                    readerStore.updateSourceDraft(markdown)
-                },
-                onTOCHeadingsExtracted: { headings in
-                    readerStore.updateTOCHeadings(headings)
-                },
-                onDroppedFileURLs: handleDroppedFileURLs,
-                onDropTargetedChange: { update in
-                    dropTargeting.update(for: surface, update: update)
-                },
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onChangedRegionNavigationResult: { _, _ in },
-                onRetryFallback: {
-                    sourceReloadToken += 1
-                    sourceMode = .web
+                onAction: { action in
+                    switch action {
+                    case .fatalCrash:
+                        Self.logger.error("source web surface hit fatal crash and fell back to plain text")
+                        sourceMode = .plainTextFallback
+                    case .postLoadStatus(let status):
+                        guard let status else {
+                            Self.logger.error("source post-load status probe returned no status")
+                            sourceMode = .plainTextFallback
+                            return
+                        }
+                        guard status == "ready" else {
+                            Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
+                            sourceMode = .plainTextFallback
+                            return
+                        }
+                        Self.logger.debug("source bootstrap completed successfully")
+                    case .scrollSyncObservation(let observation):
+                        handleScrollSyncObservation(observation, from: .source)
+                    case .sourceEdit(let markdown):
+                        readerStore.updateSourceDraft(markdown)
+                    case .tocHeadingsExtracted(let headings):
+                        readerStore.updateTOCHeadings(headings)
+                    case .droppedFileURLs(let urls):
+                        handleDroppedFileURLs(urls)
+                    case .dropTargetedChange(let update):
+                        dropTargeting.update(for: .source, update: update)
+                    case .changedRegionNavigationResult:
+                        break
+                    case .retryFallback:
+                        sourceReloadToken += 1
+                        sourceMode = .web
+                    }
                 }
             )
         }
@@ -875,7 +832,7 @@ struct ContentView: View {
 }
 
 private struct DocumentSurfaceHost: View {
-    let configuration: ContentView.DocumentSurfaceConfiguration
+    let configuration: DocumentSurfaceConfiguration
     let fallbackMarkdown: String
 
     var body: some View {
@@ -895,15 +852,15 @@ private struct DocumentSurfaceHost: View {
                     supportsInPlaceContentUpdates: configuration.supportsInPlaceContentUpdates,
                     overlayTopInset: configuration.overlayTopInset,
                     reloadAnchorProgress: configuration.reloadAnchorProgress,
-                    onFatalCrash: configuration.onFatalCrash,
-                    onPostLoadStatus: configuration.onPostLoadStatus,
-                    onScrollSyncObservation: configuration.onScrollSyncObservation,
-                    onSourceEdit: configuration.onSourceEdit,
-                    onTOCHeadingsExtracted: configuration.onTOCHeadingsExtracted,
-                    onDroppedFileURLs: configuration.onDroppedFileURLs,
-                    onDropTargetedChange: configuration.onDropTargetedChange,
+                    onFatalCrash: { configuration.onAction(.fatalCrash) },
+                    onPostLoadStatus: { status in configuration.onAction(.postLoadStatus(status)) },
+                    onScrollSyncObservation: { obs in configuration.onAction(.scrollSyncObservation(obs)) },
+                    onSourceEdit: { md in configuration.onAction(.sourceEdit(md)) },
+                    onTOCHeadingsExtracted: { headings in configuration.onAction(.tocHeadingsExtracted(headings)) },
+                    onDroppedFileURLs: { urls in configuration.onAction(.droppedFileURLs(urls)) },
+                    onDropTargetedChange: { update in configuration.onAction(.dropTargetedChange(update)) },
                     canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs,
-                    onChangedRegionNavigationResult: configuration.onChangedRegionNavigationResult
+                    onChangedRegionNavigationResult: { index, total in configuration.onAction(.changedRegionNavigationResult(index: index, total: total)) }
                 )
             } else {
                 fallbackSurface
@@ -919,12 +876,12 @@ private struct DocumentSurfaceHost: View {
         case .preview:
             NativeMarkdownFallbackView(
                 markdown: fallbackMarkdown,
-                onRetryPreview: configuration.onRetryFallback
+                onRetryPreview: { configuration.onAction(.retryFallback) }
             )
         case .source:
             MarkdownSourceFallbackView(
                 markdown: fallbackMarkdown,
-                onRetryHighlighting: configuration.onRetryFallback
+                onRetryHighlighting: { configuration.onAction(.retryFallback) }
             )
         }
     }
@@ -1015,11 +972,11 @@ private final class SplitScrollCoordinator: ObservableObject {
     @Published private var sourceRequest: ScrollSyncRequest?
 
     private var nextRequestID = 0
-    private var lastRequestedProgressByRole: [ContentView.DocumentSurfaceRole: Double] = [:]
-    private var lastObservedProgressByRole: [ContentView.DocumentSurfaceRole: Double] = [:]
+    private var lastRequestedProgressByRole: [DocumentSurfaceRole: Double] = [:]
+    private var lastObservedProgressByRole: [DocumentSurfaceRole: Double] = [:]
     private var previewBounceBackSuppressedUntil: Date?
 
-    func request(for role: ContentView.DocumentSurfaceRole) -> ScrollSyncRequest? {
+    func request(for role: DocumentSurfaceRole) -> ScrollSyncRequest? {
         switch role {
         case .preview:
             return previewRequest
@@ -1038,7 +995,7 @@ private final class SplitScrollCoordinator: ObservableObject {
 
     func handleObservation(
         _ observation: ScrollSyncObservation,
-        from role: ContentView.DocumentSurfaceRole,
+        from role: DocumentSurfaceRole,
         shouldSync: Bool
     ) {
         lastObservedProgressByRole[role] = observation.progress
@@ -1072,7 +1029,7 @@ private final class SplitScrollCoordinator: ObservableObject {
         }
     }
 
-    func latestObservedProgress(for role: ContentView.DocumentSurfaceRole) -> Double? {
+    func latestObservedProgress(for role: DocumentSurfaceRole) -> Double? {
         lastObservedProgressByRole[role]
     }
 

--- a/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
+++ b/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct ChangedRegionNavigationCoordinator {
+    private var requestID = 0
+    private var lastDirection: ReaderChangedRegionNavigationDirection?
+    private(set) var currentIndex: Int?
+
+    var currentRequest: ChangedRegionNavigationRequest? {
+        guard let lastDirection else { return nil }
+        return ChangedRegionNavigationRequest(id: requestID, direction: lastDirection)
+    }
+
+    mutating func requestNavigation(_ direction: ReaderChangedRegionNavigationDirection) {
+        lastDirection = direction
+        requestID += 1
+    }
+
+    mutating func handleNavigationResult(index: Int, total: Int) {
+        currentIndex = index
+    }
+
+    /// Called when changedRegions changes -- clears the current index but
+    /// preserves the last direction so in-progress navigation stays coherent.
+    mutating func resetForNewRegions() {
+        currentIndex = nil
+    }
+
+    /// Full reset -- called on file identity change or scroll coordinator reset.
+    mutating func reset() {
+        requestID = 0
+        lastDirection = nil
+        currentIndex = nil
+    }
+}

--- a/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
+++ b/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
@@ -15,7 +15,7 @@ struct ChangedRegionNavigationCoordinator {
         requestID += 1
     }
 
-    mutating func handleNavigationResult(index: Int, total: Int) {
+    mutating func handleNavigationResult(index: Int) {
         currentIndex = index
     }
 

--- a/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
+++ b/minimark/Views/Content/ChangedRegionNavigationCoordinator.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct ChangedRegionNavigationCoordinator {
     private var requestID = 0
     private var lastDirection: ReaderChangedRegionNavigationDirection?

--- a/minimark/Views/Content/ContentViewConfigurationFactory.swift
+++ b/minimark/Views/Content/ContentViewConfigurationFactory.swift
@@ -1,0 +1,230 @@
+import AppKit
+import OSLog
+import SwiftUI
+
+/// Document surface configuration builders, file drop/pick handlers, and scroll sync wiring.
+/// Split out from ContentView to keep that struct focused on layout and overlay composition.
+extension ContentView {
+
+    // MARK: - Document surface panes
+
+    func documentSurfacePane(for surface: DocumentSurfaceRole) -> some View {
+        DocumentSurfaceHost(
+            configuration: documentSurfaceConfiguration(for: surface),
+            fallbackMarkdown: readerStore.sourceMarkdown
+        )
+    }
+
+    func documentSurfaceConfiguration(for surface: DocumentSurfaceRole) -> DocumentSurfaceConfiguration {
+        switch surface {
+        case .preview:
+            return DocumentSurfaceConfiguration(
+                role: surface,
+                usesWebSurface: previewMode == .web,
+                htmlDocument: readerStore.renderedHTMLDocument,
+                documentIdentity: readerStore.fileURL?.standardizedFileURL.path,
+                accessibilityIdentifier: "reader-preview",
+                accessibilityValue: previewAccessibilityValue,
+                reloadToken: previewReloadToken,
+                diagnosticName: "reader-preview",
+                postLoadStatusScript: nil,
+                changedRegionNavigationRequest: canNavigateChangedRegions ? changeNavigation.currentRequest : nil,
+                scrollSyncRequest: splitScrollRequest(for: surface),
+                tocScrollRequest: readerStore.tocScrollRequest,
+                supportsInPlaceContentUpdates: true,
+                overlayTopInset: overlayInsets.scrollTargetTopInset,
+                reloadAnchorProgress: previewReloadAnchorProgress,
+                minimumWidth: minimumSurfaceWidth,
+                canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
+                onAction: { action in
+                    switch action {
+                    case .fatalCrash:
+                        Self.logger.error("preview web surface hit fatal crash and fell back to native text")
+                        previewMode = .nativeFallback
+                    case .postLoadStatus:
+                        break
+                    case .scrollSyncObservation(let observation):
+                        handleScrollSyncObservation(observation, from: .preview)
+                    case .sourceEdit:
+                        break
+                    case .tocHeadingsExtracted(let headings):
+                        readerStore.updateTOCHeadings(headings)
+                    case .droppedFileURLs(let urls):
+                        handleDroppedFileURLs(urls)
+                    case .dropTargetedChange(let update):
+                        dropTargeting.update(for: .preview, update: update)
+                    case .changedRegionNavigationResult(let index, let total):
+                        changeNavigation.handleNavigationResult(index: index, total: total)
+                    case .retryFallback:
+                        previewReloadToken += 1
+                        previewMode = .web
+                    }
+                }
+            )
+        case .source:
+            return DocumentSurfaceConfiguration(
+                role: surface,
+                usesWebSurface: sourceMode == .web,
+                htmlDocument: sourceHTMLCache.document,
+                documentIdentity: sourceDocumentIdentity,
+                accessibilityIdentifier: "reader-source",
+                accessibilityValue: sourceAccessibilityValue,
+                reloadToken: sourceReloadToken,
+                diagnosticName: "reader-source",
+                postLoadStatusScript: "window.__minimarkSourceBootstrapStatus || null",
+                changedRegionNavigationRequest: nil,
+                scrollSyncRequest: splitScrollRequest(for: surface),
+                tocScrollRequest: readerStore.tocScrollRequest,
+                supportsInPlaceContentUpdates: false,
+                overlayTopInset: overlayInsets.scrollTargetTopInset,
+                reloadAnchorProgress: nil,
+                minimumWidth: minimumSurfaceWidth,
+                canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
+                onAction: { action in
+                    switch action {
+                    case .fatalCrash:
+                        Self.logger.error("source web surface hit fatal crash and fell back to plain text")
+                        sourceMode = .plainTextFallback
+                    case .postLoadStatus(let status):
+                        guard let status else {
+                            Self.logger.error("source post-load status probe returned no status")
+                            sourceMode = .plainTextFallback
+                            return
+                        }
+                        guard status == "ready" else {
+                            Self.logger.error("source bootstrap status was \(status, privacy: .public); falling back to plain text")
+                            sourceMode = .plainTextFallback
+                            return
+                        }
+                        Self.logger.debug("source bootstrap completed successfully")
+                    case .scrollSyncObservation(let observation):
+                        handleScrollSyncObservation(observation, from: .source)
+                    case .sourceEdit(let markdown):
+                        readerStore.updateSourceDraft(markdown)
+                    case .tocHeadingsExtracted(let headings):
+                        readerStore.updateTOCHeadings(headings)
+                    case .droppedFileURLs(let urls):
+                        handleDroppedFileURLs(urls)
+                    case .dropTargetedChange(let update):
+                        dropTargeting.update(for: .source, update: update)
+                    case .changedRegionNavigationResult:
+                        break
+                    case .retryFallback:
+                        sourceReloadToken += 1
+                        sourceMode = .web
+                    }
+                }
+            )
+        }
+    }
+
+    // MARK: - Source document identity and HTML refresh
+
+    var sourceDocumentIdentity: String? {
+        guard let path = readerStore.fileURL?.standardizedFileURL.path else {
+            return nil
+        }
+
+        return "\(path)|source"
+    }
+
+    func refreshSourceHTML() {
+        sourceHTMLCache.refreshIfNeeded(
+            markdown: readerStore.sourceEditorSeedMarkdown,
+            settings: readerStore.currentSettings,
+            isEditable: readerStore.isSourceEditing
+        )
+    }
+
+    // MARK: - File drop and pick handlers
+
+    func handleDroppedFileURLs(_ fileURLs: [URL]) {
+        if let droppedFolderURL = ReaderFileRouting.firstDroppedDirectoryURL(from: fileURLs) {
+            guard folderWatchState.activeFolderWatch == nil else {
+                return
+            }
+
+            callbacks.onRequestFolderWatch(droppedFolderURL)
+            return
+        }
+
+        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
+        guard !markdownURLs.isEmpty else {
+            return
+        }
+
+        let slotStrategy: FileOpenRequest.SlotStrategy =
+            readerStore.fileURL == nil ? .reuseEmptySlotForFirst : .alwaysAppend
+        callbacks.onRequestFileOpen(FileOpenRequest(
+            fileURLs: markdownURLs,
+            origin: .manual,
+            slotStrategy: slotStrategy
+        ))
+    }
+
+    func handlePickedFileURLs(_ fileURLs: [URL]) {
+        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
+        guard !markdownURLs.isEmpty else {
+            return
+        }
+
+        let normalizedIncomingURL = ReaderFileRouting.normalizedFileURL(markdownURLs[0])
+        let currentURL = readerStore.fileURL.map(ReaderFileRouting.normalizedFileURL)
+        if readerStore.hasUnsavedDraftChanges,
+           currentURL != normalizedIncomingURL {
+            readerStore.presentError(ReaderError.unsavedDraftRequiresResolution)
+            return
+        }
+
+        callbacks.onRequestFileOpen(FileOpenRequest(
+            fileURLs: [markdownURLs[0]],
+            origin: .manual,
+            slotStrategy: .replaceSelectedSlot
+        ))
+
+        let additionalMarkdownURLs = Array(markdownURLs.dropFirst())
+        guard !additionalMarkdownURLs.isEmpty else {
+            return
+        }
+
+        callbacks.onRequestFileOpen(FileOpenRequest(
+            fileURLs: additionalMarkdownURLs,
+            origin: .manual,
+            slotStrategy: .alwaysAppend
+        ))
+    }
+
+    func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {
+        !ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs) || folderWatchState.activeFolderWatch == nil
+    }
+
+    // MARK: - Scroll sync wiring
+
+    func splitScrollRequest(for surface: DocumentSurfaceRole) -> ScrollSyncRequest? {
+        guard canSynchronizeSplitScroll else {
+            return nil
+        }
+
+        return splitScrollCoordinator.request(for: surface)
+    }
+
+    var previewReloadAnchorProgress: Double? {
+        guard canSynchronizeSplitScroll,
+              readerStore.isSourceEditing else {
+            return nil
+        }
+
+        return splitScrollCoordinator.latestObservedProgress(for: .source)
+    }
+
+    func handleScrollSyncObservation(
+        _ observation: ScrollSyncObservation,
+        from surface: DocumentSurfaceRole
+    ) {
+        splitScrollCoordinator.handleObservation(
+            observation,
+            from: surface,
+            shouldSync: canSynchronizeSplitScroll
+        )
+    }
+}

--- a/minimark/Views/Content/ContentViewConfigurationFactory.swift
+++ b/minimark/Views/Content/ContentViewConfigurationFactory.swift
@@ -1,4 +1,3 @@
-import AppKit
 import OSLog
 import SwiftUI
 

--- a/minimark/Views/Content/ContentViewConfigurationFactory.swift
+++ b/minimark/Views/Content/ContentViewConfigurationFactory.swift
@@ -37,27 +37,18 @@ extension ContentView {
                 minimumWidth: minimumSurfaceWidth,
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
                 onAction: { action in
+                    if handleSharedAction(action, for: .preview) { return }
                     switch action {
                     case .fatalCrash:
                         Self.logger.error("preview web surface hit fatal crash and fell back to native text")
                         previewMode = .nativeFallback
-                    case .postLoadStatus:
-                        break
-                    case .scrollSyncObservation(let observation):
-                        handleScrollSyncObservation(observation, from: .preview)
-                    case .sourceEdit:
-                        break
-                    case .tocHeadingsExtracted(let headings):
-                        readerStore.updateTOCHeadings(headings)
-                    case .droppedFileURLs(let urls):
-                        handleDroppedFileURLs(urls)
-                    case .dropTargetedChange(let update):
-                        dropTargeting.update(for: .preview, update: update)
-                    case .changedRegionNavigationResult(let index, let total):
-                        changeNavigation.handleNavigationResult(index: index, total: total)
+                    case .changedRegionNavigationResult(let index):
+                        changeNavigation.handleNavigationResult(index: index)
                     case .retryFallback:
                         previewReloadToken += 1
                         previewMode = .web
+                    default:
+                        break
                     }
                 }
             )
@@ -81,6 +72,7 @@ extension ContentView {
                 minimumWidth: minimumSurfaceWidth,
                 canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
                 onAction: { action in
+                    if handleSharedAction(action, for: .source) { return }
                     switch action {
                     case .fatalCrash:
                         Self.logger.error("source web surface hit fatal crash and fell back to plain text")
@@ -97,21 +89,13 @@ extension ContentView {
                             return
                         }
                         Self.logger.debug("source bootstrap completed successfully")
-                    case .scrollSyncObservation(let observation):
-                        handleScrollSyncObservation(observation, from: .source)
                     case .sourceEdit(let markdown):
                         readerStore.updateSourceDraft(markdown)
-                    case .tocHeadingsExtracted(let headings):
-                        readerStore.updateTOCHeadings(headings)
-                    case .droppedFileURLs(let urls):
-                        handleDroppedFileURLs(urls)
-                    case .dropTargetedChange(let update):
-                        dropTargeting.update(for: .source, update: update)
-                    case .changedRegionNavigationResult:
-                        break
                     case .retryFallback:
                         sourceReloadToken += 1
                         sourceMode = .web
+                    default:
+                        break
                     }
                 }
             )
@@ -134,6 +118,29 @@ extension ContentView {
             settings: readerStore.currentSettings,
             isEditable: readerStore.isSourceEditing
         )
+    }
+
+    // MARK: - Shared action handling
+
+    /// Handles action cases common to both preview and source surfaces.
+    /// Returns `true` if the action was handled.
+    func handleSharedAction(_ action: DocumentSurfaceAction, for surface: DocumentSurfaceRole) -> Bool {
+        switch action {
+        case .scrollSyncObservation(let observation):
+            handleScrollSyncObservation(observation, from: surface)
+            return true
+        case .tocHeadingsExtracted(let headings):
+            readerStore.updateTOCHeadings(headings)
+            return true
+        case .droppedFileURLs(let urls):
+            handleDroppedFileURLs(urls)
+            return true
+        case .dropTargetedChange(let update):
+            dropTargeting.update(for: surface, update: update)
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: - File drop and pick handlers

--- a/minimark/Views/Content/ContentViewFocusedValues.swift
+++ b/minimark/Views/Content/ContentViewFocusedValues.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ContentViewFocusedValues: ViewModifier {
-    var readerStore: ReaderStore
+    let readerStore: ReaderStore
     let folderWatchState: ContentViewFolderWatchState
     let callbacks: ContentViewCallbacks
     let canNavigateChangedRegions: Bool
@@ -10,6 +10,16 @@ struct ContentViewFocusedValues: ViewModifier {
     @Binding var pendingFolderWatchOpenMode: ReaderFolderWatchOpenMode
     @Binding var pendingFolderWatchScope: ReaderFolderWatchScope
     @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
+
+    private func openOrAppendDocument(_ fileURL: URL) {
+        let strategy: FileOpenRequest.SlotStrategy =
+            readerStore.fileURL == nil ? .replaceSelectedSlot : .alwaysAppend
+        callbacks.onRequestFileOpen(FileOpenRequest(
+            fileURLs: [fileURL],
+            origin: .manual,
+            slotStrategy: strategy
+        ))
+    }
 
     func body(content: Content) -> some View {
         content
@@ -31,39 +41,11 @@ struct ContentViewFocusedValues: ViewModifier {
             )
             .focusedValue(
                 \.readerOpenDocument,
-                ReaderOpenDocumentAction { fileURL in
-                    if readerStore.fileURL == nil {
-                        callbacks.onRequestFileOpen(FileOpenRequest(
-                            fileURLs: [fileURL],
-                            origin: .manual,
-                            slotStrategy: .replaceSelectedSlot
-                        ))
-                    } else {
-                        callbacks.onRequestFileOpen(FileOpenRequest(
-                            fileURLs: [fileURL],
-                            origin: .manual,
-                            slotStrategy: .alwaysAppend
-                        ))
-                    }
-                }
+                ReaderOpenDocumentAction { fileURL in openOrAppendDocument(fileURL) }
             )
             .focusedValue(
                 \.readerOpenAdditionalDocument,
-                ReaderOpenAdditionalDocumentAction { fileURL in
-                    if readerStore.fileURL == nil {
-                        callbacks.onRequestFileOpen(FileOpenRequest(
-                            fileURLs: [fileURL],
-                            origin: .manual,
-                            slotStrategy: .replaceSelectedSlot
-                        ))
-                    } else {
-                        callbacks.onRequestFileOpen(FileOpenRequest(
-                            fileURLs: [fileURL],
-                            origin: .manual,
-                            slotStrategy: .alwaysAppend
-                        ))
-                    }
-                }
+                ReaderOpenAdditionalDocumentAction { fileURL in openOrAppendDocument(fileURL) }
             )
             .focusedValue(
                 \.readerWatchFolder,

--- a/minimark/Views/Content/ContentViewFocusedValues.swift
+++ b/minimark/Views/Content/ContentViewFocusedValues.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+struct ContentViewFocusedValues: ViewModifier {
+    var readerStore: ReaderStore
+    let folderWatchState: ContentViewFolderWatchState
+    let callbacks: ContentViewCallbacks
+    let canNavigateChangedRegions: Bool
+    let onNavigateChangedRegion: (ReaderChangedRegionNavigationDirection) -> Void
+    @Binding var isFolderWatchOptionsPresented: Bool
+    @Binding var pendingFolderWatchOpenMode: ReaderFolderWatchOpenMode
+    @Binding var pendingFolderWatchScope: ReaderFolderWatchScope
+    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
+
+    func body(content: Content) -> some View {
+        content
+            .focusedValue(
+                \.readerOpenDocumentInCurrentWindow,
+                ReaderOpenDocumentInCurrentWindowAction { fileURL in
+                    let normalizedURL = ReaderFileRouting.normalizedFileURL(fileURL)
+                    let currentURL = readerStore.fileURL.map(ReaderFileRouting.normalizedFileURL)
+                    if readerStore.hasUnsavedDraftChanges, currentURL != normalizedURL {
+                        readerStore.presentError(ReaderError.unsavedDraftRequiresResolution)
+                        return
+                    }
+                    callbacks.onRequestFileOpen(FileOpenRequest(
+                        fileURLs: [fileURL],
+                        origin: .manual,
+                        slotStrategy: .replaceSelectedSlot
+                    ))
+                }
+            )
+            .focusedValue(
+                \.readerOpenDocument,
+                ReaderOpenDocumentAction { fileURL in
+                    if readerStore.fileURL == nil {
+                        callbacks.onRequestFileOpen(FileOpenRequest(
+                            fileURLs: [fileURL],
+                            origin: .manual,
+                            slotStrategy: .replaceSelectedSlot
+                        ))
+                    } else {
+                        callbacks.onRequestFileOpen(FileOpenRequest(
+                            fileURLs: [fileURL],
+                            origin: .manual,
+                            slotStrategy: .alwaysAppend
+                        ))
+                    }
+                }
+            )
+            .focusedValue(
+                \.readerOpenAdditionalDocument,
+                ReaderOpenAdditionalDocumentAction { fileURL in
+                    if readerStore.fileURL == nil {
+                        callbacks.onRequestFileOpen(FileOpenRequest(
+                            fileURLs: [fileURL],
+                            origin: .manual,
+                            slotStrategy: .replaceSelectedSlot
+                        ))
+                    } else {
+                        callbacks.onRequestFileOpen(FileOpenRequest(
+                            fileURLs: [fileURL],
+                            origin: .manual,
+                            slotStrategy: .alwaysAppend
+                        ))
+                    }
+                }
+            )
+            .focusedValue(
+                \.readerWatchFolder,
+                ReaderWatchFolderAction { folderURL in
+                    callbacks.onRequestFolderWatch(folderURL)
+                }
+            )
+            .focusedValue(
+                \.readerStartRecentFolderWatch,
+                ReaderStartRecentFolderWatchAction { entry in
+                    callbacks.onStartRecentFolderWatch(entry)
+                }
+            )
+            .focusedValue(
+                \.readerStopFolderWatch,
+                ReaderStopFolderWatchAction {
+                    guard folderWatchState.canStopFolderWatch else {
+                        return
+                    }
+                    callbacks.onStopFolderWatch()
+                }
+            )
+            .focusedValue(
+                \.readerHasActiveFolderWatch,
+                folderWatchState.canStopFolderWatch
+            )
+            .focusedValue(
+                \.readerDocumentViewModeContext,
+                ReaderDocumentViewModeContext(
+                    currentMode: readerStore.documentViewMode,
+                    canSetMode: readerStore.hasOpenDocument,
+                    setMode: { mode in
+                        readerStore.setDocumentViewMode(mode)
+                    },
+                    toggleMode: {
+                        readerStore.toggleDocumentViewMode()
+                    }
+                )
+            )
+            .focusedValue(
+                \.readerSourceEditingContext,
+                ReaderSourceEditingContext(
+                    canStartEditing: readerStore.canStartSourceEditing,
+                    canSave: readerStore.canSaveSourceDraft,
+                    canDiscard: readerStore.canDiscardSourceDraft,
+                    startEditing: {
+                        readerStore.startEditingSource()
+                    },
+                    save: {
+                        readerStore.saveSourceDraft()
+                    },
+                    discard: {
+                        readerStore.discardSourceDraft()
+                    }
+                )
+            )
+            .focusedValue(
+                \.readerChangedRegionNavigation,
+                ReaderChangedRegionNavigationAction(
+                    canNavigate: canNavigateChangedRegions,
+                    navigate: onNavigateChangedRegion
+                )
+            )
+            .focusedValue(
+                \.readerToggleTOC,
+                ReaderToggleTOCAction(
+                    canToggle: !readerStore.tocHeadings.isEmpty,
+                    toggle: { readerStore.toggleTOC() }
+                )
+            )
+            .onChange(of: isFolderWatchOptionsPresented) { _, isPresented in
+                guard !isPresented else { return }
+                callbacks.onCancelFolderWatch()
+            }
+            .sheet(isPresented: $isFolderWatchOptionsPresented) {
+                FolderWatchOptionsSheet(
+                    folderURL: folderWatchState.pendingFolderWatchURL,
+                    openMode: $pendingFolderWatchOpenMode,
+                    scope: $pendingFolderWatchScope,
+                    excludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths,
+                    onCancel: callbacks.onCancelFolderWatch,
+                    onConfirm: callbacks.onConfirmFolderWatch
+                )
+            }
+    }
+}

--- a/minimark/Views/Content/DocumentSurfaceAction.swift
+++ b/minimark/Views/Content/DocumentSurfaceAction.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum DocumentSurfaceAction {
+    case fatalCrash
+    case postLoadStatus(String?)
+    case scrollSyncObservation(ScrollSyncObservation)
+    case sourceEdit(String)
+    case tocHeadingsExtracted([TOCHeading])
+    case droppedFileURLs([URL])
+    case dropTargetedChange(DropTargetingUpdate)
+    case changedRegionNavigationResult(index: Int, total: Int)
+    case retryFallback
+}
+
+enum DocumentSurfaceRole: Hashable {
+    case preview
+    case source
+
+    var counterpart: DocumentSurfaceRole {
+        switch self {
+        case .preview:
+            return .source
+        case .source:
+            return .preview
+        }
+    }
+}
+
+struct DocumentSurfaceConfiguration {
+    let role: DocumentSurfaceRole
+    let usesWebSurface: Bool
+    let htmlDocument: String
+    let documentIdentity: String?
+    let accessibilityIdentifier: String
+    let accessibilityValue: String
+    let reloadToken: Int
+    let diagnosticName: String
+    let postLoadStatusScript: String?
+    let changedRegionNavigationRequest: ChangedRegionNavigationRequest?
+    let scrollSyncRequest: ScrollSyncRequest?
+    let tocScrollRequest: TOCScrollRequest?
+    let supportsInPlaceContentUpdates: Bool
+    let overlayTopInset: CGFloat
+    let reloadAnchorProgress: Double?
+    let minimumWidth: CGFloat?
+    let canAcceptDroppedFileURLs: ([URL]) -> Bool
+    let onAction: (DocumentSurfaceAction) -> Void
+}

--- a/minimark/Views/Content/DocumentSurfaceAction.swift
+++ b/minimark/Views/Content/DocumentSurfaceAction.swift
@@ -8,7 +8,7 @@ enum DocumentSurfaceAction {
     case tocHeadingsExtracted([TOCHeading])
     case droppedFileURLs([URL])
     case dropTargetedChange(DropTargetingUpdate)
-    case changedRegionNavigationResult(index: Int, total: Int)
+    case changedRegionNavigationResult(index: Int)
     case retryFallback
 }
 

--- a/minimark/Views/Content/DropTargetingCoordinator.swift
+++ b/minimark/Views/Content/DropTargetingCoordinator.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct DropTargetingCoordinator {
     private var dragTargetedSurfaces: Set<DocumentSurfaceRole> = []
     private var blockedFolderDropTargetedSurfaces: Set<DocumentSurfaceRole> = []

--- a/minimark/Views/Content/DropTargetingCoordinator.swift
+++ b/minimark/Views/Content/DropTargetingCoordinator.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 struct DropTargetingCoordinator {
-    private var dragTargetedSurfaces: Set<ContentView.DocumentSurfaceRole> = []
-    private var blockedFolderDropTargetedSurfaces: Set<ContentView.DocumentSurfaceRole> = []
+    private var dragTargetedSurfaces: Set<DocumentSurfaceRole> = []
+    private var blockedFolderDropTargetedSurfaces: Set<DocumentSurfaceRole> = []
 
     var isDragTargeted: Bool { !dragTargetedSurfaces.isEmpty }
     var isBlockedFolderDropTargeted: Bool { !blockedFolderDropTargetedSurfaces.isEmpty }
 
-    mutating func update(for surface: ContentView.DocumentSurfaceRole, update: DropTargetingUpdate) {
+    mutating func update(for surface: DocumentSurfaceRole, update: DropTargetingUpdate) {
         if update.isTargeted {
             dragTargetedSurfaces.insert(surface)
         } else {
@@ -22,7 +22,7 @@ struct DropTargetingCoordinator {
         }
     }
 
-    mutating func clear(for surface: ContentView.DocumentSurfaceRole) {
+    mutating func clear(for surface: DocumentSurfaceRole) {
         dragTargetedSurfaces.remove(surface)
         blockedFolderDropTargetedSurfaces.remove(surface)
     }

--- a/minimark/Views/Content/DropTargetingCoordinator.swift
+++ b/minimark/Views/Content/DropTargetingCoordinator.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct DropTargetingCoordinator {
+    private var dragTargetedSurfaces: Set<ContentView.DocumentSurfaceRole> = []
+    private var blockedFolderDropTargetedSurfaces: Set<ContentView.DocumentSurfaceRole> = []
+
+    var isDragTargeted: Bool { !dragTargetedSurfaces.isEmpty }
+    var isBlockedFolderDropTargeted: Bool { !blockedFolderDropTargetedSurfaces.isEmpty }
+
+    mutating func update(for surface: ContentView.DocumentSurfaceRole, update: DropTargetingUpdate) {
+        if update.isTargeted {
+            dragTargetedSurfaces.insert(surface)
+        } else {
+            dragTargetedSurfaces.remove(surface)
+        }
+
+        let isBlockedFolderDrop = update.isTargeted && !update.canDrop && update.containsDirectoryHint
+        if isBlockedFolderDrop {
+            blockedFolderDropTargetedSurfaces.insert(surface)
+        } else {
+            blockedFolderDropTargetedSurfaces.remove(surface)
+        }
+    }
+
+    mutating func clear(for surface: ContentView.DocumentSurfaceRole) {
+        dragTargetedSurfaces.remove(surface)
+        blockedFolderDropTargetedSurfaces.remove(surface)
+    }
+
+    mutating func clearAll() {
+        dragTargetedSurfaces.removeAll()
+        blockedFolderDropTargetedSurfaces.removeAll()
+    }
+}

--- a/minimark/Views/Content/SourceHTMLDocumentCache.swift
+++ b/minimark/Views/Content/SourceHTMLDocumentCache.swift
@@ -1,0 +1,28 @@
+//
+//  SourceHTMLDocumentCache.swift
+//  minimark
+//
+
+import Foundation
+
+struct SourceHTMLDocumentCache {
+    private struct Inputs: Equatable {
+        let markdown: String
+        let settings: ReaderSettings
+        let isEditable: Bool
+    }
+
+    private var lastInputs: Inputs?
+    private(set) var document: String = ""
+
+    mutating func refreshIfNeeded(markdown: String, settings: ReaderSettings, isEditable: Bool) {
+        let inputs = Inputs(markdown: markdown, settings: settings, isEditable: isEditable)
+        guard lastInputs != inputs else { return }
+        lastInputs = inputs
+        document = MarkdownSourceHTMLRenderer.makeHTMLDocument(
+            markdown: markdown,
+            settings: settings,
+            isEditable: isEditable
+        )
+    }
+}

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -24,15 +24,8 @@ struct MarkdownWebView: NSViewRepresentable {
     var supportsInPlaceContentUpdates: Bool = false
     var overlayTopInset: CGFloat = ReaderOverlayInsetCalculator.defaultScrollTargetTopInset
     var reloadAnchorProgress: Double?
-    var onFatalCrash: () -> Void = {}
-    var onPostLoadStatus: (String?) -> Void = { _ in }
-        var onScrollSyncObservation: (ScrollSyncObservation) -> Void = { _ in }
-    var onSourceEdit: (String) -> Void = { _ in }
-    var onTOCHeadingsExtracted: ([TOCHeading]) -> Void = { _ in }
-    var onDroppedFileURLs: ([URL]) -> Void = { _ in }
-        var onDropTargetedChange: (DropTargetingUpdate) -> Void = { _ in }
-        var canAcceptDroppedFileURLs: ([URL]) -> Bool = { _ in true }
-    var onChangedRegionNavigationResult: (Int, Int) -> Void = { _, _ in }
+    var canAcceptDroppedFileURLs: ([URL]) -> Bool = { _ in true }
+    var onAction: (DocumentSurfaceAction) -> Void = { _ in }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -59,9 +52,8 @@ struct MarkdownWebView: NSViewRepresentable {
         #endif
         let containerView = MarkdownWebContainerView(webView: webView)
         context.coordinator.attach(webView, containerView: containerView)
-        context.coordinator.onDroppedFileURLs = onDroppedFileURLs
-        context.coordinator.onDropTargetedChange = onDropTargetedChange
         context.coordinator.canAcceptDroppedFileURLs = canAcceptDroppedFileURLs
+        context.coordinator.onAction = onAction
         webView.dropDelegate = context.coordinator
         webView.navigationDelegate = context.coordinator
         webView.setValue(false, forKey: "drawsBackground")
@@ -77,15 +69,8 @@ struct MarkdownWebView: NSViewRepresentable {
         let webView = containerView.webView
         context.coordinator.diagnosticName = diagnosticName
         context.coordinator.postLoadStatusScript = postLoadStatusScript
-        context.coordinator.onFatalCrash = onFatalCrash
-        context.coordinator.onPostLoadStatus = onPostLoadStatus
-        context.coordinator.onScrollSyncObservation = onScrollSyncObservation
-        context.coordinator.onSourceEdit = onSourceEdit
-        context.coordinator.onTOCHeadingsExtracted = onTOCHeadingsExtracted
-        context.coordinator.onDroppedFileURLs = onDroppedFileURLs
-        context.coordinator.onDropTargetedChange = onDropTargetedChange
         context.coordinator.canAcceptDroppedFileURLs = canAcceptDroppedFileURLs
-        context.coordinator.onChangedRegionNavigationResult = onChangedRegionNavigationResult
+        context.coordinator.onAction = onAction
         context.coordinator.reloadAnchorProgress = reloadAnchorProgress
         context.coordinator.supportsInPlaceContentUpdates = supportsInPlaceContentUpdates
         context.coordinator.overlayTopInset = max(0, overlayTopInset)
@@ -141,15 +126,8 @@ struct MarkdownWebView: NSViewRepresentable {
         private var lastTOCScrollRequestID: Int?
         private var pendingChangedRegionNavigationRequest: ChangedRegionNavigationRequest?
         private var pendingTOCScrollRequest: TOCScrollRequest?
-        var onFatalCrash: () -> Void = {}
-        var onPostLoadStatus: (String?) -> Void = { _ in }
-        var onScrollSyncObservation: (ScrollSyncObservation) -> Void = { _ in }
-        var onSourceEdit: (String) -> Void = { _ in }
-        var onTOCHeadingsExtracted: ([TOCHeading]) -> Void = { _ in }
-        var onDroppedFileURLs: ([URL]) -> Void = { _ in }
-        var onDropTargetedChange: (DropTargetingUpdate) -> Void = { _ in }
         var canAcceptDroppedFileURLs: ([URL]) -> Bool = { _ in true }
-        var onChangedRegionNavigationResult: (Int, Int) -> Void = { _, _ in }
+        var onAction: (DocumentSurfaceAction) -> Void = { _ in }
         var supportsInPlaceContentUpdates = false
         var overlayTopInset: CGFloat = ReaderOverlayInsetCalculator.defaultScrollTargetTopInset
         var reloadAnchorProgress: Double?
@@ -349,7 +327,7 @@ struct MarkdownWebView: NSViewRepresentable {
         }
 
         func dropAwareWebViewDidChangeTargeting(_ update: DropTargetingUpdate) {
-            onDropTargetedChange(update)
+            onAction(.dropTargetedChange(update))
         }
 
         func dropAwareWebViewCanAcceptDrop(_ fileURLs: [URL]) -> Bool {
@@ -357,7 +335,7 @@ struct MarkdownWebView: NSViewRepresentable {
         }
 
         func dropAwareWebViewDidReceiveDrop(_ fileURLs: [URL]) {
-            onDroppedFileURLs(fileURLs)
+            onAction(.droppedFileURLs(fileURLs))
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
@@ -377,7 +355,7 @@ struct MarkdownWebView: NSViewRepresentable {
                 }
 
             case .lockedOut:
-                onFatalCrash()
+                onAction(.fatalCrash)
                 loadFallbackMessage(
                     "Web content process stopped repeatedly while rendering markdown. " +
                         "Try reopening the file."
@@ -393,7 +371,7 @@ struct MarkdownWebView: NSViewRepresentable {
             scrollSync.cancelPendingRestore()
             crashRecovery.lock()
             logError("navigation failed: \(error.localizedDescription)")
-            onFatalCrash()
+            onAction(.fatalCrash)
             loadFallbackMessage("Failed to render markdown: \(error.localizedDescription)")
         }
 
@@ -405,7 +383,7 @@ struct MarkdownWebView: NSViewRepresentable {
             scrollSync.cancelPendingRestore()
             crashRecovery.lock()
             logError("provisional navigation failed: \(error.localizedDescription)")
-            onFatalCrash()
+            onAction(.fatalCrash)
             loadFallbackMessage("Failed to load markdown preview: \(error.localizedDescription)")
         }
 
@@ -585,7 +563,7 @@ struct MarkdownWebView: NSViewRepresentable {
                    let count = (dict["count"] as? NSNumber)?.intValue {
                     let clampedCount = max(0, count)
                     let clampedIndex = clampedCount > 0 ? min(max(0, index), clampedCount - 1) : 0
-                    self.onChangedRegionNavigationResult(clampedIndex, clampedCount)
+                    self.onAction(.changedRegionNavigationResult(index: clampedIndex, total: clampedCount))
                 }
             }
         }
@@ -692,7 +670,7 @@ struct MarkdownWebView: NSViewRepresentable {
             if message.name == MarkdownWebView.sourceEditMessageName,
                let payload = message.body as? [String: Any],
                let markdown = payload["markdown"] as? String {
-                onSourceEdit(markdown)
+                onAction(.sourceEdit(markdown))
                 return
             }
 
@@ -712,7 +690,7 @@ struct MarkdownWebView: NSViewRepresentable {
             if message.name == MarkdownWebView.tocMessageName,
                let payload = message.body as? [[String: Any]] {
                 let headings = TOCHeading.fromJavaScriptPayload(payload)
-                onTOCHeadingsExtracted(headings)
+                onAction(.tocHeadingsExtracted(headings))
                 return
             }
 
@@ -732,7 +710,7 @@ struct MarkdownWebView: NSViewRepresentable {
                 progress: progress,
                 suppressionToken: suppressionToken
             ) {
-                onScrollSyncObservation(observation)
+                onAction(.scrollSyncObservation(observation))
             }
         }
 
@@ -783,7 +761,7 @@ struct MarkdownWebView: NSViewRepresentable {
 
                 if let error {
                     self.logDebug("post-load status probe failed: \(error.localizedDescription)")
-                    self.onPostLoadStatus(nil)
+                    self.onAction(.postLoadStatus(nil))
                     return
                 }
 
@@ -793,7 +771,7 @@ struct MarkdownWebView: NSViewRepresentable {
                 } else {
                     self.logDebug("post-load status probe returned no string status")
                 }
-                self.onPostLoadStatus(status)
+                self.onAction(.postLoadStatus(status))
             }
         }
 

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -563,7 +563,7 @@ struct MarkdownWebView: NSViewRepresentable {
                    let count = (dict["count"] as? NSNumber)?.intValue {
                     let clampedCount = max(0, count)
                     let clampedIndex = clampedCount > 0 ? min(max(0, index), clampedCount - 1) : 0
-                    self.onAction(.changedRegionNavigationResult(index: clampedIndex, total: clampedCount))
+                    self.onAction(.changedRegionNavigationResult(index: clampedIndex))
                 }
             }
         }

--- a/minimarkTests/Core/ChangedRegionNavigationCoordinatorTests.swift
+++ b/minimarkTests/Core/ChangedRegionNavigationCoordinatorTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import minimark
+
+@Suite
+struct ChangedRegionNavigationCoordinatorTests {
+
+    @Test func initialStateHasNoRequest() {
+        let coordinator = ChangedRegionNavigationCoordinator()
+        #expect(coordinator.currentIndex == nil)
+        #expect(coordinator.currentRequest == nil)
+    }
+
+    @Test func requestIncreasesIDAndSetsDirection() {
+        var coordinator = ChangedRegionNavigationCoordinator()
+        coordinator.requestNavigation(.next)
+        let request = coordinator.currentRequest
+        #expect(request != nil)
+        #expect(request?.direction == .next)
+        #expect(request?.id == 1)
+    }
+
+    @Test func consecutiveRequestsIncrementID() {
+        var coordinator = ChangedRegionNavigationCoordinator()
+        coordinator.requestNavigation(.next)
+        coordinator.requestNavigation(.previous)
+        #expect(coordinator.currentRequest?.id == 2)
+        #expect(coordinator.currentRequest?.direction == .previous)
+    }
+
+    @Test func handleResultUpdatesCurrentIndex() {
+        var coordinator = ChangedRegionNavigationCoordinator()
+        coordinator.requestNavigation(.next)
+        coordinator.handleNavigationResult(index: 2, total: 5)
+        #expect(coordinator.currentIndex == 2)
+    }
+
+    @Test func resetOnRegionsChangeClearsIndex() {
+        var coordinator = ChangedRegionNavigationCoordinator()
+        coordinator.requestNavigation(.next)
+        coordinator.handleNavigationResult(index: 1, total: 3)
+        coordinator.resetForNewRegions()
+        #expect(coordinator.currentIndex == nil)
+    }
+
+    @Test func resetClearsAllState() {
+        var coordinator = ChangedRegionNavigationCoordinator()
+        coordinator.requestNavigation(.next)
+        coordinator.handleNavigationResult(index: 0, total: 3)
+        coordinator.reset()
+        #expect(coordinator.currentIndex == nil)
+        #expect(coordinator.currentRequest == nil)
+    }
+}

--- a/minimarkTests/Core/ChangedRegionNavigationCoordinatorTests.swift
+++ b/minimarkTests/Core/ChangedRegionNavigationCoordinatorTests.swift
@@ -30,14 +30,14 @@ struct ChangedRegionNavigationCoordinatorTests {
     @Test func handleResultUpdatesCurrentIndex() {
         var coordinator = ChangedRegionNavigationCoordinator()
         coordinator.requestNavigation(.next)
-        coordinator.handleNavigationResult(index: 2, total: 5)
+        coordinator.handleNavigationResult(index: 2)
         #expect(coordinator.currentIndex == 2)
     }
 
     @Test func resetOnRegionsChangeClearsIndex() {
         var coordinator = ChangedRegionNavigationCoordinator()
         coordinator.requestNavigation(.next)
-        coordinator.handleNavigationResult(index: 1, total: 3)
+        coordinator.handleNavigationResult(index: 1)
         coordinator.resetForNewRegions()
         #expect(coordinator.currentIndex == nil)
     }
@@ -45,7 +45,7 @@ struct ChangedRegionNavigationCoordinatorTests {
     @Test func resetClearsAllState() {
         var coordinator = ChangedRegionNavigationCoordinator()
         coordinator.requestNavigation(.next)
-        coordinator.handleNavigationResult(index: 0, total: 3)
+        coordinator.handleNavigationResult(index: 0)
         coordinator.reset()
         #expect(coordinator.currentIndex == nil)
         #expect(coordinator.currentRequest == nil)

--- a/minimarkTests/Core/DropTargetingCoordinatorTests.swift
+++ b/minimarkTests/Core/DropTargetingCoordinatorTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import minimark
+
+@Suite
+struct DropTargetingCoordinatorTests {
+
+    @Test func initialStateIsNotTargeted() {
+        let coordinator = DropTargetingCoordinator()
+        #expect(!coordinator.isDragTargeted)
+        #expect(!coordinator.isBlockedFolderDropTargeted)
+    }
+
+    @Test func targetingSurfaceMarksDragTargeted() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .preview,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        #expect(coordinator.isDragTargeted)
+    }
+
+    @Test func untargetingSurfaceClearsDragTargeted() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .preview,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        coordinator.update(
+            for: .preview,
+            update: DropTargetingUpdate(isTargeted: false, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        #expect(!coordinator.isDragTargeted)
+    }
+
+    @Test func blockedFolderDropIsTracked() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .source,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: true, canDrop: false)
+        )
+        #expect(coordinator.isBlockedFolderDropTargeted)
+    }
+
+    @Test func clearForSurfaceRemovesOnlyThatSurface() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .preview,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        coordinator.update(
+            for: .source,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        coordinator.clear(for: .preview)
+        #expect(coordinator.isDragTargeted) // source still targeted
+    }
+
+    @Test func untargetingBlockedFolderDropClearsBlockedState() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .source,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: true, canDrop: false)
+        )
+        coordinator.update(
+            for: .source,
+            update: DropTargetingUpdate(isTargeted: false, droppedFileURLs: [], containsDirectoryHint: true, canDrop: false)
+        )
+        #expect(!coordinator.isBlockedFolderDropTargeted)
+    }
+
+    @Test func clearAllRemovesAllSurfaces() {
+        var coordinator = DropTargetingCoordinator()
+        coordinator.update(
+            for: .preview,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: false, canDrop: true)
+        )
+        coordinator.update(
+            for: .source,
+            update: DropTargetingUpdate(isTargeted: true, droppedFileURLs: [], containsDirectoryHint: true, canDrop: false)
+        )
+        coordinator.clearAll()
+        #expect(!coordinator.isDragTargeted)
+        #expect(!coordinator.isBlockedFolderDropTargeted)
+    }
+}

--- a/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
+++ b/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
@@ -3,7 +3,6 @@
 //  minimarkTests
 //
 
-import Foundation
 import Testing
 @testable import minimark
 

--- a/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
+++ b/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
@@ -1,0 +1,86 @@
+//
+//  SourceHTMLDocumentCacheTests.swift
+//  minimarkTests
+//
+
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite
+struct SourceHTMLDocumentCacheTests {
+
+    private static func makeSettings(
+        readerTheme: ReaderThemeKind = .blackOnWhite,
+        baseFontSize: Double = 15
+    ) -> ReaderSettings {
+        ReaderSettings(
+            appAppearance: .system,
+            readerTheme: readerTheme,
+            syntaxTheme: .monokai,
+            baseFontSize: baseFontSize,
+            autoRefreshOnExternalChange: true,
+            notificationsEnabled: false,
+            multiFileDisplayMode: .sidebarLeft,
+            sidebarSortMode: .openOrder,
+            recentWatchedFolders: [],
+            recentManuallyOpenedFiles: []
+        )
+    }
+
+    @Test func returnsEmptyDocumentBeforeFirstRefresh() {
+        let cache = SourceHTMLDocumentCache()
+        #expect(cache.document == "")
+    }
+
+    @Test func refreshProducesNonEmptyDocument() {
+        var cache = SourceHTMLDocumentCache()
+        let settings = Self.makeSettings()
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: false)
+        #expect(!cache.document.isEmpty)
+        #expect(cache.document.contains("<!DOCTYPE html>"))
+    }
+
+    @Test func skipsRefreshWhenInputsUnchanged() {
+        var cache = SourceHTMLDocumentCache()
+        let settings = Self.makeSettings()
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: false)
+        let first = cache.document
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: false)
+        #expect(cache.document == first)
+    }
+
+    @Test func refreshesWhenMarkdownChanges() {
+        var cache = SourceHTMLDocumentCache()
+        let settings = Self.makeSettings()
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: false)
+        let first = cache.document
+        cache.refreshIfNeeded(markdown: "# World", settings: settings, isEditable: false)
+        #expect(cache.document != first)
+    }
+
+    @Test func refreshesWhenEditableChanges() {
+        var cache = SourceHTMLDocumentCache()
+        let settings = Self.makeSettings()
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: false)
+        let first = cache.document
+        cache.refreshIfNeeded(markdown: "# Hello", settings: settings, isEditable: true)
+        #expect(cache.document != first)
+    }
+
+    @Test func refreshesWhenSettingsChange() {
+        var cache = SourceHTMLDocumentCache()
+        cache.refreshIfNeeded(
+            markdown: "# Hello",
+            settings: Self.makeSettings(baseFontSize: 15),
+            isEditable: false
+        )
+        let first = cache.document
+        cache.refreshIfNeeded(
+            markdown: "# Hello",
+            settings: Self.makeSettings(baseFontSize: 20),
+            isEditable: false
+        )
+        #expect(cache.document != first)
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts all business logic from ContentView (1,249 → 488 lines, 11 → 7 @State)
- Three new testable coordinator value types: `SourceHTMLDocumentCache`, `ChangedRegionNavigationCoordinator`, `DropTargetingCoordinator`
- Replaces 8 individual `DocumentSurfaceConfiguration` callbacks with a single `DocumentSurfaceAction` enum, propagated through to `MarkdownWebView`
- Moves focused-value wiring into `ContentViewFocusedValues` ViewModifier
- Moves configuration builders into `ContentViewConfigurationFactory` extension
- 19 new unit tests across three test suites

## Test plan

- [ ] All unit tests pass (`minimarkTests`)
- [ ] Open a markdown file — preview renders correctly
- [ ] Toggle between preview/source/split modes
- [ ] Drag and drop a markdown file onto the window
- [ ] Drag a folder while a watch is active — blocked overlay appears
- [ ] Navigate changed regions with the change pill arrows
- [ ] Trigger a TOC popover and select a heading
- [ ] Start source editing, make changes, save/discard
- [ ] Verify crash recovery: if WebKit crashes, fallback view appears

Closes #284