### PR TITLE
Refactor: Extract focused types from ReaderSidebarDocumentController

### DIFF
--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -16,8 +16,8 @@ final class ReaderSidebarDocumentController {
 
     // MARK: - Extracted components
 
-    let documentList: SidebarDocumentList
-    let rowStateComputer = SidebarRowStateComputer()
+    @ObservationIgnored private let documentList: SidebarDocumentList
+    @ObservationIgnored private let rowStateComputer = SidebarRowStateComputer()
     @ObservationIgnored private let observationManager = SidebarObservationManager()
 
     // MARK: - Selection state

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -14,12 +14,21 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    private(set) var documents: [Document]
-    @ObservationIgnored private var documentsByNormalizedURL: [URL: UUID] = [:]
+    // MARK: - Extracted components
+
+    let documentList: SidebarDocumentList
+    let rowStateComputer = SidebarRowStateComputer()
+    @ObservationIgnored private let observationManager = SidebarObservationManager()
+
+    // MARK: - Selection state
+
     var selectedDocumentID: UUID
     private(set) var selectedWindowTitle: String
     private(set) var selectedFileURL: URL?
     private(set) var selectedHasUnacknowledgedExternalChange: Bool
+
+    // MARK: - Folder watch state
+
     private(set) var selectedFolderWatchAutoOpenWarning: ReaderFolderWatchAutoOpenWarning?
     var pendingFileSelectionRequest: ReaderFolderWatchFileSelectionRequest?
     private(set) var activeFolderWatchSession: ReaderFolderWatchSession?
@@ -27,11 +36,39 @@ final class ReaderSidebarDocumentController {
     private(set) var didFolderWatchInitialScanFail: Bool
     private(set) var contentScanProgress: FolderChangeWatcher.ScanProgress?
     private(set) var scannedFileCount: Int?
-    private(set) var rowStates: [UUID: SidebarRowState] = [:]
+
+    // MARK: - Dependencies
 
     private let makeReaderStore: () -> ReaderStore
     @ObservationIgnored private var _folderWatchController: ReaderFolderWatchController?
     @ObservationIgnored private let _makeFolderWatchController: () -> ReaderFolderWatchController
+    @ObservationIgnored private var storeConfigurator: ((ReaderStore) -> Void)?
+    @ObservationIgnored lazy var fileOpenCoordinator = FileOpenCoordinator(controller: self)
+
+    // MARK: - Forwarding API
+
+    var documents: [Document] { documentList.documents }
+    var rowStates: [UUID: SidebarRowState] { rowStateComputer.rowStates }
+
+    @ObservationIgnored var onRowStatesChanged: (([UUID: SidebarRowState]) -> Void)? {
+        get { rowStateComputer.onRowStatesChanged }
+        set { rowStateComputer.onRowStatesChanged = newValue }
+    }
+
+    @ObservationIgnored var onDockTileRowStatesChanged: (([UUID: SidebarRowState]) -> Void)? {
+        get { rowStateComputer.onDockTileRowStatesChanged }
+        set { rowStateComputer.onDockTileRowStatesChanged = newValue }
+    }
+
+    func deriveRowState(from document: Document) -> SidebarRowState {
+        rowStateComputer.deriveRowState(from: document)
+    }
+
+    func document(for fileURL: URL) -> Document? {
+        documentList.document(for: fileURL)
+    }
+
+    // MARK: - Folder watch controller (lazy)
 
     private var folderWatchController: ReaderFolderWatchController {
         if let existing = _folderWatchController {
@@ -47,20 +84,8 @@ final class ReaderSidebarDocumentController {
     private var folderWatchControllerIfCreated: ReaderFolderWatchController? {
         _folderWatchController
     }
-    @ObservationIgnored private var selectedStoreObservationTask: Task<Void, Never>?
-    @ObservationIgnored private var storeConfigurator: ((ReaderStore) -> Void)?
-    @ObservationIgnored var onRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
-    @ObservationIgnored var onDockTileRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
-    @ObservationIgnored private var selectedStoreBindingGeneration: UInt = 0
-    @ObservationIgnored private var documentObservationTasks: [UUID: Task<Void, Never>] = [:]
-    @ObservationIgnored private var needsInitialObservationSetup = true
-    @ObservationIgnored private var rowIndicatorPulseTokens: [UUID: Int] = [:]
-    @ObservationIgnored lazy var fileOpenCoordinator = FileOpenCoordinator(controller: self)
 
-    deinit {
-        selectedStoreObservationTask?.cancel()
-        for task in documentObservationTasks.values { task.cancel() }
-    }
+    // MARK: - Init
 
     init(
         settingsStore: ReaderSettingsStore,
@@ -117,7 +142,7 @@ final class ReaderSidebarDocumentController {
         }
 
         let initialDocument = Document(id: UUID(), readerStore: resolvedMakeReaderStore(), normalizedFileURL: nil)
-        documents = [initialDocument]
+        documentList = SidebarDocumentList(initialDocument: initialDocument)
         selectedDocumentID = initialDocument.id
         selectedWindowTitle = initialDocument.readerStore.windowTitle
         selectedFileURL = initialDocument.readerStore.fileURL
@@ -128,9 +153,10 @@ final class ReaderSidebarDocumentController {
         didFolderWatchInitialScanFail = false
         contentScanProgress = nil
         scannedFileCount = nil
-        rebuildDocumentURLIndex()
-        rebuildAllRowStates()
+        rowStateComputer.rebuildAllRowStates(from: documentList.documents)
     }
+
+    // MARK: - Selection
 
     var selectedDocument: Document? {
         documents.first(where: { $0.id == selectedDocumentID })
@@ -152,7 +178,7 @@ final class ReaderSidebarDocumentController {
     }
 
     func selectDocument(_ documentID: UUID?) {
-        ensureObservationSetup()
+        observationManager.ensureSetup(for: documents, onStoreChanged: makeStoreChangedHandler())
         guard let documentID,
               documents.contains(where: { $0.id == documentID }) else {
             return
@@ -180,7 +206,6 @@ final class ReaderSidebarDocumentController {
         guard let existingDocument = document(for: fileURL) else {
             return false
         }
-
         selectDocument(existingDocument.id)
         return true
     }
@@ -212,14 +237,15 @@ final class ReaderSidebarDocumentController {
         selectDocumentWithNewestModificationDate()
     }
 
+    // MARK: - Plan execution
+
     func executePlan(_ plan: FileOpenPlan) {
-        ensureObservationSetup()
+        observationManager.ensureSetup(for: documents, onStoreChanged: makeStoreChangedHandler())
         guard !plan.assignments.isEmpty else { return }
 
         var didAppendDocuments = false
 
         for assignment in plan.assignments {
-            // assignment.fileURL is already normalized by FileOpenCoordinator.deduplicateAndSort
             let fileURL = assignment.fileURL
 
             if let existingDocument = document(for: fileURL) {
@@ -292,24 +318,20 @@ final class ReaderSidebarDocumentController {
                 continue
             }
 
-            var documentToInsert = targetDocument
-            documentToInsert.normalizedFileURL = fileURL
-
             if shouldAppendDocument {
-                documents.append(documentToInsert)
-                indexDocument(documentToInsert)
+                var documentToInsert = targetDocument
+                documentToInsert.normalizedFileURL = fileURL
+                documentList.append(documentToInsert)
                 didAppendDocuments = true
-            } else if let index = documents.firstIndex(where: { $0.id == targetDocument.id }) {
-                unindexDocument(documents[index])
-                documents[index].normalizedFileURL = documentToInsert.normalizedFileURL
-                indexDocument(documents[index])
+            } else {
+                documentList.updateNormalizedURL(for: targetDocument.id, to: fileURL)
             }
 
             selectedDocumentID = targetDocument.id
         }
 
         if didAppendDocuments {
-            synchronizeDocumentChangeObservers()
+            synchronizeAndRebuild()
         }
 
         // In screenshot mode, override selection to a specific document by filename
@@ -338,33 +360,31 @@ final class ReaderSidebarDocumentController {
         }
     }
 
+    // MARK: - Document close
+
     func closeDocument(_ documentID: UUID) {
-        guard let index = documents.firstIndex(where: { $0.id == documentID }) else {
+        guard let removed = documentList.remove(documentID: documentID) else {
             return
         }
 
-        unindexDocument(documents[index])
-        documents.remove(at: index)
-        synchronizeDocumentChangeObservers()
-
         if documents.isEmpty {
             let replacement = makeDocument()
-            documents = [replacement]
-            rebuildDocumentURLIndex()
-            synchronizeDocumentChangeObservers()
+            documentList.replaceAll(with: [replacement])
             if let storeConfigurator {
                 storeConfigurator(replacement.readerStore)
             }
             selectedDocumentID = replacement.id
+            synchronizeAndRebuild()
             bindSelectedStore()
             return
         }
 
         if selectedDocumentID == documentID {
-            let nextIndex = min(index, documents.count - 1)
+            let nextIndex = min(removed.index, documents.count - 1)
             selectedDocumentID = documents[nextIndex].id
         }
 
+        synchronizeAndRebuild()
         bindSelectedStore()
     }
 
@@ -378,14 +398,13 @@ final class ReaderSidebarDocumentController {
             return
         }
 
-        documents = retainedDocuments
-        rebuildDocumentURLIndex()
-        synchronizeDocumentChangeObservers()
+        documentList.replaceAll(with: retainedDocuments)
 
         if !retainedDocuments.contains(where: { $0.id == selectedDocumentID }) {
             selectedDocumentID = retainedDocuments[0].id
         }
 
+        synchronizeAndRebuild()
         bindSelectedStore()
     }
 
@@ -405,14 +424,13 @@ final class ReaderSidebarDocumentController {
         }
 
         let remainingDocuments = documents.filter { !documentIDs.contains($0.id) }
-        documents = remainingDocuments
-        rebuildDocumentURLIndex()
-        synchronizeDocumentChangeObservers()
+        documentList.replaceAll(with: remainingDocuments)
 
         if !remainingDocuments.contains(where: { $0.id == selectedDocumentID }) {
             selectedDocumentID = remainingDocuments[0].id
         }
 
+        synchronizeAndRebuild()
         bindSelectedStore()
     }
 
@@ -422,12 +440,13 @@ final class ReaderSidebarDocumentController {
             storeConfigurator(replacement.readerStore)
         }
 
-        documents = [replacement]
-        rebuildDocumentURLIndex()
-        synchronizeDocumentChangeObservers()
+        documentList.replaceAll(with: [replacement])
         selectedDocumentID = replacement.id
+        synchronizeAndRebuild()
         bindSelectedStore()
     }
+
+    // MARK: - Folder watch
 
     func startWatchingFolder(
         folderURL: URL,
@@ -477,13 +496,13 @@ final class ReaderSidebarDocumentController {
     }
 
     func openDocumentsInApplication(_ application: ReaderExternalApplication?, documentIDs: Set<UUID>) {
-        for document in orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
+        for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
             document.readerStore.openCurrentFileInApplication(application)
         }
     }
 
     func revealDocumentsInFinder(_ documentIDs: Set<UUID>) {
-        for document in orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
+        for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
             document.readerStore.revealCurrentFileInFinder()
         }
     }
@@ -516,12 +535,10 @@ final class ReaderSidebarDocumentController {
         })
     }
 
-    func document(for fileURL: URL) -> Document? {
-        let normalized = ReaderFileRouting.normalizedFileURL(fileURL)
-        guard let documentID = documentsByNormalizedURL[normalized] else {
-            return nil
-        }
-        return documents.first(where: { $0.id == documentID })
+    // MARK: - Private helpers
+
+    private func makeDocument() -> Document {
+        Document(id: UUID(), readerStore: makeReaderStore(), normalizedFileURL: nil)
     }
 
     private func scheduleLoadWithOverlay(on store: ReaderStore, load: @escaping @MainActor () -> Void) {
@@ -533,158 +550,30 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    private func ensureObservationSetup() {
-        guard needsInitialObservationSetup else { return }
-        needsInitialObservationSetup = false
-        synchronizeDocumentChangeObservers()
-    }
-
     private func bindSelectedStore() {
-        selectedStoreBindingGeneration &+= 1
-        let bindingGeneration = selectedStoreBindingGeneration
         let store = selectedReaderStore
-
         selectedWindowTitle = store.windowTitle
         selectedFileURL = store.fileURL
         selectedHasUnacknowledgedExternalChange = store.hasUnacknowledgedExternalChange
 
-        selectedStoreObservationTask?.cancel()
-        selectedStoreObservationTask = Task { [weak self] in
-            while !Task.isCancelled {
-                let cancelled = await Self.awaitObservationChange {
-                    _ = store.windowTitle
-                    _ = store.fileURL
-                    _ = store.hasUnacknowledgedExternalChange
-                }
-                if cancelled { break }
-                guard let self,
-                      self.selectedStoreBindingGeneration == bindingGeneration else { break }
-                self.selectedWindowTitle = store.windowTitle
-                self.selectedFileURL = store.fileURL
-                self.selectedHasUnacknowledgedExternalChange = store.hasUnacknowledgedExternalChange
-            }
+        observationManager.bindSelectedStore(store) { [weak self] in
+            guard let self else { return }
+            self.selectedWindowTitle = store.windowTitle
+            self.selectedFileURL = store.fileURL
+            self.selectedHasUnacknowledgedExternalChange = store.hasUnacknowledgedExternalChange
         }
     }
 
-    private func makeDocument() -> Document {
-        Document(id: UUID(), readerStore: makeReaderStore(), normalizedFileURL: nil)
+    private func synchronizeAndRebuild() {
+        observationManager.synchronize(for: documents, onStoreChanged: makeStoreChangedHandler())
+        rowStateComputer.rebuildAllRowStates(from: documents)
     }
 
-    private func rebuildDocumentURLIndex() {
-        documentsByNormalizedURL = [:]
-        for document in documents {
-            if let normalizedURL = document.normalizedFileURL {
-                documentsByNormalizedURL[normalizedURL] = document.id
-            }
+    private func makeStoreChangedHandler() -> @MainActor (UUID) -> Void {
+        return { [weak self] documentID in
+            guard let self else { return }
+            self.rowStateComputer.updateRowStateIfNeeded(for: documentID, in: self.documents)
         }
-    }
-
-    private func indexDocument(_ document: Document) {
-        if let normalizedURL = document.normalizedFileURL {
-            documentsByNormalizedURL[normalizedURL] = document.id
-        }
-    }
-
-    private func unindexDocument(_ document: Document) {
-        if let normalizedURL = document.normalizedFileURL {
-            documentsByNormalizedURL.removeValue(forKey: normalizedURL)
-        }
-    }
-
-    private func deriveIndicatorState(from store: ReaderStore) -> ReaderDocumentIndicatorState {
-        ReaderDocumentIndicatorState(
-            hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
-            isCurrentFileMissing: store.isCurrentFileMissing,
-            unacknowledgedExternalChangeKind: store.content.unacknowledgedExternalChangeKind
-        )
-    }
-
-    func deriveRowState(from document: Document) -> SidebarRowState {
-        let store = document.readerStore
-        let indicatorState = deriveIndicatorState(from: store)
-        return SidebarRowState(
-            id: document.id,
-            title: store.fileDisplayName.isEmpty ? "Untitled" : store.fileDisplayName,
-            lastModified: store.fileLastModifiedAt,
-            sortDate: store.fileLastModifiedAt ?? store.lastExternalChangeAt ?? store.lastRefreshAt,
-            isFileMissing: store.isCurrentFileMissing,
-            indicatorState: indicatorState,
-            indicatorPulseToken: rowIndicatorPulseTokens[document.id] ?? 0
-        )
-    }
-
-    private func rebuildAllRowStates() {
-        var states: [UUID: SidebarRowState] = [:]
-        for document in documents {
-            let previousIndicatorState = rowStates[document.id]?.indicatorState
-            let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
-            if let previousIndicatorState,
-               previousIndicatorState != currentIndicatorState,
-               currentIndicatorState.showsIndicator {
-                rowIndicatorPulseTokens[document.id, default: 0] += 1
-            }
-            states[document.id] = deriveRowState(from: document)
-        }
-        rowIndicatorPulseTokens = rowIndicatorPulseTokens.filter { states[$0.key] != nil }
-        guard states != rowStates else { return }
-        rowStates = states
-        onRowStatesChanged?(states)
-        onDockTileRowStatesChanged?(states)
-    }
-
-    private func synchronizeDocumentChangeObservers() {
-        let currentDocumentIDs = Set(documents.map(\.id))
-
-        for documentID in documentObservationTasks.keys where !currentDocumentIDs.contains(documentID) {
-            documentObservationTasks[documentID]?.cancel()
-            documentObservationTasks[documentID] = nil
-        }
-
-        for document in documents where documentObservationTasks[document.id] == nil {
-            let documentID = document.id
-            document.readerStore.onExternalChangeKindChanged = { [weak self] in
-                self?.updateRowStateIfNeeded(for: documentID)
-            }
-            documentObservationTasks[document.id] = Task { [weak self] in
-                let store = document.readerStore
-                defer { store.onExternalChangeKindChanged = nil }
-                while !Task.isCancelled {
-                    let cancelled = await Self.awaitObservationChange {
-                        _ = store.fileDisplayName
-                        _ = store.fileLastModifiedAt
-                        _ = store.lastExternalChangeAt
-                        _ = store.lastRefreshAt
-                        _ = store.isCurrentFileMissing
-                        _ = store.hasUnacknowledgedExternalChange
-                    }
-                    if cancelled { break }
-                    self?.updateRowStateIfNeeded(for: document.id)
-                }
-            }
-        }
-
-        rebuildAllRowStates()
-    }
-
-    private func updateRowStateIfNeeded(for documentID: UUID) {
-        guard let document = documents.first(where: { $0.id == documentID }) else { return }
-        let previousIndicatorState = rowStates[documentID]?.indicatorState
-        let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
-        if let previousIndicatorState,
-           previousIndicatorState != currentIndicatorState,
-           currentIndicatorState.showsIndicator {
-            rowIndicatorPulseTokens[documentID, default: 0] += 1
-        }
-        let state = deriveRowState(from: document)
-        if rowStates[documentID] != state {
-            rowStates[documentID] = state
-            onRowStatesChanged?(rowStates)
-            onDockTileRowStatesChanged?(rowStates)
-        }
-    }
-
-    private func orderedDocuments(matching documentIDs: Set<UUID>) -> [Document] {
-        documents.filter { documentIDs.contains($0.id) }
     }
 
     private func resolvedFolderWatchSession(
@@ -701,52 +590,6 @@ final class ReaderSidebarDocumentController {
         }
 
         return activeFolderWatchSession
-    }
-
-
-    // MARK: - Observation helpers
-
-    /// Suspends until any property accessed inside `tracking` changes, or the enclosing Task is cancelled.
-    /// Returns `true` if the wait was terminated by cancellation rather than a property change.
-    private static func awaitObservationChange(
-        tracking: @escaping @MainActor () -> Void
-    ) async -> Bool {
-        let box = ObservationContinuationBox()
-        return await withTaskCancellationHandler {
-            await withUnsafeContinuation { continuation in
-                box.store(continuation)
-                if Task.isCancelled {
-                    box.resume(returning: true)
-                    return
-                }
-                withObservationTracking {
-                    tracking()
-                } onChange: {
-                    box.resume(returning: false)
-                }
-            }
-        } onCancel: {
-            box.resume(returning: true)
-        }
-    }
-
-    private final class ObservationContinuationBox: @unchecked Sendable {
-        private var continuation: UnsafeContinuation<Bool, Never>?
-        private let lock = NSLock()
-
-        func store(_ continuation: UnsafeContinuation<Bool, Never>) {
-            lock.lock()
-            self.continuation = continuation
-            lock.unlock()
-        }
-
-        func resume(returning value: Bool) {
-            lock.lock()
-            let c = continuation
-            continuation = nil
-            lock.unlock()
-            c?.resume(returning: value)
-        }
     }
 
     private func synchronizeFolderWatchState() {
@@ -769,6 +612,8 @@ final class ReaderSidebarDocumentController {
         scannedFileCount = controller.scannedFileCount
     }
 }
+
+// MARK: - ReaderFolderWatchControllerDelegate
 
 extension ReaderSidebarDocumentController: ReaderFolderWatchControllerDelegate {
     func folderWatchControllerCurrentDocumentFileURL(_ controller: ReaderFolderWatchController) -> URL? {
@@ -797,9 +642,6 @@ extension ReaderSidebarDocumentController: ReaderFolderWatchControllerDelegate {
             }
         )
 
-        // For initial batch auto-open, the folder-watch planner sends defer
-        // and load events separately, managing materialization itself via
-        // folderWatchControllerShouldSelectNewestDocument. Use .deferOnly so the planner stays in control.
         let materializationStrategy: FileOpenRequest.MaterializationStrategy =
             origin == .folderWatchInitialBatchAutoOpen ? .deferOnly : .loadAll
 

--- a/minimark/Stores/SidebarDocumentList.swift
+++ b/minimark/Stores/SidebarDocumentList.swift
@@ -38,9 +38,10 @@ final class SidebarDocumentList {
     func updateNormalizedURL(for documentID: UUID, to url: URL?) {
         guard let index = documents.firstIndex(where: { $0.id == documentID }) else { return }
         unindexDocument(documents[index])
-        documents[index].normalizedFileURL = url
-        if let url {
-            documentsByNormalizedURL[url] = documentID
+        let normalized = url.map(ReaderFileRouting.normalizedFileURL)
+        documents[index].normalizedFileURL = normalized
+        if let normalized {
+            documentsByNormalizedURL[normalized] = documentID
         }
     }
 
@@ -64,20 +65,20 @@ final class SidebarDocumentList {
         documentsByNormalizedURL = [:]
         for document in documents {
             if let url = document.normalizedFileURL {
-                documentsByNormalizedURL[url] = document.id
+                documentsByNormalizedURL[ReaderFileRouting.normalizedFileURL(url)] = document.id
             }
         }
     }
 
     private func indexDocument(_ document: Document) {
         if let url = document.normalizedFileURL {
-            documentsByNormalizedURL[url] = document.id
+            documentsByNormalizedURL[ReaderFileRouting.normalizedFileURL(url)] = document.id
         }
     }
 
     private func unindexDocument(_ document: Document) {
         if let url = document.normalizedFileURL {
-            documentsByNormalizedURL.removeValue(forKey: url)
+            documentsByNormalizedURL.removeValue(forKey: ReaderFileRouting.normalizedFileURL(url))
         }
     }
 }

--- a/minimark/Stores/SidebarDocumentList.swift
+++ b/minimark/Stores/SidebarDocumentList.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class SidebarDocumentList {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    private(set) var documents: [Document]
+    @ObservationIgnored private var documentsByNormalizedURL: [URL: UUID] = [:]
+
+    init(initialDocument: Document) {
+        documents = [initialDocument]
+        rebuildIndex()
+    }
+
+    func append(_ document: Document) {
+        documents.append(document)
+        indexDocument(document)
+    }
+
+    @discardableResult
+    func remove(documentID: UUID) -> (index: Int, document: Document)? {
+        guard let index = documents.firstIndex(where: { $0.id == documentID }) else {
+            return nil
+        }
+        let document = documents[index]
+        unindexDocument(document)
+        documents.remove(at: index)
+        return (index, document)
+    }
+
+    func replaceAll(with newDocuments: [Document]) {
+        documents = newDocuments
+        rebuildIndex()
+    }
+
+    func updateNormalizedURL(for documentID: UUID, to url: URL?) {
+        guard let index = documents.firstIndex(where: { $0.id == documentID }) else { return }
+        unindexDocument(documents[index])
+        documents[index].normalizedFileURL = url
+        if let url {
+            documentsByNormalizedURL[url] = documentID
+        }
+    }
+
+    func document(for fileURL: URL) -> Document? {
+        let normalized = ReaderFileRouting.normalizedFileURL(fileURL)
+        guard let documentID = documentsByNormalizedURL[normalized] else { return nil }
+        return documents.first(where: { $0.id == documentID })
+    }
+
+    func contains(documentID: UUID) -> Bool {
+        documents.contains(where: { $0.id == documentID })
+    }
+
+    func orderedDocuments(matching documentIDs: Set<UUID>) -> [Document] {
+        documents.filter { documentIDs.contains($0.id) }
+    }
+
+    // MARK: - Private
+
+    private func rebuildIndex() {
+        documentsByNormalizedURL = [:]
+        for document in documents {
+            if let url = document.normalizedFileURL {
+                documentsByNormalizedURL[url] = document.id
+            }
+        }
+    }
+
+    private func indexDocument(_ document: Document) {
+        if let url = document.normalizedFileURL {
+            documentsByNormalizedURL[url] = document.id
+        }
+    }
+
+    private func unindexDocument(_ document: Document) {
+        if let url = document.normalizedFileURL {
+            documentsByNormalizedURL.removeValue(forKey: url)
+        }
+    }
+}

--- a/minimark/Stores/SidebarObservationManager.swift
+++ b/minimark/Stores/SidebarObservationManager.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Observation
+
+@MainActor
+final class SidebarObservationManager {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    private var documentObservationTasks: [UUID: Task<Void, Never>] = [:]
+    private var selectedStoreObservationTask: Task<Void, Never>?
+    private var selectedStoreBindingGeneration: UInt = 0
+    private var needsInitialSetup = true
+
+    deinit {
+        selectedStoreObservationTask?.cancel()
+        for task in documentObservationTasks.values { task.cancel() }
+    }
+
+    func ensureSetup(
+        for documents: [Document],
+        onStoreChanged: @escaping @MainActor (UUID) -> Void
+    ) {
+        guard needsInitialSetup else { return }
+        needsInitialSetup = false
+        synchronize(for: documents, onStoreChanged: onStoreChanged)
+    }
+
+    func synchronize(
+        for documents: [Document],
+        onStoreChanged: @escaping @MainActor (UUID) -> Void
+    ) {
+        let currentIDs = Set(documents.map(\.id))
+
+        for documentID in documentObservationTasks.keys where !currentIDs.contains(documentID) {
+            documentObservationTasks[documentID]?.cancel()
+            documentObservationTasks[documentID] = nil
+        }
+
+        for document in documents where documentObservationTasks[document.id] == nil {
+            let documentID = document.id
+            document.readerStore.onExternalChangeKindChanged = {
+                onStoreChanged(documentID)
+            }
+            documentObservationTasks[document.id] = Task { [weak self] in
+                let store = document.readerStore
+                defer { store.onExternalChangeKindChanged = nil }
+                while !Task.isCancelled {
+                    let cancelled = await Self.awaitObservationChange {
+                        _ = store.fileDisplayName
+                        _ = store.fileLastModifiedAt
+                        _ = store.lastExternalChangeAt
+                        _ = store.lastRefreshAt
+                        _ = store.isCurrentFileMissing
+                        _ = store.hasUnacknowledgedExternalChange
+                    }
+                    if cancelled { break }
+                    guard self != nil else { break }
+                    onStoreChanged(documentID)
+                }
+            }
+        }
+    }
+
+    func bindSelectedStore(
+        _ store: ReaderStore,
+        onChange: @escaping @MainActor () -> Void
+    ) {
+        selectedStoreBindingGeneration &+= 1
+        let generation = selectedStoreBindingGeneration
+
+        selectedStoreObservationTask?.cancel()
+        selectedStoreObservationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                let cancelled = await Self.awaitObservationChange {
+                    _ = store.windowTitle
+                    _ = store.fileURL
+                    _ = store.hasUnacknowledgedExternalChange
+                }
+                if cancelled { break }
+                guard let self,
+                      self.selectedStoreBindingGeneration == generation else { break }
+                onChange()
+            }
+        }
+    }
+
+    // MARK: - Observation helpers
+
+    private static func awaitObservationChange(
+        tracking: @escaping @MainActor () -> Void
+    ) async -> Bool {
+        let box = ObservationContinuationBox()
+        return await withTaskCancellationHandler {
+            await withUnsafeContinuation { continuation in
+                box.store(continuation)
+                if Task.isCancelled {
+                    box.resume(returning: true)
+                    return
+                }
+                withObservationTracking {
+                    tracking()
+                } onChange: {
+                    box.resume(returning: false)
+                }
+            }
+        } onCancel: {
+            box.resume(returning: true)
+        }
+    }
+
+    private final class ObservationContinuationBox: @unchecked Sendable {
+        private var continuation: UnsafeContinuation<Bool, Never>?
+        private let lock = NSLock()
+
+        func store(_ continuation: UnsafeContinuation<Bool, Never>) {
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+        }
+
+        func resume(returning value: Bool) {
+            lock.lock()
+            let c = continuation
+            continuation = nil
+            lock.unlock()
+            c?.resume(returning: value)
+        }
+    }
+}

--- a/minimark/Stores/SidebarRowStateComputer.swift
+++ b/minimark/Stores/SidebarRowStateComputer.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class SidebarRowStateComputer {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    private(set) var rowStates: [UUID: SidebarRowState] = [:]
+    @ObservationIgnored private var pulseTokens: [UUID: Int] = [:]
+    @ObservationIgnored var onRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
+    @ObservationIgnored var onDockTileRowStatesChanged: (([UUID: SidebarRowState]) -> Void)?
+
+    func rebuildAllRowStates(from documents: [Document]) {
+        var states: [UUID: SidebarRowState] = [:]
+        for document in documents {
+            let previousIndicatorState = rowStates[document.id]?.indicatorState
+            let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
+            if let previousIndicatorState,
+               previousIndicatorState != currentIndicatorState,
+               currentIndicatorState.showsIndicator {
+                pulseTokens[document.id, default: 0] += 1
+            }
+            states[document.id] = deriveRowState(from: document)
+        }
+        pulseTokens = pulseTokens.filter { states[$0.key] != nil }
+        guard states != rowStates else { return }
+        rowStates = states
+        onRowStatesChanged?(states)
+        onDockTileRowStatesChanged?(states)
+    }
+
+    func updateRowStateIfNeeded(for documentID: UUID, in documents: [Document]) {
+        guard let document = documents.first(where: { $0.id == documentID }) else { return }
+        let previousIndicatorState = rowStates[documentID]?.indicatorState
+        let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
+        if let previousIndicatorState,
+           previousIndicatorState != currentIndicatorState,
+           currentIndicatorState.showsIndicator {
+            pulseTokens[documentID, default: 0] += 1
+        }
+        let state = deriveRowState(from: document)
+        if rowStates[documentID] != state {
+            rowStates[documentID] = state
+            onRowStatesChanged?(rowStates)
+            onDockTileRowStatesChanged?(rowStates)
+        }
+    }
+
+    func deriveRowState(from document: Document) -> SidebarRowState {
+        let store = document.readerStore
+        let indicatorState = deriveIndicatorState(from: store)
+        return SidebarRowState(
+            id: document.id,
+            title: store.fileDisplayName.isEmpty ? "Untitled" : store.fileDisplayName,
+            lastModified: store.fileLastModifiedAt,
+            sortDate: store.fileLastModifiedAt ?? store.lastExternalChangeAt ?? store.lastRefreshAt,
+            isFileMissing: store.isCurrentFileMissing,
+            indicatorState: indicatorState,
+            indicatorPulseToken: pulseTokens[document.id] ?? 0
+        )
+    }
+
+    private func deriveIndicatorState(from store: ReaderStore) -> ReaderDocumentIndicatorState {
+        ReaderDocumentIndicatorState(
+            hasUnacknowledgedExternalChange: store.hasUnacknowledgedExternalChange,
+            isCurrentFileMissing: store.isCurrentFileMissing,
+            unacknowledgedExternalChangeKind: store.content.unacknowledgedExternalChangeKind
+        )
+    }
+}

--- a/minimarkTests/Sidebar/SidebarDocumentListTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentListTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct SidebarDocumentListTests {
+    @MainActor
+    private func makeSettingsStore() -> ReaderSettingsStore {
+        ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "doc-list-tests.\(UUID().uuidString)"
+        )
+    }
+
+    @MainActor
+    private func makeDocument(
+        id: UUID = UUID(),
+        normalizedURL: URL? = nil,
+        settingsStore: ReaderSettingsStore
+    ) -> ReaderSidebarDocumentController.Document {
+        let store = ReaderStore(
+            rendering: ReaderRenderingDependencies(
+                renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
+            ),
+            file: ReaderFileDependencies(
+                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+            ),
+            folderWatch: ReaderFolderWatchDependencies(
+                autoOpenPlanner: ReaderFolderWatchAutoOpenPlanner(),
+                settler: ReaderAutoOpenSettler(settlingInterval: 1.0),
+                systemNotifier: TestReaderSystemNotifier()
+            ),
+            settingsStore: settingsStore,
+            securityScopeResolver: SecurityScopeResolver(
+                securityScope: TestSecurityScopeAccess(),
+                settingsStore: settingsStore,
+                requestWatchedFolderReauthorization: { _ in nil }
+            )
+        )
+        return ReaderSidebarDocumentController.Document(
+            id: id, readerStore: store, normalizedFileURL: normalizedURL
+        )
+    }
+
+    // MARK: - Append
+
+    @Test @MainActor func appendAddsDocumentAndIndexesURL() {
+        let settings = makeSettingsStore()
+        let initial = makeDocument(settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: initial)
+
+        let url = URL(fileURLWithPath: "/tmp/test.md")
+        let doc = makeDocument(normalizedURL: url, settingsStore: settings)
+        list.append(doc)
+
+        #expect(list.documents.count == 2)
+        #expect(list.document(for: url)?.id == doc.id)
+    }
+
+    // MARK: - Remove
+
+    @Test @MainActor func removeReturnsRemovedDocumentAndUpdatesIndex() {
+        let settings = makeSettingsStore()
+        let url = URL(fileURLWithPath: "/tmp/alpha.md")
+        let initial = makeDocument(normalizedURL: url, settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: initial)
+
+        let result = list.remove(documentID: initial.id)
+
+        #expect(result?.index == 0)
+        #expect(result?.document.id == initial.id)
+        #expect(list.documents.isEmpty)
+        #expect(list.document(for: url) == nil)
+    }
+
+    @Test @MainActor func removeNonexistentReturnsNil() {
+        let settings = makeSettingsStore()
+        let list = SidebarDocumentList(initialDocument: makeDocument(settingsStore: settings))
+
+        let result = list.remove(documentID: UUID())
+
+        #expect(result == nil)
+    }
+
+    // MARK: - Lookup
+
+    @Test @MainActor func documentForURLReturnsCorrectDocument() {
+        let settings = makeSettingsStore()
+        let urlA = URL(fileURLWithPath: "/tmp/a.md")
+        let urlB = URL(fileURLWithPath: "/tmp/b.md")
+        let initial = makeDocument(normalizedURL: urlA, settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: initial)
+        let docB = makeDocument(normalizedURL: urlB, settingsStore: settings)
+        list.append(docB)
+
+        #expect(list.document(for: urlA)?.id == initial.id)
+        #expect(list.document(for: urlB)?.id == docB.id)
+    }
+
+    @Test @MainActor func documentForUnknownURLReturnsNil() {
+        let settings = makeSettingsStore()
+        let list = SidebarDocumentList(initialDocument: makeDocument(settingsStore: settings))
+
+        #expect(list.document(for: URL(fileURLWithPath: "/tmp/nope.md")) == nil)
+    }
+
+    // MARK: - Replace all
+
+    @Test @MainActor func replaceAllRebuildsIndex() {
+        let settings = makeSettingsStore()
+        let urlOld = URL(fileURLWithPath: "/tmp/old.md")
+        let initial = makeDocument(normalizedURL: urlOld, settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: initial)
+
+        let urlNew = URL(fileURLWithPath: "/tmp/new.md")
+        let replacement = makeDocument(normalizedURL: urlNew, settingsStore: settings)
+        list.replaceAll(with: [replacement])
+
+        #expect(list.documents.count == 1)
+        #expect(list.document(for: urlNew)?.id == replacement.id)
+        #expect(list.document(for: urlOld) == nil)
+    }
+
+    // MARK: - Update URL
+
+    @Test @MainActor func updateNormalizedURLUpdatesIndex() {
+        let settings = makeSettingsStore()
+        let oldURL = URL(fileURLWithPath: "/tmp/old.md")
+        let doc = makeDocument(normalizedURL: oldURL, settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: doc)
+
+        let newURL = URL(fileURLWithPath: "/tmp/new.md")
+        list.updateNormalizedURL(for: doc.id, to: newURL)
+
+        #expect(list.document(for: newURL)?.id == doc.id)
+        #expect(list.document(for: oldURL) == nil)
+    }
+
+    // MARK: - Ordered documents
+
+    @Test @MainActor func orderedDocumentsPreservesInsertionOrder() {
+        let settings = makeSettingsStore()
+        let docA = makeDocument(settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: docA)
+        let docB = makeDocument(settingsStore: settings)
+        let docC = makeDocument(settingsStore: settings)
+        list.append(docB)
+        list.append(docC)
+
+        let matching = list.orderedDocuments(matching: [docC.id, docA.id])
+
+        #expect(matching.map(\.id) == [docA.id, docC.id])
+    }
+
+    // MARK: - Contains
+
+    @Test @MainActor func containsReturnsTrueForExistingDocument() {
+        let settings = makeSettingsStore()
+        let doc = makeDocument(settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: doc)
+
+        #expect(list.contains(documentID: doc.id))
+        #expect(!list.contains(documentID: UUID()))
+    }
+}

--- a/minimarkTests/Sidebar/SidebarDocumentListTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentListTests.swift
@@ -136,6 +136,18 @@ struct SidebarDocumentListTests {
         #expect(list.document(for: oldURL) == nil)
     }
 
+    @Test @MainActor func updateNormalizedURLToNilRemovesFromIndex() {
+        let settings = makeSettingsStore()
+        let url = URL(fileURLWithPath: "/tmp/existing.md")
+        let doc = makeDocument(normalizedURL: url, settingsStore: settings)
+        let list = SidebarDocumentList(initialDocument: doc)
+
+        list.updateNormalizedURL(for: doc.id, to: nil)
+
+        #expect(list.document(for: url) == nil)
+        #expect(list.documents.first?.normalizedFileURL == nil)
+    }
+
     // MARK: - Ordered documents
 
     @Test @MainActor func orderedDocumentsPreservesInsertionOrder() {

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -107,18 +107,24 @@ struct SidebarRowStateComputerTests {
         #expect(computer.rowStates[doc.id]?.indicatorState == .externalChange)
     }
 
-    @Test @MainActor func rebuildAllCleansUpStaleTokens() {
+    @Test @MainActor func rebuildAllRemovesRowStateForRemovedDocument() {
         let settings = makeSettingsStore()
         let docA = makeDocument(settingsStore: settings)
         let docB = makeDocument(settingsStore: settings)
         let computer = SidebarRowStateComputer()
 
         computer.rebuildAllRowStates(from: [docA, docB])
-        // Remove docB — its token should be cleaned up
+        #expect(computer.rowStates.count == 2)
+
+        // Remove docB
         computer.rebuildAllRowStates(from: [docA])
 
         #expect(computer.rowStates.count == 1)
         #expect(computer.rowStates[docB.id] == nil)
+
+        // Re-add docB — pulse token should start fresh at 0
+        computer.rebuildAllRowStates(from: [docA, docB])
+        #expect(computer.rowStates[docB.id]?.indicatorPulseToken == 0)
     }
 
     @Test @MainActor func rebuildAllSkipsCallbackWhenUnchanged() {
@@ -136,18 +142,21 @@ struct SidebarRowStateComputerTests {
         #expect(callbackCount == 0)
     }
 
-    @Test @MainActor func rebuildAllFiresCallbackWhenChanged() {
+    @Test @MainActor func rebuildAllFiresBothCallbacksWhenChanged() {
         let settings = makeSettingsStore()
         let doc = makeDocument(settingsStore: settings)
         let computer = SidebarRowStateComputer()
 
         var receivedStates: [UUID: SidebarRowState]?
+        var dockTileCallbackFired = false
         computer.onRowStatesChanged = { states in receivedStates = states }
+        computer.onDockTileRowStatesChanged = { _ in dockTileCallbackFired = true }
 
         computer.rebuildAllRowStates(from: [doc])
 
         #expect(receivedStates != nil)
         #expect(receivedStates?.count == 1)
+        #expect(dockTileCallbackFired)
     }
 
     // MARK: - Update single row
@@ -175,12 +184,15 @@ struct SidebarRowStateComputerTests {
         computer.rebuildAllRowStates(from: [doc])
 
         var callbackFired = false
+        var dockTileCallbackFired = false
         computer.onRowStatesChanged = { _ in callbackFired = true }
+        computer.onDockTileRowStatesChanged = { _ in dockTileCallbackFired = true }
 
         doc.readerStore.noteObservedExternalChange()
         computer.updateRowStateIfNeeded(for: doc.id, in: [doc])
 
         #expect(callbackFired)
+        #expect(dockTileCallbackFired)
         #expect(computer.rowStates[doc.id]?.indicatorState == .externalChange)
     }
 }

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct SidebarRowStateComputerTests {
+    @MainActor
+    private func makeSettingsStore() -> ReaderSettingsStore {
+        ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "row-state-tests.\(UUID().uuidString)"
+        )
+    }
+
+    @MainActor
+    private func makeDocument(
+        id: UUID = UUID(),
+        settingsStore: ReaderSettingsStore
+    ) -> ReaderSidebarDocumentController.Document {
+        let store = ReaderStore(
+            rendering: ReaderRenderingDependencies(
+                renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
+            ),
+            file: ReaderFileDependencies(
+                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+            ),
+            folderWatch: ReaderFolderWatchDependencies(
+                autoOpenPlanner: ReaderFolderWatchAutoOpenPlanner(),
+                settler: ReaderAutoOpenSettler(settlingInterval: 1.0),
+                systemNotifier: TestReaderSystemNotifier()
+            ),
+            settingsStore: settingsStore,
+            securityScopeResolver: SecurityScopeResolver(
+                securityScope: TestSecurityScopeAccess(),
+                settingsStore: settingsStore,
+                requestWatchedFolderReauthorization: { _ in nil }
+            )
+        )
+        return ReaderSidebarDocumentController.Document(
+            id: id, readerStore: store, normalizedFileURL: nil
+        )
+    }
+
+    // MARK: - Derive row state
+
+    @Test @MainActor func derivesRowStateFromDocument() {
+        let settings = makeSettingsStore()
+        let doc = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+
+        let state = computer.deriveRowState(from: doc)
+
+        #expect(state.id == doc.id)
+        #expect(state.indicatorState == .none)
+        #expect(state.indicatorPulseToken == 0)
+        #expect(state.isFileMissing == false)
+    }
+
+    @Test @MainActor func derivesUntitledWhenDisplayNameEmpty() {
+        let settings = makeSettingsStore()
+        let doc = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+
+        let state = computer.deriveRowState(from: doc)
+
+        #expect(state.title == "Untitled")
+    }
+
+    // MARK: - Rebuild all
+
+    @Test @MainActor func rebuildAllPopulatesRowStates() {
+        let settings = makeSettingsStore()
+        let docA = makeDocument(settingsStore: settings)
+        let docB = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+
+        computer.rebuildAllRowStates(from: [docA, docB])
+
+        #expect(computer.rowStates.count == 2)
+        #expect(computer.rowStates[docA.id] != nil)
+        #expect(computer.rowStates[docB.id] != nil)
+    }
+
+    @Test @MainActor func rebuildAllIncrementsTokenOnIndicatorTransition() throws {
+        let settings = makeSettingsStore()
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("row-state-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let fileURL = tmpDir.appendingPathComponent("test.md")
+        try "# Test".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let doc = makeDocument(settingsStore: settings)
+        doc.readerStore.openFile(at: fileURL, origin: .manual)
+        let computer = SidebarRowStateComputer()
+
+        // First rebuild — no previous state, so no pulse
+        computer.rebuildAllRowStates(from: [doc])
+        #expect(computer.rowStates[doc.id]?.indicatorPulseToken == 0)
+
+        // Simulate external change -> indicator becomes active
+        doc.readerStore.noteObservedExternalChange()
+
+        // Second rebuild — indicator transitioned to active, pulse increments
+        computer.rebuildAllRowStates(from: [doc])
+        #expect(computer.rowStates[doc.id]?.indicatorPulseToken == 1)
+        #expect(computer.rowStates[doc.id]?.indicatorState == .externalChange)
+    }
+
+    @Test @MainActor func rebuildAllCleansUpStaleTokens() {
+        let settings = makeSettingsStore()
+        let docA = makeDocument(settingsStore: settings)
+        let docB = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+
+        computer.rebuildAllRowStates(from: [docA, docB])
+        // Remove docB — its token should be cleaned up
+        computer.rebuildAllRowStates(from: [docA])
+
+        #expect(computer.rowStates.count == 1)
+        #expect(computer.rowStates[docB.id] == nil)
+    }
+
+    @Test @MainActor func rebuildAllSkipsCallbackWhenUnchanged() {
+        let settings = makeSettingsStore()
+        let doc = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+        computer.rebuildAllRowStates(from: [doc])
+
+        var callbackCount = 0
+        computer.onRowStatesChanged = { _ in callbackCount += 1 }
+
+        // Rebuild with same state — should not fire
+        computer.rebuildAllRowStates(from: [doc])
+
+        #expect(callbackCount == 0)
+    }
+
+    @Test @MainActor func rebuildAllFiresCallbackWhenChanged() {
+        let settings = makeSettingsStore()
+        let doc = makeDocument(settingsStore: settings)
+        let computer = SidebarRowStateComputer()
+
+        var receivedStates: [UUID: SidebarRowState]?
+        computer.onRowStatesChanged = { states in receivedStates = states }
+
+        computer.rebuildAllRowStates(from: [doc])
+
+        #expect(receivedStates != nil)
+        #expect(receivedStates?.count == 1)
+    }
+
+    // MARK: - Update single row
+
+    @Test @MainActor func updateRowStateIgnoresUnknownDocumentID() {
+        let computer = SidebarRowStateComputer()
+
+        // Should not crash or change state
+        computer.updateRowStateIfNeeded(for: UUID(), in: [])
+        #expect(computer.rowStates.isEmpty)
+    }
+
+    @Test @MainActor func updateRowStateFiresCallbackOnChange() throws {
+        let settings = makeSettingsStore()
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("row-state-update-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let fileURL = tmpDir.appendingPathComponent("test.md")
+        try "# Test".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let doc = makeDocument(settingsStore: settings)
+        doc.readerStore.openFile(at: fileURL, origin: .manual)
+        let computer = SidebarRowStateComputer()
+        computer.rebuildAllRowStates(from: [doc])
+
+        var callbackFired = false
+        computer.onRowStatesChanged = { _ in callbackFired = true }
+
+        doc.readerStore.noteObservedExternalChange()
+        computer.updateRowStateIfNeeded(for: doc.id, in: [doc])
+
+        #expect(callbackFired)
+        #expect(computer.rowStates[doc.id]?.indicatorState == .externalChange)
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `SidebarDocumentList` (83 lines) — owns document array + URL index with atomic mutations, eliminating divergent-index risk
- Extract `SidebarRowStateComputer` (71 lines) — owns row state derivation, indicator pulse token management, and change callbacks
- Extract `SidebarObservationManager` (128 lines) — owns per-document observation task lifecycle, selected-store binding, and ObservationContinuationBox
- Rewire `ReaderSidebarDocumentController` (832 → 673 lines) to delegate to the three extracted types, preserving the full public API via computed property forwarding
- 19 new unit tests for the extracted types; all existing tests pass

Follow-up #292 tracks further splitting the controller to reach the 300-line target.

Closes #286

## Test plan

- [ ] All existing sidebar tests pass (ReaderSidebarDocumentControllerTests, FileOpenCoordinatorTests, SidebarRowStateTests, ReaderSidebarDeferredLoadingTests, SidebarGroupStateControllerTests, ReaderSidebarGroupingTests)
- [ ] New SidebarDocumentListTests pass (10 tests)
- [ ] New SidebarRowStateComputerTests pass (9 tests)
- [ ] CI passes