### PR TITLE
Refactor: Further split ReaderSidebarDocumentController

### DIFF
--- a/minimark/Stores/DocumentCloseCoordinator.swift
+++ b/minimark/Stores/DocumentCloseCoordinator.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+@MainActor
+protocol DocumentCloseCoordinatorDelegate: AnyObject {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    var selectedDocumentID: UUID { get set }
+    var storeConfigurator: ((ReaderStore) -> Void)? { get }
+    func makeDocument() -> Document
+    func bindSelectedStore()
+}
+
+@MainActor
+final class DocumentCloseCoordinator {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    private let documentList: SidebarDocumentList
+    private let observationManager: SidebarObservationManager
+    private let rowStateComputer: SidebarRowStateComputer
+    weak var delegate: DocumentCloseCoordinatorDelegate?
+
+    init(
+        documentList: SidebarDocumentList,
+        observationManager: SidebarObservationManager,
+        rowStateComputer: SidebarRowStateComputer
+    ) {
+        self.documentList = documentList
+        self.observationManager = observationManager
+        self.rowStateComputer = rowStateComputer
+    }
+
+    // MARK: - Public API
+
+    func closeDocument(_ documentID: UUID) {
+        guard let delegate else { return }
+        guard let removed = documentList.remove(documentID: documentID) else {
+            return
+        }
+
+        if documentList.documents.isEmpty {
+            let replacement = delegate.makeDocument()
+            documentList.replaceAll(with: [replacement])
+            if let storeConfigurator = delegate.storeConfigurator {
+                storeConfigurator(replacement.readerStore)
+            }
+            delegate.selectedDocumentID = replacement.id
+            synchronizeAndRebuild()
+            delegate.bindSelectedStore()
+            return
+        }
+
+        if delegate.selectedDocumentID == documentID {
+            let nextIndex = min(removed.index, documentList.documents.count - 1)
+            delegate.selectedDocumentID = documentList.documents[nextIndex].id
+        }
+
+        synchronizeAndRebuild()
+        delegate.bindSelectedStore()
+    }
+
+    func closeOtherDocuments(keeping documentID: UUID) {
+        closeOtherDocuments(keeping: [documentID])
+    }
+
+    func closeOtherDocuments(keeping documentIDs: Set<UUID>) {
+        guard let delegate else { return }
+        let retainedDocuments = documentList.documents.filter { documentIDs.contains($0.id) }
+        guard !retainedDocuments.isEmpty else {
+            return
+        }
+
+        documentList.replaceAll(with: retainedDocuments)
+
+        if !retainedDocuments.contains(where: { $0.id == delegate.selectedDocumentID }) {
+            delegate.selectedDocumentID = retainedDocuments[0].id
+        }
+
+        synchronizeAndRebuild()
+        delegate.bindSelectedStore()
+    }
+
+    func closeDocuments(_ documentIDs: Set<UUID>) {
+        guard let delegate else { return }
+        guard !documentIDs.isEmpty else {
+            return
+        }
+
+        let removedDocuments = documentList.documents.filter { documentIDs.contains($0.id) }
+        guard !removedDocuments.isEmpty else {
+            return
+        }
+
+        if removedDocuments.count >= documentList.documents.count {
+            closeAllDocuments()
+            return
+        }
+
+        let remainingDocuments = documentList.documents.filter { !documentIDs.contains($0.id) }
+        documentList.replaceAll(with: remainingDocuments)
+
+        if !remainingDocuments.contains(where: { $0.id == delegate.selectedDocumentID }) {
+            delegate.selectedDocumentID = remainingDocuments[0].id
+        }
+
+        synchronizeAndRebuild()
+        delegate.bindSelectedStore()
+    }
+
+    func closeAllDocuments() {
+        guard let delegate else { return }
+        let replacement = delegate.makeDocument()
+        if let storeConfigurator = delegate.storeConfigurator {
+            storeConfigurator(replacement.readerStore)
+        }
+
+        documentList.replaceAll(with: [replacement])
+        delegate.selectedDocumentID = replacement.id
+        synchronizeAndRebuild()
+        delegate.bindSelectedStore()
+    }
+
+    // MARK: - Private
+
+    private func synchronizeAndRebuild() {
+        observationManager.synchronize(
+            for: documentList.documents,
+            onStoreChanged: makeStoreChangedHandler()
+        )
+        rowStateComputer.rebuildAllRowStates(from: documentList.documents)
+    }
+
+    private func makeStoreChangedHandler() -> @MainActor (UUID) -> Void {
+        return { [weak self] documentID in
+            guard let self else { return }
+            self.rowStateComputer.updateRowStateIfNeeded(
+                for: documentID,
+                in: self.documentList.documents
+            )
+        }
+    }
+}

--- a/minimark/Stores/FileOpenPlanExecutor.swift
+++ b/minimark/Stores/FileOpenPlanExecutor.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+@MainActor
+protocol FileOpenPlanExecutorDelegate: AnyObject {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    var selectedDocumentID: UUID { get set }
+    var selectedReaderStore: ReaderStore { get }
+    var storeConfigurator: ((ReaderStore) -> Void)? { get }
+    func makeDocument() -> Document
+    func selectDocument(_ documentID: UUID?)
+    func bindSelectedStore()
+    func resolvedFolderWatchSession(
+        for fileURL: URL,
+        requestedSession: ReaderFolderWatchSession?
+    ) -> ReaderFolderWatchSession?
+}
+
+@MainActor
+final class FileOpenPlanExecutor {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    private let documentList: SidebarDocumentList
+    private let observationManager: SidebarObservationManager
+    private let rowStateComputer: SidebarRowStateComputer
+    weak var delegate: FileOpenPlanExecutorDelegate?
+
+    init(
+        documentList: SidebarDocumentList,
+        observationManager: SidebarObservationManager,
+        rowStateComputer: SidebarRowStateComputer
+    ) {
+        self.documentList = documentList
+        self.observationManager = observationManager
+        self.rowStateComputer = rowStateComputer
+    }
+
+    // MARK: - Public API
+
+    func executePlan(_ plan: FileOpenPlan) {
+        guard let delegate else { return }
+
+        observationManager.ensureSetup(
+            for: documentList.documents,
+            onStoreChanged: makeStoreChangedHandler()
+        )
+        guard !plan.assignments.isEmpty else { return }
+
+        var didAppendDocuments = false
+
+        for assignment in plan.assignments {
+            let fileURL = assignment.fileURL
+
+            if let existingDocument = documentList.document(for: fileURL) {
+                if existingDocument.readerStore.isDeferredDocument, assignment.loadMode == .loadFully {
+                    let store = existingDocument.readerStore
+                    let effectiveSession = delegate.resolvedFolderWatchSession(
+                        for: fileURL,
+                        requestedSession: plan.folderWatchSession
+                    )
+                    scheduleLoadWithOverlay(on: store) {
+                        store.materializeDeferredDocument(
+                            origin: plan.origin,
+                            folderWatchSession: effectiveSession,
+                            initialDiffBaselineMarkdown: assignment.initialDiffBaselineMarkdown
+                        )
+                    }
+                }
+                delegate.selectDocument(existingDocument.id)
+                continue
+            }
+
+            let effectiveFolderWatchSession = delegate.resolvedFolderWatchSession(
+                for: fileURL,
+                requestedSession: plan.folderWatchSession
+            )
+
+            let targetDocument: Document
+            let shouldAppendDocument: Bool
+
+            switch assignment.target {
+            case .reuseExisting(let documentID):
+                if let existing = documentList.documents.first(where: { $0.id == documentID }) {
+                    targetDocument = existing
+                    shouldAppendDocument = false
+                } else {
+                    let document = delegate.makeDocument()
+                    if let storeConfigurator = delegate.storeConfigurator {
+                        storeConfigurator(document.readerStore)
+                    }
+                    targetDocument = document
+                    shouldAppendDocument = true
+                }
+
+            case .createNew:
+                let document = delegate.makeDocument()
+                if let storeConfigurator = delegate.storeConfigurator {
+                    storeConfigurator(document.readerStore)
+                }
+                targetDocument = document
+                shouldAppendDocument = true
+            }
+
+            switch assignment.loadMode {
+            case .deferOnly:
+                targetDocument.readerStore.deferFile(
+                    at: fileURL,
+                    origin: plan.origin,
+                    folderWatchSession: effectiveFolderWatchSession
+                )
+            case .loadFully:
+                targetDocument.readerStore.openFile(
+                    at: fileURL,
+                    origin: plan.origin,
+                    folderWatchSession: effectiveFolderWatchSession,
+                    initialDiffBaselineMarkdown: assignment.initialDiffBaselineMarkdown
+                )
+            }
+
+            guard targetDocument.readerStore.fileURL != nil else {
+                continue
+            }
+
+            if shouldAppendDocument {
+                var documentToInsert = targetDocument
+                documentToInsert.normalizedFileURL = fileURL
+                documentList.append(documentToInsert)
+                didAppendDocuments = true
+            } else {
+                documentList.updateNormalizedURL(for: targetDocument.id, to: fileURL)
+            }
+
+            delegate.selectedDocumentID = targetDocument.id
+        }
+
+        if didAppendDocuments {
+            synchronizeAndRebuild()
+        }
+
+        // In screenshot mode, override selection to a specific document by filename
+        if let targetFile = ProcessInfo.processInfo.environment["MINIMARK_SCREENSHOT_SELECT_FILE"],
+           let match = documentList.documents.first(where: { $0.readerStore.fileURL?.lastPathComponent == targetFile }) {
+            delegate.selectedDocumentID = match.id
+        }
+
+        applyMaterializationStrategy(plan.materializationStrategy)
+        delegate.bindSelectedStore()
+    }
+
+    func selectDocumentWithNewestModificationDate() {
+        let newest = documentList.documents
+            .filter { $0.readerStore.fileURL != nil }
+            .max(by: {
+                ($0.readerStore.fileLastModifiedAt ?? .distantPast) < ($1.readerStore.fileLastModifiedAt ?? .distantPast)
+            })
+        if let newest {
+            delegate?.selectDocument(newest.id)
+        }
+    }
+
+    func materializeNewestDeferredDocuments(
+        count: Int = ReaderFolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount
+    ) {
+        let deferredDocs = documentList.documents
+            .filter { $0.readerStore.isDeferredDocument }
+            .sorted {
+                ($0.readerStore.fileLastModifiedAt ?? .distantPast) > ($1.readerStore.fileLastModifiedAt ?? .distantPast)
+            }
+
+        for document in deferredDocs.prefix(count) {
+            document.readerStore.materializeDeferredDocument()
+        }
+
+        selectDocumentWithNewestModificationDate()
+    }
+
+    // MARK: - Private
+
+    private func applyMaterializationStrategy(_ strategy: FileOpenRequest.MaterializationStrategy) {
+        guard let delegate else { return }
+        switch strategy {
+        case .loadAll, .deferOnly:
+            break
+        case .deferThenMaterializeNewest(let count):
+            materializeNewestDeferredDocuments(count: count)
+        case .deferThenMaterializeSelected:
+            if delegate.selectedReaderStore.isDeferredDocument {
+                let store = delegate.selectedReaderStore
+                scheduleLoadWithOverlay(on: store) {
+                    store.materializeDeferredDocument()
+                }
+            }
+        }
+    }
+
+    private func scheduleLoadWithOverlay(on store: ReaderStore, load: @escaping @MainActor () -> Void) {
+        store.transitionToLoading()
+        Task { @MainActor in
+            await Task.yield()
+            load()
+            store.holdLoadingOverlayBriefly()
+        }
+    }
+
+    private func synchronizeAndRebuild() {
+        observationManager.synchronize(
+            for: documentList.documents,
+            onStoreChanged: makeStoreChangedHandler()
+        )
+        rowStateComputer.rebuildAllRowStates(from: documentList.documents)
+    }
+
+    private func makeStoreChangedHandler() -> @MainActor (UUID) -> Void {
+        return { [weak self] documentID in
+            guard let self else { return }
+            self.rowStateComputer.updateRowStateIfNeeded(
+                for: documentID,
+                in: self.documentList.documents
+            )
+        }
+    }
+}

--- a/minimark/Stores/FolderWatchSessionCoordinator.swift
+++ b/minimark/Stores/FolderWatchSessionCoordinator.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Observation
+
+@MainActor
+protocol FolderWatchSessionCoordinatorDelegate: AnyObject {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    var documents: [Document] { get }
+    var selectedReaderStore: ReaderStore { get }
+    func document(for fileURL: URL) -> Document?
+    func selectDocumentWithNewestModificationDate()
+    func handleFolderWatchOpenRequest(_ request: FileOpenRequest)
+}
+
+@MainActor
+@Observable
+final class FolderWatchSessionCoordinator {
+    typealias Document = ReaderSidebarDocumentController.Document
+
+    // MARK: - State
+
+    private(set) var activeFolderWatchSession: ReaderFolderWatchSession?
+    private(set) var selectedFolderWatchAutoOpenWarning: ReaderFolderWatchAutoOpenWarning?
+    var pendingFileSelectionRequest: ReaderFolderWatchFileSelectionRequest?
+    private(set) var isFolderWatchInitialScanInProgress: Bool
+    private(set) var didFolderWatchInitialScanFail: Bool
+    private(set) var contentScanProgress: FolderChangeWatcher.ScanProgress?
+    private(set) var scannedFileCount: Int?
+
+    var canStopFolderWatch: Bool {
+        activeFolderWatchSession != nil
+    }
+
+    // MARK: - Dependencies
+
+    @ObservationIgnored private var _folderWatchController: ReaderFolderWatchController?
+    @ObservationIgnored private let _makeFolderWatchController: () -> ReaderFolderWatchController
+    @ObservationIgnored weak var delegate: FolderWatchSessionCoordinatorDelegate?
+
+    // MARK: - Lazy controller access
+
+    private var folderWatchController: ReaderFolderWatchController {
+        if let existing = _folderWatchController {
+            return existing
+        }
+        let controller = _makeFolderWatchController()
+        controller.delegate = self
+        _folderWatchController = controller
+        synchronizeFolderWatchState()
+        return controller
+    }
+
+    var folderWatchControllerIfCreated: ReaderFolderWatchController? {
+        _folderWatchController
+    }
+
+    // MARK: - Init
+
+    init(makeFolderWatchController: @escaping () -> ReaderFolderWatchController) {
+        self._makeFolderWatchController = makeFolderWatchController
+        self.activeFolderWatchSession = nil
+        self.selectedFolderWatchAutoOpenWarning = nil
+        self.pendingFileSelectionRequest = nil
+        self.isFolderWatchInitialScanInProgress = false
+        self.didFolderWatchInitialScanFail = false
+        self.contentScanProgress = nil
+        self.scannedFileCount = nil
+    }
+
+    // MARK: - Pass-through methods
+
+    func startWatchingFolder(
+        folderURL: URL,
+        options: ReaderFolderWatchOptions,
+        performInitialAutoOpen: Bool = true
+    ) throws {
+        try folderWatchController.startWatching(
+            folderURL: folderURL,
+            options: options,
+            performInitialAutoOpen: performInitialAutoOpen
+        )
+    }
+
+    func scanCurrentMarkdownFiles(completion: @escaping @MainActor ([URL]) -> Void) {
+        folderWatchController.scanCurrentMarkdownFiles(completion: completion)
+    }
+
+    func stopFolderWatch() {
+        folderWatchController.stopWatching()
+    }
+
+    func updateFolderWatchExcludedSubdirectories(_ paths: [String]) throws {
+        try folderWatchController.updateExcludedSubdirectories(paths)
+    }
+
+    func dismissFolderWatchAutoOpenWarnings() {
+        folderWatchController.dismissFolderWatchAutoOpenWarning()
+    }
+
+    func dismissPendingFileSelectionRequest() {
+        folderWatchController.pendingFileSelectionRequest = nil
+        pendingFileSelectionRequest = nil
+    }
+
+    // MARK: - Methods with real logic
+
+    func stopWatchingFolders(_ documentIDs: Set<UUID>) {
+        guard let session = activeFolderWatchSession,
+              let watchController = folderWatchControllerIfCreated else {
+            return
+        }
+
+        let normalizedFolder = session.folderURL
+        let hasWatchedDocument = documentIDs.contains { documentID in
+            guard let delegate,
+                  let document = delegate.documents.first(where: { $0.id == documentID }),
+                  let normalizedFileURL = document.normalizedFileURL else {
+                return false
+            }
+            return watchController.watchApplies(
+                normalizedFileURL: normalizedFileURL,
+                toNormalizedFolderAt: normalizedFolder,
+                scope: session.options.scope
+            )
+        }
+
+        guard hasWatchedDocument else { return }
+        watchController.stopWatching()
+    }
+
+    func watchedDocumentIDs() -> Set<UUID> {
+        guard let session = activeFolderWatchSession,
+              let watchController = folderWatchControllerIfCreated,
+              let delegate else {
+            return []
+        }
+
+        let normalizedFolder = session.folderURL
+        return Set(delegate.documents.compactMap { document in
+            guard let normalizedFileURL = document.normalizedFileURL else {
+                return nil
+            }
+            return watchController.watchApplies(
+                normalizedFileURL: normalizedFileURL,
+                toNormalizedFolderAt: normalizedFolder,
+                scope: session.options.scope
+            ) ? document.id : nil
+        })
+    }
+
+    func resolvedFolderWatchSession(
+        for fileURL: URL,
+        requestedSession: ReaderFolderWatchSession?
+    ) -> ReaderFolderWatchSession? {
+        if let requestedSession {
+            return requestedSession
+        }
+
+        guard let watchController = folderWatchControllerIfCreated,
+              watchController.watchApplies(to: fileURL) else {
+            return nil
+        }
+
+        return activeFolderWatchSession
+    }
+
+    // MARK: - Private
+
+    private func synchronizeFolderWatchState() {
+        guard let controller = _folderWatchController else {
+            activeFolderWatchSession = nil
+            selectedFolderWatchAutoOpenWarning = nil
+            pendingFileSelectionRequest = nil
+            isFolderWatchInitialScanInProgress = false
+            didFolderWatchInitialScanFail = false
+            contentScanProgress = nil
+            scannedFileCount = nil
+            return
+        }
+        activeFolderWatchSession = controller.activeFolderWatchSession
+        selectedFolderWatchAutoOpenWarning = controller.folderWatchAutoOpenWarning
+        pendingFileSelectionRequest = controller.pendingFileSelectionRequest
+        isFolderWatchInitialScanInProgress = controller.isInitialMarkdownScanInProgress
+        didFolderWatchInitialScanFail = controller.didInitialMarkdownScanFail
+        contentScanProgress = controller.contentScanProgress
+        scannedFileCount = controller.scannedFileCount
+    }
+}
+
+// MARK: - ReaderFolderWatchControllerDelegate
+
+extension FolderWatchSessionCoordinator: ReaderFolderWatchControllerDelegate {
+    func folderWatchControllerCurrentDocumentFileURL(_ controller: ReaderFolderWatchController) -> URL? {
+        delegate?.selectedReaderStore.fileURL
+    }
+
+    func folderWatchControllerOpenDocumentFileURLs(_ controller: ReaderFolderWatchController) -> [URL] {
+        guard let delegate else { return [] }
+        return delegate.documents.compactMap { document in
+            document.readerStore.isDeferredDocument ? nil : document.readerStore.fileURL
+        }
+    }
+
+    func folderWatchController(
+        _ controller: ReaderFolderWatchController,
+        handleEvents events: [ReaderFolderWatchChangeEvent],
+        in session: ReaderFolderWatchSession,
+        origin: ReaderOpenOrigin
+    ) {
+        let diffBaselineByURL: [URL: String] = Dictionary(
+            uniqueKeysWithValues: events.compactMap { event in
+                guard let previousMarkdown = event.previousMarkdown else {
+                    return nil
+                }
+                return (ReaderFileRouting.normalizedFileURL(event.fileURL), previousMarkdown)
+            }
+        )
+
+        let materializationStrategy: FileOpenRequest.MaterializationStrategy =
+            origin == .folderWatchInitialBatchAutoOpen ? .deferOnly : .loadAll
+
+        delegate?.handleFolderWatchOpenRequest(FileOpenRequest(
+            fileURLs: events.map(\.fileURL),
+            origin: origin,
+            folderWatchSession: session,
+            initialDiffBaselineMarkdownByURL: diffBaselineByURL,
+            slotStrategy: .reuseEmptySlotForFirst,
+            materializationStrategy: materializationStrategy
+        ))
+    }
+
+    func folderWatchController(_ controller: ReaderFolderWatchController, didLiveAutoOpenFileURLs urls: [URL]) {
+        guard let delegate else { return }
+        for url in urls {
+            if let doc = delegate.document(for: url) {
+                doc.readerStore.noteObservedExternalChange(kind: .added)
+            }
+        }
+    }
+
+    func folderWatchControllerShouldSelectNewestDocument(_ controller: ReaderFolderWatchController) {
+        delegate?.selectDocumentWithNewestModificationDate()
+    }
+
+    func folderWatchControllerStateDidChange(_ controller: ReaderFolderWatchController) {
+        synchronizeFolderWatchState()
+    }
+}

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -20,6 +20,7 @@ final class ReaderSidebarDocumentController {
     @ObservationIgnored private let rowStateComputer = SidebarRowStateComputer()
     @ObservationIgnored private let observationManager = SidebarObservationManager()
     let folderWatchCoordinator: FolderWatchSessionCoordinator
+    @ObservationIgnored private let fileOpenPlanExecutor: FileOpenPlanExecutor
 
     // MARK: - Selection state
 
@@ -31,7 +32,7 @@ final class ReaderSidebarDocumentController {
     // MARK: - Dependencies
 
     private let makeReaderStore: () -> ReaderStore
-    @ObservationIgnored private var storeConfigurator: ((ReaderStore) -> Void)?
+    @ObservationIgnored private(set) var storeConfigurator: ((ReaderStore) -> Void)?
     @ObservationIgnored lazy var fileOpenCoordinator = FileOpenCoordinator(controller: self)
 
     // MARK: - Forwarding API
@@ -118,12 +119,18 @@ final class ReaderSidebarDocumentController {
 
         let initialDocument = Document(id: UUID(), readerStore: resolvedMakeReaderStore(), normalizedFileURL: nil)
         documentList = SidebarDocumentList(initialDocument: initialDocument)
+        fileOpenPlanExecutor = FileOpenPlanExecutor(
+            documentList: documentList,
+            observationManager: observationManager,
+            rowStateComputer: rowStateComputer
+        )
         selectedDocumentID = initialDocument.id
         selectedWindowTitle = initialDocument.readerStore.windowTitle
         selectedFileURL = initialDocument.readerStore.fileURL
         selectedHasUnacknowledgedExternalChange = initialDocument.readerStore.hasUnacknowledgedExternalChange
         rowStateComputer.rebuildAllRowStates(from: documentList.documents)
         folderWatchCoordinator.delegate = self
+        fileOpenPlanExecutor.delegate = self
     }
 
     // MARK: - Selection
@@ -177,153 +184,19 @@ final class ReaderSidebarDocumentController {
     }
 
     func selectDocumentWithNewestModificationDate() {
-        let newest = documents
-            .filter { $0.readerStore.fileURL != nil }
-            .max(by: {
-                ($0.readerStore.fileLastModifiedAt ?? .distantPast) < ($1.readerStore.fileLastModifiedAt ?? .distantPast)
-            })
-        if let newest {
-            selectDocument(newest.id)
-        }
+        fileOpenPlanExecutor.selectDocumentWithNewestModificationDate()
     }
 
     func materializeNewestDeferredDocuments(
         count: Int = ReaderFolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount
     ) {
-        let deferredDocs = documents
-            .filter { $0.readerStore.isDeferredDocument }
-            .sorted {
-                ($0.readerStore.fileLastModifiedAt ?? .distantPast) > ($1.readerStore.fileLastModifiedAt ?? .distantPast)
-            }
-
-        for document in deferredDocs.prefix(count) {
-            document.readerStore.materializeDeferredDocument()
-        }
-
-        selectDocumentWithNewestModificationDate()
+        fileOpenPlanExecutor.materializeNewestDeferredDocuments(count: count)
     }
 
     // MARK: - Plan execution
 
     func executePlan(_ plan: FileOpenPlan) {
-        observationManager.ensureSetup(for: documents, onStoreChanged: makeStoreChangedHandler())
-        guard !plan.assignments.isEmpty else { return }
-
-        var didAppendDocuments = false
-
-        for assignment in plan.assignments {
-            let fileURL = assignment.fileURL
-
-            if let existingDocument = document(for: fileURL) {
-                if existingDocument.readerStore.isDeferredDocument, assignment.loadMode == .loadFully {
-                    let store = existingDocument.readerStore
-                    let effectiveSession = folderWatchCoordinator.resolvedFolderWatchSession(
-                        for: fileURL,
-                        requestedSession: plan.folderWatchSession
-                    )
-                    scheduleLoadWithOverlay(on: store) {
-                        store.materializeDeferredDocument(
-                            origin: plan.origin,
-                            folderWatchSession: effectiveSession,
-                            initialDiffBaselineMarkdown: assignment.initialDiffBaselineMarkdown
-                        )
-                    }
-                }
-                selectDocument(existingDocument.id)
-                continue
-            }
-
-            let effectiveFolderWatchSession = folderWatchCoordinator.resolvedFolderWatchSession(
-                for: fileURL,
-                requestedSession: plan.folderWatchSession
-            )
-
-            let targetDocument: Document
-            let shouldAppendDocument: Bool
-
-            switch assignment.target {
-            case .reuseExisting(let documentID):
-                if let existing = documents.first(where: { $0.id == documentID }) {
-                    targetDocument = existing
-                    shouldAppendDocument = false
-                } else {
-                    let document = makeDocument()
-                    if let storeConfigurator {
-                        storeConfigurator(document.readerStore)
-                    }
-                    targetDocument = document
-                    shouldAppendDocument = true
-                }
-
-            case .createNew:
-                let document = makeDocument()
-                if let storeConfigurator {
-                    storeConfigurator(document.readerStore)
-                }
-                targetDocument = document
-                shouldAppendDocument = true
-            }
-
-            switch assignment.loadMode {
-            case .deferOnly:
-                targetDocument.readerStore.deferFile(
-                    at: fileURL,
-                    origin: plan.origin,
-                    folderWatchSession: effectiveFolderWatchSession
-                )
-            case .loadFully:
-                targetDocument.readerStore.openFile(
-                    at: fileURL,
-                    origin: plan.origin,
-                    folderWatchSession: effectiveFolderWatchSession,
-                    initialDiffBaselineMarkdown: assignment.initialDiffBaselineMarkdown
-                )
-            }
-
-            guard targetDocument.readerStore.fileURL != nil else {
-                continue
-            }
-
-            if shouldAppendDocument {
-                var documentToInsert = targetDocument
-                documentToInsert.normalizedFileURL = fileURL
-                documentList.append(documentToInsert)
-                didAppendDocuments = true
-            } else {
-                documentList.updateNormalizedURL(for: targetDocument.id, to: fileURL)
-            }
-
-            selectedDocumentID = targetDocument.id
-        }
-
-        if didAppendDocuments {
-            synchronizeAndRebuild()
-        }
-
-        // In screenshot mode, override selection to a specific document by filename
-        if let targetFile = ProcessInfo.processInfo.environment["MINIMARK_SCREENSHOT_SELECT_FILE"],
-           let match = documents.first(where: { $0.readerStore.fileURL?.lastPathComponent == targetFile }) {
-            selectedDocumentID = match.id
-        }
-
-        applyMaterializationStrategy(plan.materializationStrategy)
-        bindSelectedStore()
-    }
-
-    private func applyMaterializationStrategy(_ strategy: FileOpenRequest.MaterializationStrategy) {
-        switch strategy {
-        case .loadAll, .deferOnly:
-            break
-        case .deferThenMaterializeNewest(let count):
-            materializeNewestDeferredDocuments(count: count)
-        case .deferThenMaterializeSelected:
-            if selectedReaderStore.isDeferredDocument {
-                let store = selectedReaderStore
-                scheduleLoadWithOverlay(on: store) {
-                    store.materializeDeferredDocument()
-                }
-            }
-        }
+        fileOpenPlanExecutor.executePlan(plan)
     }
 
     // MARK: - Document close
@@ -426,9 +299,9 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    // MARK: - Private helpers
+    // MARK: - Internal helpers
 
-    private func makeDocument() -> Document {
+    func makeDocument() -> Document {
         Document(id: UUID(), readerStore: makeReaderStore(), normalizedFileURL: nil)
     }
 
@@ -441,7 +314,7 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    private func bindSelectedStore() {
+    func bindSelectedStore() {
         let store = selectedReaderStore
         selectedWindowTitle = store.windowTitle
         selectedFileURL = store.fileURL
@@ -474,5 +347,19 @@ final class ReaderSidebarDocumentController {
 extension ReaderSidebarDocumentController: FolderWatchSessionCoordinatorDelegate {
     func handleFolderWatchOpenRequest(_ request: FileOpenRequest) {
         fileOpenCoordinator.open(request)
+    }
+}
+
+// MARK: - FileOpenPlanExecutorDelegate
+
+extension ReaderSidebarDocumentController: FileOpenPlanExecutorDelegate {
+    func resolvedFolderWatchSession(
+        for fileURL: URL,
+        requestedSession: ReaderFolderWatchSession?
+    ) -> ReaderFolderWatchSession? {
+        folderWatchCoordinator.resolvedFolderWatchSession(
+            for: fileURL,
+            requestedSession: requestedSession
+        )
     }
 }

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -19,6 +19,7 @@ final class ReaderSidebarDocumentController {
     @ObservationIgnored private let documentList: SidebarDocumentList
     @ObservationIgnored private let rowStateComputer = SidebarRowStateComputer()
     @ObservationIgnored private let observationManager = SidebarObservationManager()
+    let folderWatchCoordinator: FolderWatchSessionCoordinator
 
     // MARK: - Selection state
 
@@ -27,21 +28,9 @@ final class ReaderSidebarDocumentController {
     private(set) var selectedFileURL: URL?
     private(set) var selectedHasUnacknowledgedExternalChange: Bool
 
-    // MARK: - Folder watch state
-
-    private(set) var selectedFolderWatchAutoOpenWarning: ReaderFolderWatchAutoOpenWarning?
-    var pendingFileSelectionRequest: ReaderFolderWatchFileSelectionRequest?
-    private(set) var activeFolderWatchSession: ReaderFolderWatchSession?
-    private(set) var isFolderWatchInitialScanInProgress: Bool
-    private(set) var didFolderWatchInitialScanFail: Bool
-    private(set) var contentScanProgress: FolderChangeWatcher.ScanProgress?
-    private(set) var scannedFileCount: Int?
-
     // MARK: - Dependencies
 
     private let makeReaderStore: () -> ReaderStore
-    @ObservationIgnored private var _folderWatchController: ReaderFolderWatchController?
-    @ObservationIgnored private let _makeFolderWatchController: () -> ReaderFolderWatchController
     @ObservationIgnored private var storeConfigurator: ((ReaderStore) -> Void)?
     @ObservationIgnored lazy var fileOpenCoordinator = FileOpenCoordinator(controller: self)
 
@@ -66,23 +55,6 @@ final class ReaderSidebarDocumentController {
 
     func document(for fileURL: URL) -> Document? {
         documentList.document(for: fileURL)
-    }
-
-    // MARK: - Folder watch controller (lazy)
-
-    private var folderWatchController: ReaderFolderWatchController {
-        if let existing = _folderWatchController {
-            return existing
-        }
-        let controller = _makeFolderWatchController()
-        controller.delegate = self
-        _folderWatchController = controller
-        synchronizeFolderWatchState()
-        return controller
-    }
-
-    private var folderWatchControllerIfCreated: ReaderFolderWatchController? {
-        _folderWatchController
     }
 
     // MARK: - Init
@@ -129,7 +101,7 @@ final class ReaderSidebarDocumentController {
             return store
         }
         self.makeReaderStore = resolvedMakeReaderStore
-        self._makeFolderWatchController = makeFolderWatchController ?? {
+        let resolvedMakeFolderWatchController = makeFolderWatchController ?? {
             ReaderFolderWatchController(
                 folderWatcher: FolderChangeWatcher(),
                 settingsStore: settingsStore,
@@ -140,6 +112,9 @@ final class ReaderSidebarDocumentController {
                 )
             )
         }
+        folderWatchCoordinator = FolderWatchSessionCoordinator(
+            makeFolderWatchController: resolvedMakeFolderWatchController
+        )
 
         let initialDocument = Document(id: UUID(), readerStore: resolvedMakeReaderStore(), normalizedFileURL: nil)
         documentList = SidebarDocumentList(initialDocument: initialDocument)
@@ -147,13 +122,8 @@ final class ReaderSidebarDocumentController {
         selectedWindowTitle = initialDocument.readerStore.windowTitle
         selectedFileURL = initialDocument.readerStore.fileURL
         selectedHasUnacknowledgedExternalChange = initialDocument.readerStore.hasUnacknowledgedExternalChange
-        selectedFolderWatchAutoOpenWarning = nil
-        activeFolderWatchSession = nil
-        isFolderWatchInitialScanInProgress = false
-        didFolderWatchInitialScanFail = false
-        contentScanProgress = nil
-        scannedFileCount = nil
         rowStateComputer.rebuildAllRowStates(from: documentList.documents)
+        folderWatchCoordinator.delegate = self
     }
 
     // MARK: - Selection
@@ -164,10 +134,6 @@ final class ReaderSidebarDocumentController {
 
     var selectedReaderStore: ReaderStore {
         selectedDocument?.readerStore ?? documents[0].readerStore
-    }
-
-    var canStopFolderWatch: Bool {
-        activeFolderWatchSession != nil
     }
 
     func setStoreConfigurator(_ configurator: @escaping (ReaderStore) -> Void) {
@@ -251,7 +217,7 @@ final class ReaderSidebarDocumentController {
             if let existingDocument = document(for: fileURL) {
                 if existingDocument.readerStore.isDeferredDocument, assignment.loadMode == .loadFully {
                     let store = existingDocument.readerStore
-                    let effectiveSession = resolvedFolderWatchSession(
+                    let effectiveSession = folderWatchCoordinator.resolvedFolderWatchSession(
                         for: fileURL,
                         requestedSession: plan.folderWatchSession
                     )
@@ -267,7 +233,7 @@ final class ReaderSidebarDocumentController {
                 continue
             }
 
-            let effectiveFolderWatchSession = resolvedFolderWatchSession(
+            let effectiveFolderWatchSession = folderWatchCoordinator.resolvedFolderWatchSession(
                 for: fileURL,
                 requestedSession: plan.folderWatchSession
             )
@@ -446,54 +412,7 @@ final class ReaderSidebarDocumentController {
         bindSelectedStore()
     }
 
-    // MARK: - Folder watch
-
-    func startWatchingFolder(
-        folderURL: URL,
-        options: ReaderFolderWatchOptions,
-        performInitialAutoOpen: Bool = true
-    ) throws {
-        try folderWatchController.startWatching(
-            folderURL: folderURL,
-            options: options,
-            performInitialAutoOpen: performInitialAutoOpen
-        )
-    }
-
-    func scanCurrentMarkdownFiles(completion: @escaping @MainActor ([URL]) -> Void) {
-        folderWatchController.scanCurrentMarkdownFiles(completion: completion)
-    }
-
-    func stopFolderWatch() {
-        folderWatchController.stopWatching()
-    }
-
-    func updateFolderWatchExcludedSubdirectories(_ paths: [String]) throws {
-        try folderWatchController.updateExcludedSubdirectories(paths)
-    }
-
-    func stopWatchingFolders(_ documentIDs: Set<UUID>) {
-        guard let session = activeFolderWatchSession,
-              let watchController = folderWatchControllerIfCreated else {
-            return
-        }
-
-        let normalizedFolder = session.folderURL
-        let hasWatchedDocument = documentIDs.contains { documentID in
-            guard let document = documents.first(where: { $0.id == documentID }),
-                  let normalizedFileURL = document.normalizedFileURL else {
-                return false
-            }
-            return watchController.watchApplies(
-                normalizedFileURL: normalizedFileURL,
-                toNormalizedFolderAt: normalizedFolder,
-                scope: session.options.scope
-            )
-        }
-
-        guard hasWatchedDocument else { return }
-        watchController.stopWatching()
-    }
+    // MARK: - Document actions
 
     func openDocumentsInApplication(_ application: ReaderExternalApplication?, documentIDs: Set<UUID>) {
         for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
@@ -505,34 +424,6 @@ final class ReaderSidebarDocumentController {
         for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.fileURL != nil {
             document.readerStore.revealCurrentFileInFinder()
         }
-    }
-
-    func dismissFolderWatchAutoOpenWarnings() {
-        folderWatchController.dismissFolderWatchAutoOpenWarning()
-    }
-
-    func dismissPendingFileSelectionRequest() {
-        folderWatchController.pendingFileSelectionRequest = nil
-        pendingFileSelectionRequest = nil
-    }
-
-    func watchedDocumentIDs() -> Set<UUID> {
-        guard let session = activeFolderWatchSession,
-              let watchController = folderWatchControllerIfCreated else {
-            return []
-        }
-
-        let normalizedFolder = session.folderURL
-        return Set(documents.compactMap { document in
-            guard let normalizedFileURL = document.normalizedFileURL else {
-                return nil
-            }
-            return watchController.watchApplies(
-                normalizedFileURL: normalizedFileURL,
-                toNormalizedFolderAt: normalizedFolder,
-                scope: session.options.scope
-            ) ? document.id : nil
-        })
     }
 
     // MARK: - Private helpers
@@ -576,98 +467,12 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    private func resolvedFolderWatchSession(
-        for fileURL: URL,
-        requestedSession: ReaderFolderWatchSession?
-    ) -> ReaderFolderWatchSession? {
-        if let requestedSession {
-            return requestedSession
-        }
-
-        guard let watchController = folderWatchControllerIfCreated,
-              watchController.watchApplies(to: fileURL) else {
-            return nil
-        }
-
-        return activeFolderWatchSession
-    }
-
-    private func synchronizeFolderWatchState() {
-        guard let controller = _folderWatchController else {
-            activeFolderWatchSession = nil
-            selectedFolderWatchAutoOpenWarning = nil
-            pendingFileSelectionRequest = nil
-            isFolderWatchInitialScanInProgress = false
-            didFolderWatchInitialScanFail = false
-            contentScanProgress = nil
-            scannedFileCount = nil
-            return
-        }
-        activeFolderWatchSession = controller.activeFolderWatchSession
-        selectedFolderWatchAutoOpenWarning = controller.folderWatchAutoOpenWarning
-        pendingFileSelectionRequest = controller.pendingFileSelectionRequest
-        isFolderWatchInitialScanInProgress = controller.isInitialMarkdownScanInProgress
-        didFolderWatchInitialScanFail = controller.didInitialMarkdownScanFail
-        contentScanProgress = controller.contentScanProgress
-        scannedFileCount = controller.scannedFileCount
-    }
 }
 
-// MARK: - ReaderFolderWatchControllerDelegate
+// MARK: - FolderWatchSessionCoordinatorDelegate
 
-extension ReaderSidebarDocumentController: ReaderFolderWatchControllerDelegate {
-    func folderWatchControllerCurrentDocumentFileURL(_ controller: ReaderFolderWatchController) -> URL? {
-        selectedReaderStore.fileURL
-    }
-
-    func folderWatchControllerOpenDocumentFileURLs(_ controller: ReaderFolderWatchController) -> [URL] {
-        documents.compactMap { document in
-            document.readerStore.isDeferredDocument ? nil : document.readerStore.fileURL
-        }
-    }
-
-    func folderWatchController(
-        _ controller: ReaderFolderWatchController,
-        handleEvents events: [ReaderFolderWatchChangeEvent],
-        in session: ReaderFolderWatchSession,
-        origin: ReaderOpenOrigin
-    ) {
-        let coordinator = fileOpenCoordinator
-        let diffBaselineByURL: [URL: String] = Dictionary(
-            uniqueKeysWithValues: events.compactMap { event in
-                guard let previousMarkdown = event.previousMarkdown else {
-                    return nil
-                }
-                return (ReaderFileRouting.normalizedFileURL(event.fileURL), previousMarkdown)
-            }
-        )
-
-        let materializationStrategy: FileOpenRequest.MaterializationStrategy =
-            origin == .folderWatchInitialBatchAutoOpen ? .deferOnly : .loadAll
-
-        coordinator.open(FileOpenRequest(
-            fileURLs: events.map(\.fileURL),
-            origin: origin,
-            folderWatchSession: session,
-            initialDiffBaselineMarkdownByURL: diffBaselineByURL,
-            slotStrategy: .reuseEmptySlotForFirst,
-            materializationStrategy: materializationStrategy
-        ))
-    }
-
-    func folderWatchController(_ controller: ReaderFolderWatchController, didLiveAutoOpenFileURLs urls: [URL]) {
-        for url in urls {
-            if let doc = document(for: url) {
-                doc.readerStore.noteObservedExternalChange(kind: .added)
-            }
-        }
-    }
-
-    func folderWatchControllerShouldSelectNewestDocument(_ controller: ReaderFolderWatchController) {
-        selectDocumentWithNewestModificationDate()
-    }
-
-    func folderWatchControllerStateDidChange(_ controller: ReaderFolderWatchController) {
-        synchronizeFolderWatchState()
+extension ReaderSidebarDocumentController: FolderWatchSessionCoordinatorDelegate {
+    func handleFolderWatchOpenRequest(_ request: FileOpenRequest) {
+        fileOpenCoordinator.open(request)
     }
 }

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -21,6 +21,7 @@ final class ReaderSidebarDocumentController {
     @ObservationIgnored private let observationManager = SidebarObservationManager()
     let folderWatchCoordinator: FolderWatchSessionCoordinator
     @ObservationIgnored private let fileOpenPlanExecutor: FileOpenPlanExecutor
+    @ObservationIgnored private let documentCloseCoordinator: DocumentCloseCoordinator
 
     // MARK: - Selection state
 
@@ -124,6 +125,11 @@ final class ReaderSidebarDocumentController {
             observationManager: observationManager,
             rowStateComputer: rowStateComputer
         )
+        documentCloseCoordinator = DocumentCloseCoordinator(
+            documentList: documentList,
+            observationManager: observationManager,
+            rowStateComputer: rowStateComputer
+        )
         selectedDocumentID = initialDocument.id
         selectedWindowTitle = initialDocument.readerStore.windowTitle
         selectedFileURL = initialDocument.readerStore.fileURL
@@ -131,6 +137,7 @@ final class ReaderSidebarDocumentController {
         rowStateComputer.rebuildAllRowStates(from: documentList.documents)
         folderWatchCoordinator.delegate = self
         fileOpenPlanExecutor.delegate = self
+        documentCloseCoordinator.delegate = self
     }
 
     // MARK: - Selection
@@ -151,7 +158,10 @@ final class ReaderSidebarDocumentController {
     }
 
     func selectDocument(_ documentID: UUID?) {
-        observationManager.ensureSetup(for: documents, onStoreChanged: makeStoreChangedHandler())
+        observationManager.ensureSetup(for: documents) { [weak self] documentID in
+            guard let self else { return }
+            self.rowStateComputer.updateRowStateIfNeeded(for: documentID, in: self.documents)
+        }
         guard let documentID,
               documents.contains(where: { $0.id == documentID }) else {
             return
@@ -202,87 +212,23 @@ final class ReaderSidebarDocumentController {
     // MARK: - Document close
 
     func closeDocument(_ documentID: UUID) {
-        guard let removed = documentList.remove(documentID: documentID) else {
-            return
-        }
-
-        if documents.isEmpty {
-            let replacement = makeDocument()
-            documentList.replaceAll(with: [replacement])
-            if let storeConfigurator {
-                storeConfigurator(replacement.readerStore)
-            }
-            selectedDocumentID = replacement.id
-            synchronizeAndRebuild()
-            bindSelectedStore()
-            return
-        }
-
-        if selectedDocumentID == documentID {
-            let nextIndex = min(removed.index, documents.count - 1)
-            selectedDocumentID = documents[nextIndex].id
-        }
-
-        synchronizeAndRebuild()
-        bindSelectedStore()
+        documentCloseCoordinator.closeDocument(documentID)
     }
 
     func closeOtherDocuments(keeping documentID: UUID) {
-        closeOtherDocuments(keeping: [documentID])
+        documentCloseCoordinator.closeOtherDocuments(keeping: documentID)
     }
 
     func closeOtherDocuments(keeping documentIDs: Set<UUID>) {
-        let retainedDocuments = documents.filter { documentIDs.contains($0.id) }
-        guard !retainedDocuments.isEmpty else {
-            return
-        }
-
-        documentList.replaceAll(with: retainedDocuments)
-
-        if !retainedDocuments.contains(where: { $0.id == selectedDocumentID }) {
-            selectedDocumentID = retainedDocuments[0].id
-        }
-
-        synchronizeAndRebuild()
-        bindSelectedStore()
+        documentCloseCoordinator.closeOtherDocuments(keeping: documentIDs)
     }
 
     func closeDocuments(_ documentIDs: Set<UUID>) {
-        guard !documentIDs.isEmpty else {
-            return
-        }
-
-        let removedDocuments = documents.filter { documentIDs.contains($0.id) }
-        guard !removedDocuments.isEmpty else {
-            return
-        }
-
-        if removedDocuments.count >= documents.count {
-            closeAllDocuments()
-            return
-        }
-
-        let remainingDocuments = documents.filter { !documentIDs.contains($0.id) }
-        documentList.replaceAll(with: remainingDocuments)
-
-        if !remainingDocuments.contains(where: { $0.id == selectedDocumentID }) {
-            selectedDocumentID = remainingDocuments[0].id
-        }
-
-        synchronizeAndRebuild()
-        bindSelectedStore()
+        documentCloseCoordinator.closeDocuments(documentIDs)
     }
 
     func closeAllDocuments() {
-        let replacement = makeDocument()
-        if let storeConfigurator {
-            storeConfigurator(replacement.readerStore)
-        }
-
-        documentList.replaceAll(with: [replacement])
-        selectedDocumentID = replacement.id
-        synchronizeAndRebuild()
-        bindSelectedStore()
+        documentCloseCoordinator.closeAllDocuments()
     }
 
     // MARK: - Document actions
@@ -328,29 +274,15 @@ final class ReaderSidebarDocumentController {
         }
     }
 
-    private func synchronizeAndRebuild() {
-        observationManager.synchronize(for: documents, onStoreChanged: makeStoreChangedHandler())
-        rowStateComputer.rebuildAllRowStates(from: documents)
-    }
-
-    private func makeStoreChangedHandler() -> @MainActor (UUID) -> Void {
-        return { [weak self] documentID in
-            guard let self else { return }
-            self.rowStateComputer.updateRowStateIfNeeded(for: documentID, in: self.documents)
-        }
-    }
-
 }
 
-// MARK: - FolderWatchSessionCoordinatorDelegate
+// MARK: - Delegate conformances
 
 extension ReaderSidebarDocumentController: FolderWatchSessionCoordinatorDelegate {
     func handleFolderWatchOpenRequest(_ request: FileOpenRequest) {
         fileOpenCoordinator.open(request)
     }
 }
-
-// MARK: - FileOpenPlanExecutorDelegate
 
 extension ReaderSidebarDocumentController: FileOpenPlanExecutorDelegate {
     func resolvedFolderWatchSession(
@@ -363,3 +295,5 @@ extension ReaderSidebarDocumentController: FileOpenPlanExecutorDelegate {
         )
     }
 }
+
+extension ReaderSidebarDocumentController: DocumentCloseCoordinatorDelegate {}

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -36,8 +36,8 @@ struct ContentViewAdapter: View {
             settingsStore: settingsStore,
             folderWatchState: ContentViewFolderWatchState(
                 activeFolderWatch: sharedFolderWatchSession,
-                isFolderWatchInitialScanInProgress: sidebarDocumentController.isFolderWatchInitialScanInProgress,
-                isFolderWatchInitialScanFailed: sidebarDocumentController.didFolderWatchInitialScanFail,
+                isFolderWatchInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
+                isFolderWatchInitialScanFailed: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
                 canStopFolderWatch: canStopSharedFolderWatch,
                 pendingFolderWatchURL: pendingFolderWatchURL,
                 isCurrentWatchAFavorite: isCurrentWatchAFavorite,

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -88,7 +88,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
     }
 
     private var watchedDocumentIDs: Set<UUID> {
-        controller.watchedDocumentIDs()
+        controller.folderWatchCoordinator.watchedDocumentIDs()
     }
 
     private var sidebarColumn: some View {

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -162,7 +162,7 @@ struct ReaderWindowRootView: View {
 
     private func windowLifecycleBaseView<Content: View>(_ view: Content) -> some View {
         @Bindable var warningCoordinator = folderWatchWarningCoordinator
-        @Bindable var sidebarController = sidebarDocumentController
+        @Bindable var folderWatchCoordinator = sidebarDocumentController.folderWatchCoordinator
         return view
             .sheet(item: $warningCoordinator.activeFlow, onDismiss: {
                 dismissFolderWatchAutoOpenWarning()
@@ -177,16 +177,16 @@ struct ReaderWindowRootView: View {
                     }
                 )
             }
-            .sheet(item: $sidebarController.pendingFileSelectionRequest, onDismiss: {
-                sidebarDocumentController.dismissPendingFileSelectionRequest()
+            .sheet(item: $folderWatchCoordinator.pendingFileSelectionRequest, onDismiss: {
+                sidebarDocumentController.folderWatchCoordinator.dismissPendingFileSelectionRequest()
             }) { request in
                 FolderWatchFileSelectionSheetWrapper(
                     request: request,
                     onSkip: {
-                        sidebarDocumentController.dismissPendingFileSelectionRequest()
+                        sidebarDocumentController.folderWatchCoordinator.dismissPendingFileSelectionRequest()
                     },
                     onConfirm: { selectedFileURLs in
-                        sidebarDocumentController.dismissPendingFileSelectionRequest()
+                        sidebarDocumentController.folderWatchCoordinator.dismissPendingFileSelectionRequest()
                         fileOpenCoordinator.open(FileOpenRequest(
                             fileURLs: selectedFileURLs,
                             origin: .folderWatchInitialBatchAutoOpen,
@@ -301,10 +301,10 @@ struct ReaderWindowRootView: View {
 
     private func windowLifecycleChangeObservers<Content: View>(_ view: Content) -> some View {
         view
-            .onChange(of: sidebarDocumentController.selectedFolderWatchAutoOpenWarning) { _, warning in
+            .onChange(of: sidebarDocumentController.folderWatchCoordinator.selectedFolderWatchAutoOpenWarning) { _, warning in
                 handleFolderWatchAutoOpenWarningChange(warning)
             }
-            .onChange(of: sidebarDocumentController.activeFolderWatchSession) { _, _ in
+            .onChange(of: sidebarDocumentController.folderWatchCoordinator.activeFolderWatchSession) { _, _ in
                 refreshWindowShellState()
             }
             .onChange(of: isFolderWatchOptionsPresented) { _, isPresented in
@@ -553,8 +553,8 @@ struct ReaderWindowRootView: View {
             ToolbarItem(placement: .navigation) {
                 FolderWatchToolbarButton(
                     activeFolderWatch: sharedFolderWatchSession,
-                    isInitialScanInProgress: sidebarDocumentController.isFolderWatchInitialScanInProgress,
-                    didInitialScanFail: sidebarDocumentController.didFolderWatchInitialScanFail,
+                    isInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
+                    didInitialScanFail: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
                     favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
                     recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
                     onActivate: {

--- a/minimark/Views/SidebarScanProgressView.swift
+++ b/minimark/Views/SidebarScanProgressView.swift
@@ -4,7 +4,7 @@ struct SidebarScanProgressView: View {
     var controller: ReaderSidebarDocumentController
 
     var body: some View {
-        if let session = controller.activeFolderWatchSession {
+        if let session = controller.folderWatchCoordinator.activeFolderWatchSession {
             VStack(spacing: 0) {
                 Divider()
                 footerContent(session: session)
@@ -15,7 +15,7 @@ struct SidebarScanProgressView: View {
 
     private func footerContent(session: ReaderFolderWatchSession) -> some View {
         HStack(spacing: 6) {
-            if let progress = controller.contentScanProgress, !progress.isFinished {
+            if let progress = controller.folderWatchCoordinator.contentScanProgress, !progress.isFinished {
                 ProgressView(value: Double(progress.completed), total: max(Double(progress.total), 1))
                     .progressViewStyle(.linear)
                     .frame(maxWidth: 60)
@@ -29,7 +29,7 @@ struct SidebarScanProgressView: View {
                     .fill(Color.green)
                     .frame(width: 6, height: 6)
 
-                if let fileCount = controller.scannedFileCount, fileCount > 0 {
+                if let fileCount = controller.folderWatchCoordinator.scannedFileCount, fileCount > 0 {
                     Text("\(fileCount) \(fileCount == 1 ? "file" : "files")")
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)
@@ -44,6 +44,6 @@ struct SidebarScanProgressView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-        .animation(.easeInOut(duration: 0.3), value: controller.contentScanProgress?.isFinished)
+        .animation(.easeInOut(duration: 0.3), value: controller.folderWatchCoordinator.contentScanProgress?.isFinished)
     }
 }

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -55,8 +55,8 @@ final class ReaderWindowCoordinator {
 
     func sharedFolderWatchState() -> (session: ReaderFolderWatchSession?, canStop: Bool) {
         (
-            sidebarDocumentController.activeFolderWatchSession,
-            sidebarDocumentController.canStopFolderWatch
+            sidebarDocumentController.folderWatchCoordinator.activeFolderWatchSession,
+            sidebarDocumentController.folderWatchCoordinator.canStopFolderWatch
         )
     }
 

--- a/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowRootView+SidebarCommandFlow.swift
@@ -143,7 +143,7 @@ extension ReaderWindowRootView {
         _ entry: ReaderFavoriteWatchedFolder,
         resolvedFolderURL: URL
     ) {
-        sidebarDocumentController.scanCurrentMarkdownFiles { scannedURLs in
+        sidebarDocumentController.folderWatchCoordinator.scanCurrentMarkdownFiles { scannedURLs in
             guard let session = sharedFolderWatchSession else {
                 return
             }
@@ -243,7 +243,7 @@ extension ReaderWindowRootView {
         }
 
         do {
-            try sidebarDocumentController.startWatchingFolder(
+            try sidebarDocumentController.folderWatchCoordinator.startWatchingFolder(
                 folderURL: folderURL,
                 options: options,
                 performInitialAutoOpen: performInitialAutoOpen
@@ -280,7 +280,7 @@ extension ReaderWindowRootView {
 
     func stopWatchingSidebarFolders(_ documentIDs: Set<UUID>) {
         performSidebarMutation {
-            sidebarDocumentController.stopWatchingFolders(documentIDs)
+            sidebarDocumentController.folderWatchCoordinator.stopWatchingFolders(documentIDs)
         }
     }
 
@@ -331,7 +331,7 @@ extension ReaderWindowRootView {
         syncFavoriteExclusionsIfNeeded(newExcludedPaths)
 
         do {
-            try sidebarDocumentController.updateFolderWatchExcludedSubdirectories(newExcludedPaths)
+            try sidebarDocumentController.folderWatchCoordinator.updateFolderWatchExcludedSubdirectories(newExcludedPaths)
         } catch {
             sidebarDocumentController.selectedReaderStore.presentError(error)
             return false
@@ -389,7 +389,7 @@ extension ReaderWindowRootView {
             return normalized.hasSuffix("/") ? normalized : normalized + "/"
         }
 
-        sidebarDocumentController.scanCurrentMarkdownFiles { [self] scannedURLs in
+        sidebarDocumentController.folderWatchCoordinator.scanCurrentMarkdownFiles { [self] scannedURLs in
             guard let session = sharedFolderWatchSession else { return }
 
             let alreadyOpenPaths = Set(

--- a/minimark/Views/Window/Flow/ReaderWindowRootView+WarningFlow.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowRootView+WarningFlow.swift
@@ -24,7 +24,7 @@ extension ReaderWindowRootView {
         groupStateController.pinnedGroupIDs = []
         groupStateController.collapsedGroupIDs = []
         sidebarWidth = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
-        sidebarDocumentController.stopFolderWatch()
+        sidebarDocumentController.folderWatchCoordinator.stopFolderWatch()
         refreshWindowPresentation()
         cancelFolderWatch()
     }
@@ -36,13 +36,13 @@ extension ReaderWindowRootView {
     }
 
     func refreshFolderWatchAutoOpenWarningPresentation() {
-        let warning = sidebarDocumentController.selectedFolderWatchAutoOpenWarning
+        let warning = sidebarDocumentController.folderWatchCoordinator.selectedFolderWatchAutoOpenWarning
         handleFolderWatchAutoOpenWarningChange(warning)
     }
 
     func dismissFolderWatchAutoOpenWarning() {
         folderWatchWarningCoordinator.dismiss {
-            sidebarDocumentController.dismissFolderWatchAutoOpenWarnings()
+            sidebarDocumentController.folderWatchCoordinator.dismissFolderWatchAutoOpenWarnings()
         }
     }
 

--- a/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
+++ b/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
@@ -198,7 +198,7 @@ struct EditFolderWatchExclusionsTests {
         )
 
         let coordinator = FileOpenCoordinator(controller: controller)
-        try controller.startWatchingFolder(
+        try controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: tempDir,
             options: ReaderFolderWatchOptions(
                 openMode: .watchChangesOnly,

--- a/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@MainActor
+struct DocumentCloseCoordinatorTests {
+    // MARK: - Test doubles
+
+    final class MockDelegate: DocumentCloseCoordinatorDelegate {
+        var selectedDocumentID: UUID
+        var storeConfigurator: ((ReaderStore) -> Void)?
+        var bindSelectedStoreCalled = false
+        let makeDocumentFactory: () -> ReaderSidebarDocumentController.Document
+
+        init(
+            selectedDocumentID: UUID,
+            makeDocument: @escaping () -> ReaderSidebarDocumentController.Document
+        ) {
+            self.selectedDocumentID = selectedDocumentID
+            self.makeDocumentFactory = makeDocument
+        }
+
+        func makeDocument() -> ReaderSidebarDocumentController.Document {
+            makeDocumentFactory()
+        }
+
+        func bindSelectedStore() {
+            bindSelectedStoreCalled = true
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func makeStore(settingsStore: ReaderSettingsStore) -> ReaderStore {
+        let settler = ReaderAutoOpenSettler(settlingInterval: 1.0)
+        let securityScopeResolver = SecurityScopeResolver(
+            securityScope: TestSecurityScopeAccess(),
+            settingsStore: settingsStore,
+            requestWatchedFolderReauthorization: { _ in nil }
+        )
+        return ReaderStore(
+            rendering: ReaderRenderingDependencies(
+                renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
+            ),
+            file: ReaderFileDependencies(
+                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+            ),
+            folderWatch: ReaderFolderWatchDependencies(
+                autoOpenPlanner: ReaderFolderWatchAutoOpenPlanner(),
+                settler: settler,
+                systemNotifier: TestReaderSystemNotifier()
+            ),
+            settingsStore: settingsStore,
+            securityScopeResolver: securityScopeResolver
+        )
+    }
+
+    private static func makeDocument(settingsStore: ReaderSettingsStore) -> ReaderSidebarDocumentController.Document {
+        ReaderSidebarDocumentController.Document(
+            id: UUID(),
+            readerStore: makeStore(settingsStore: settingsStore),
+            normalizedFileURL: nil
+        )
+    }
+
+    private static func makeHarness(documentCount: Int = 1) -> (
+        coordinator: DocumentCloseCoordinator,
+        delegate: MockDelegate,
+        documentList: SidebarDocumentList
+    ) {
+        let settingsStore = ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "test.\(UUID().uuidString)"
+        )
+        let initialDocument = makeDocument(settingsStore: settingsStore)
+        let documentList = SidebarDocumentList(initialDocument: initialDocument)
+
+        for _ in 1..<documentCount {
+            documentList.append(makeDocument(settingsStore: settingsStore))
+        }
+
+        let coordinator = DocumentCloseCoordinator(
+            documentList: documentList,
+            observationManager: SidebarObservationManager(),
+            rowStateComputer: SidebarRowStateComputer()
+        )
+
+        let delegate = MockDelegate(
+            selectedDocumentID: initialDocument.id,
+            makeDocument: { makeDocument(settingsStore: settingsStore) }
+        )
+        coordinator.delegate = delegate
+
+        return (coordinator, delegate, documentList)
+    }
+
+    // MARK: - Tests
+
+    @Test func closeLastDocumentCreatesReplacement() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 1)
+        let originalID = documentList.documents[0].id
+
+        coordinator.closeDocument(originalID)
+
+        #expect(documentList.documents.count == 1)
+        #expect(documentList.documents[0].id != originalID)
+        #expect(delegate.selectedDocumentID == documentList.documents[0].id)
+        #expect(delegate.bindSelectedStoreCalled)
+    }
+
+    @Test func closeDocumentRemovesFromList() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 3)
+        _ = delegate  // prevent deallocation of weak delegate
+        let idToRemove = documentList.documents[1].id
+
+        coordinator.closeDocument(idToRemove)
+
+        #expect(documentList.documents.count == 2)
+        #expect(!documentList.documents.contains(where: { $0.id == idToRemove }))
+    }
+
+    @Test func closeSelectedDocumentUpdatesSelection() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 3)
+        let selectedID = documentList.documents[1].id
+        delegate.selectedDocumentID = selectedID
+
+        coordinator.closeDocument(selectedID)
+
+        #expect(delegate.selectedDocumentID != selectedID)
+        #expect(documentList.documents.contains(where: { $0.id == delegate.selectedDocumentID }))
+    }
+
+    @Test func closeOtherDocumentsRetainsSpecified() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 3)
+        let keepID = documentList.documents[1].id
+        delegate.selectedDocumentID = keepID
+
+        coordinator.closeOtherDocuments(keeping: keepID)
+
+        #expect(documentList.documents.count == 1)
+        #expect(documentList.documents[0].id == keepID)
+        #expect(delegate.selectedDocumentID == keepID)
+    }
+
+    @Test func closeAllDocumentsCreatesReplacement() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 3)
+
+        coordinator.closeAllDocuments()
+
+        #expect(documentList.documents.count == 1)
+        #expect(delegate.selectedDocumentID == documentList.documents[0].id)
+        #expect(delegate.bindSelectedStoreCalled)
+    }
+
+    @Test func closeDocumentsWithSetRemovesMultiple() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 4)
+        _ = delegate  // prevent deallocation of weak delegate
+        let idsToRemove: Set<UUID> = [documentList.documents[1].id, documentList.documents[2].id]
+
+        coordinator.closeDocuments(idsToRemove)
+
+        #expect(documentList.documents.count == 2)
+        for id in idsToRemove {
+            #expect(!documentList.documents.contains(where: { $0.id == id }))
+        }
+    }
+
+    @Test func closeDocumentsWithAllDocumentsCreatesReplacement() {
+        let (coordinator, delegate, documentList) = Self.makeHarness(documentCount: 2)
+        let allIDs = Set(documentList.documents.map(\.id))
+
+        coordinator.closeDocuments(allIDs)
+
+        #expect(documentList.documents.count == 1)
+        #expect(!allIDs.contains(delegate.selectedDocumentID))
+        #expect(delegate.bindSelectedStoreCalled)
+    }
+}

--- a/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
+++ b/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@MainActor
+struct FileOpenPlanExecutorTests {
+    // MARK: - Test doubles
+
+    final class MockDelegate: FileOpenPlanExecutorDelegate {
+        var selectedDocumentID: UUID
+        var selectedReaderStore: ReaderStore
+        var storeConfigurator: ((ReaderStore) -> Void)?
+        var selectDocumentCalls: [UUID?] = []
+        var bindSelectedStoreCalled = false
+        var makeDocumentFactory: () -> ReaderSidebarDocumentController.Document
+
+        init(
+            selectedDocumentID: UUID,
+            selectedReaderStore: ReaderStore,
+            makeDocument: @escaping () -> ReaderSidebarDocumentController.Document
+        ) {
+            self.selectedDocumentID = selectedDocumentID
+            self.selectedReaderStore = selectedReaderStore
+            self.makeDocumentFactory = makeDocument
+        }
+
+        func makeDocument() -> ReaderSidebarDocumentController.Document {
+            makeDocumentFactory()
+        }
+
+        func selectDocument(_ documentID: UUID?) {
+            selectDocumentCalls.append(documentID)
+        }
+
+        func bindSelectedStore() {
+            bindSelectedStoreCalled = true
+        }
+
+        func resolvedFolderWatchSession(
+            for fileURL: URL,
+            requestedSession: ReaderFolderWatchSession?
+        ) -> ReaderFolderWatchSession? {
+            requestedSession
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func makeStore(settingsStore: ReaderSettingsStore) -> ReaderStore {
+        let settler = ReaderAutoOpenSettler(settlingInterval: 1.0)
+        let securityScopeResolver = SecurityScopeResolver(
+            securityScope: TestSecurityScopeAccess(),
+            settingsStore: settingsStore,
+            requestWatchedFolderReauthorization: { _ in nil }
+        )
+        return ReaderStore(
+            rendering: ReaderRenderingDependencies(
+                renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
+            ),
+            file: ReaderFileDependencies(
+                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+            ),
+            folderWatch: ReaderFolderWatchDependencies(
+                autoOpenPlanner: ReaderFolderWatchAutoOpenPlanner(),
+                settler: settler,
+                systemNotifier: TestReaderSystemNotifier()
+            ),
+            settingsStore: settingsStore,
+            securityScopeResolver: securityScopeResolver
+        )
+    }
+
+    private static func makeHarness() -> (
+        executor: FileOpenPlanExecutor,
+        delegate: MockDelegate,
+        documentList: SidebarDocumentList,
+        settingsStore: ReaderSettingsStore
+    ) {
+        let settingsStore = ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "test.\(UUID().uuidString)"
+        )
+        let initialStore = makeStore(settingsStore: settingsStore)
+        let initialDocument = ReaderSidebarDocumentController.Document(
+            id: UUID(), readerStore: initialStore, normalizedFileURL: nil
+        )
+        let documentList = SidebarDocumentList(initialDocument: initialDocument)
+        let observationManager = SidebarObservationManager()
+        let rowStateComputer = SidebarRowStateComputer()
+        rowStateComputer.rebuildAllRowStates(from: documentList.documents)
+
+        let executor = FileOpenPlanExecutor(
+            documentList: documentList,
+            observationManager: observationManager,
+            rowStateComputer: rowStateComputer
+        )
+
+        let delegate = MockDelegate(
+            selectedDocumentID: initialDocument.id,
+            selectedReaderStore: initialStore,
+            makeDocument: {
+                ReaderSidebarDocumentController.Document(
+                    id: UUID(),
+                    readerStore: makeStore(settingsStore: settingsStore),
+                    normalizedFileURL: nil
+                )
+            }
+        )
+        executor.delegate = delegate
+
+        return (executor, delegate, documentList, settingsStore)
+    }
+
+    // MARK: - Tests
+
+    @Test func executePlanWithEmptyAssignmentsDoesNothing() {
+        let (executor, delegate, documentList, _) = Self.makeHarness()
+        let plan = FileOpenPlan(
+            assignments: [],
+            origin: .manual,
+            folderWatchSession: nil,
+            materializationStrategy: .loadAll
+        )
+
+        executor.executePlan(plan)
+
+        #expect(documentList.documents.count == 1)
+        #expect(delegate.bindSelectedStoreCalled == false)
+    }
+
+    @Test func executePlanAppendsNewDocumentForCreateNewTarget() throws {
+        let (executor, delegate, documentList, _) = Self.makeHarness()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plan-executor-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("test.md")
+        try "# Test".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let plan = FileOpenPlan(
+            assignments: [
+                FileOpenPlan.SlotAssignment(
+                    fileURL: fileURL,
+                    target: .createNew,
+                    loadMode: .loadFully,
+                    initialDiffBaselineMarkdown: nil
+                )
+            ],
+            origin: .manual,
+            folderWatchSession: nil,
+            materializationStrategy: .loadAll
+        )
+
+        executor.executePlan(plan)
+
+        #expect(documentList.documents.count == 2)
+        #expect(delegate.bindSelectedStoreCalled == true)
+    }
+
+    @Test func selectDocumentWithNewestModificationDateCallsDelegate() throws {
+        let (executor, delegate, documentList, settingsStore) = Self.makeHarness()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plan-executor-newest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("newest.md")
+        try "# Newest".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        // Add a document with a file
+        let store = Self.makeStore(settingsStore: settingsStore)
+        store.openFile(at: fileURL, origin: .manual)
+        let doc = ReaderSidebarDocumentController.Document(
+            id: UUID(), readerStore: store, normalizedFileURL: fileURL
+        )
+        documentList.append(doc)
+
+        executor.selectDocumentWithNewestModificationDate()
+
+        #expect(delegate.selectDocumentCalls.contains(doc.id))
+    }
+}

--- a/minimarkTests/Sidebar/FolderWatchSessionCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/FolderWatchSessionCoordinatorTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@MainActor
+struct FolderWatchSessionCoordinatorTests {
+    // MARK: - Test doubles
+
+    final class MockDelegate: FolderWatchSessionCoordinatorDelegate {
+        var documents: [ReaderSidebarDocumentController.Document] = []
+        var _selectedReaderStore: ReaderStore?
+        var selectedReaderStore: ReaderStore { _selectedReaderStore! }
+        var documentForURLResult: ReaderSidebarDocumentController.Document?
+        var selectNewestCalled = false
+        var lastOpenRequest: FileOpenRequest?
+
+        func document(for fileURL: URL) -> ReaderSidebarDocumentController.Document? {
+            documentForURLResult
+        }
+
+        func selectDocumentWithNewestModificationDate() {
+            selectNewestCalled = true
+        }
+
+        func handleFolderWatchOpenRequest(_ request: FileOpenRequest) {
+            lastOpenRequest = request
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test func initialStateHasNilProperties() {
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            fatalError("Should not be called")
+        })
+
+        #expect(owner.activeFolderWatchSession == nil)
+        #expect(owner.isFolderWatchInitialScanInProgress == false)
+        #expect(owner.didFolderWatchInitialScanFail == false)
+        #expect(owner.contentScanProgress == nil)
+        #expect(owner.scannedFileCount == nil)
+        #expect(owner.canStopFolderWatch == false)
+    }
+
+    @Test func folderWatchControllerCreatedLazilyOnFirstUse() throws {
+        var controllerCreated = false
+        let settingsStore = ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "test.\(UUID().uuidString)"
+        )
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            controllerCreated = true
+            return ReaderFolderWatchController(
+                folderWatcher: TestFolderWatcher(),
+                settingsStore: settingsStore,
+                securityScope: TestSecurityScopeAccess(),
+                systemNotifier: TestReaderSystemNotifier(),
+                folderWatchAutoOpenPlanner: ReaderFolderWatchAutoOpenPlanner()
+            )
+        })
+        owner.delegate = MockDelegate()
+
+        #expect(owner.folderWatchControllerIfCreated == nil)
+        #expect(controllerCreated == false)
+
+        // Trigger lazy creation via a pass-through method
+        owner.stopFolderWatch()
+
+        #expect(controllerCreated == true)
+        #expect(owner.folderWatchControllerIfCreated != nil)
+    }
+
+    @Test func resolvedFolderWatchSessionReturnsRequestedSessionWhenProvided() {
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            fatalError("Should not be called")
+        })
+        let session = ReaderFolderWatchSession(
+            folderURL: URL(fileURLWithPath: "/tmp/test"),
+            options: .default,
+            startedAt: .now
+        )
+
+        let result = owner.resolvedFolderWatchSession(
+            for: URL(fileURLWithPath: "/tmp/test/file.md"),
+            requestedSession: session
+        )
+
+        #expect(result == session)
+    }
+
+    @Test func resolvedFolderWatchSessionReturnsNilWhenNoWatchActive() {
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            fatalError("Should not be called")
+        })
+
+        let result = owner.resolvedFolderWatchSession(
+            for: URL(fileURLWithPath: "/tmp/test/file.md"),
+            requestedSession: nil
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func watchedDocumentIDsReturnsEmptyWhenNoWatchActive() {
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            fatalError("Should not be called")
+        })
+        let delegate = MockDelegate()
+        owner.delegate = delegate
+
+        #expect(owner.watchedDocumentIDs().isEmpty)
+    }
+
+    @Test func canStopFolderWatchReflectsActiveSession() {
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            fatalError("Should not be called")
+        })
+
+        #expect(owner.canStopFolderWatch == false)
+        // Note: canStopFolderWatch becomes true only after a folder watch starts
+        // and synchronizeFolderWatchState runs — tested via integration tests
+    }
+
+    @Test func dismissPendingFileSelectionRequestClearsBothProperties() {
+        let settingsStore = ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "test.\(UUID().uuidString)"
+        )
+        let owner = FolderWatchSessionCoordinator(makeFolderWatchController: {
+            ReaderFolderWatchController(
+                folderWatcher: TestFolderWatcher(),
+                settingsStore: settingsStore,
+                securityScope: TestSecurityScopeAccess(),
+                systemNotifier: TestReaderSystemNotifier(),
+                folderWatchAutoOpenPlanner: ReaderFolderWatchAutoOpenPlanner()
+            )
+        })
+        owner.delegate = MockDelegate()
+
+        // Force controller creation, then dismiss
+        owner.stopFolderWatch()
+        owner.dismissPendingFileSelectionRequest()
+
+        #expect(owner.pendingFileSelectionRequest == nil)
+        #expect(owner.folderWatchControllerIfCreated?.pendingFileSelectionRequest == nil)
+    }
+}

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -101,7 +101,7 @@ struct ReaderSidebarDocumentControllerTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: .default
         )
@@ -115,14 +115,14 @@ struct ReaderSidebarDocumentControllerTests {
         coordinator.open(FileOpenRequest(
             fileURLs: [missingFileURL],
             origin: .folderWatchAutoOpen,
-            folderWatchSession: harness.controller.activeFolderWatchSession,
+            folderWatchSession: harness.controller.folderWatchCoordinator.activeFolderWatchSession,
             slotStrategy: .alwaysAppend
         ))
 
         #expect(harness.controller.documents.count == 1)
         #expect(harness.controller.selectedReaderStore.fileURL == nil)
-        #expect(harness.controller.canStopFolderWatch)
-        #expect(harness.controller.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
+        #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
+        #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
         #expect(harness.folderWatchControllerWatcher.stopCallCount == stopCallCountBeforeFailedOpen)
     }
 
@@ -135,7 +135,7 @@ struct ReaderSidebarDocumentControllerTests {
             code: 91
         )
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(
                 openMode: .openAllMarkdownFiles,
@@ -143,9 +143,9 @@ struct ReaderSidebarDocumentControllerTests {
             )
         )
 
-        #expect(harness.controller.isFolderWatchInitialScanInProgress)
+        #expect(harness.controller.folderWatchCoordinator.isFolderWatchInitialScanInProgress)
         #expect(await waitUntil(timeout: .seconds(2)) {
-            harness.controller.didFolderWatchInitialScanFail && !harness.controller.isFolderWatchInitialScanInProgress
+            harness.controller.folderWatchCoordinator.didFolderWatchInitialScanFail && !harness.controller.folderWatchCoordinator.isFolderWatchInitialScanInProgress
         })
     }
 
@@ -153,17 +153,17 @@ struct ReaderSidebarDocumentControllerTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: .default
         )
 
-        #expect(harness.controller.canStopFolderWatch)
+        #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
 
-        harness.controller.stopFolderWatch()
+        harness.controller.folderWatchCoordinator.stopFolderWatch()
 
-        #expect(!harness.controller.canStopFolderWatch)
-        #expect(harness.controller.activeFolderWatchSession == nil)
+        #expect(!harness.controller.folderWatchCoordinator.canStopFolderWatch)
+        #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession == nil)
         #expect(harness.folderWatchControllerWatcher.stopCallCount >= 1)
     }
 
@@ -171,7 +171,7 @@ struct ReaderSidebarDocumentControllerTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: .default
         )
@@ -191,7 +191,7 @@ struct ReaderSidebarDocumentControllerTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: .default
         )
@@ -222,7 +222,7 @@ struct ReaderSidebarDocumentControllerTests {
             origin: .manual
         ))
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
         )
@@ -235,14 +235,14 @@ struct ReaderSidebarDocumentControllerTests {
 
             return document.id
         })
-        #expect(harness.controller.watchedDocumentIDs() == topLevelDocumentIDs)
+        #expect(harness.controller.folderWatchCoordinator.watchedDocumentIDs() == topLevelDocumentIDs)
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .includeSubfolders)
         )
 
-        #expect(harness.controller.watchedDocumentIDs() == Set(harness.controller.documents.map(\.id)))
+        #expect(harness.controller.folderWatchCoordinator.watchedDocumentIDs() == Set(harness.controller.documents.map(\.id)))
     }
 
     @Test @MainActor func sidebarControllerWatchChangesOnlyWithIncludedSubfoldersDoesNotCreateInitialDocuments() async throws {
@@ -309,7 +309,7 @@ struct ReaderSidebarDocumentControllerTests {
         try "# Top Level".write(to: topLevelFileURL, atomically: false, encoding: .utf8)
         try "# Nested".write(to: nestedFileURL, atomically: false, encoding: .utf8)
 
-        try controller.startWatchingFolder(
+        try controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: directoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .includeSubfolders)
         )
@@ -340,7 +340,7 @@ struct ReaderSidebarDocumentControllerTests {
             ]
         )
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: favoriteEntry.options
         )
@@ -349,7 +349,7 @@ struct ReaderSidebarDocumentControllerTests {
         coordinator.open(FileOpenRequest(
             fileURLs: favoriteEntry.resolvedOpenDocumentFileURLs(relativeTo: harness.temporaryDirectoryURL),
             origin: .folderWatchInitialBatchAutoOpen,
-            folderWatchSession: harness.controller.activeFolderWatchSession,
+            folderWatchSession: harness.controller.folderWatchCoordinator.activeFolderWatchSession,
             materializationStrategy: .deferThenMaterializeSelected
         ))
 
@@ -427,14 +427,14 @@ struct ReaderSidebarDocumentControllerTests {
         }
         harness.folderWatchControllerWatcher.markdownFilesToReturn = fileURLs
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         )
 
-        #expect(harness.controller.pendingFileSelectionRequest != nil)
-        #expect(harness.controller.pendingFileSelectionRequest?.allFileURLs.count == performanceLimit + 1)
-        #expect(harness.controller.selectedFolderWatchAutoOpenWarning == nil)
+        #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest != nil)
+        #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest?.allFileURLs.count == performanceLimit + 1)
+        #expect(harness.controller.folderWatchCoordinator.selectedFolderWatchAutoOpenWarning == nil)
     }
 
     @Test @MainActor func sidebarControllerCanSkipInitialAutoOpenPromptForFavoriteRestore() throws {
@@ -447,13 +447,13 @@ struct ReaderSidebarDocumentControllerTests {
         }
         harness.folderWatchControllerWatcher.markdownFilesToReturn = fileURLs
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly),
             performInitialAutoOpen: false
         )
 
-        #expect(harness.controller.pendingFileSelectionRequest == nil)
+        #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest == nil)
         #expect(harness.controller.documents.count == 1)
         #expect(harness.controller.selectedReaderStore.fileURL == nil)
     }
@@ -468,7 +468,7 @@ struct ReaderSidebarDocumentControllerTests {
             origin: .manual
         ))
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
         )
@@ -487,7 +487,7 @@ struct ReaderSidebarDocumentControllerTests {
         await Task.yield()
 
         #expect(harness.controller.documents.count == autoOpenLimit + 1)
-        #expect(harness.controller.selectedFolderWatchAutoOpenWarning == nil)
+        #expect(harness.controller.folderWatchCoordinator.selectedFolderWatchAutoOpenWarning == nil)
     }
 
     @Test @MainActor func sidebarControllerCloseOtherDocumentsKeepsRequestedDocumentOnly() throws {
@@ -558,7 +558,7 @@ struct ReaderSidebarDocumentControllerTests {
         ))
         harness.controller.selectDocument(harness.controller.documents[0].id)
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: .default
         )
@@ -570,8 +570,8 @@ struct ReaderSidebarDocumentControllerTests {
 
         #expect(harness.controller.documents.count == 1)
         #expect(harness.controller.selectedReaderStore.fileURL == nil)
-        #expect(harness.controller.canStopFolderWatch)
-        #expect(harness.controller.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
+        #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
+        #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
         #expect(watcher.stopCallCount == stopCallCountBeforeCloseAll)
     }
 
@@ -587,7 +587,7 @@ struct ReaderSidebarDocumentControllerTests {
             thirdFileURL
         ]
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         )
@@ -597,8 +597,8 @@ struct ReaderSidebarDocumentControllerTests {
 
         harness.controller.closeDocuments(documentIDsToClose)
 
-        #expect(harness.controller.canStopFolderWatch)
-        #expect(harness.controller.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
+        #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
+        #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
         #expect(harness.controller.documents.map(\.id) == [remainingDocumentID])
     }
 
@@ -617,16 +617,16 @@ struct ReaderSidebarDocumentControllerTests {
             subfolderFileURL
         ]
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .includeSubfolders)
         )
 
         // The includeSubfolders path runs the scan asynchronously.
-        #expect(harness.controller.isFolderWatchInitialScanInProgress)
+        #expect(harness.controller.folderWatchCoordinator.isFolderWatchInitialScanInProgress)
 
         #expect(await waitUntil(timeout: .seconds(2)) {
-            !harness.controller.isFolderWatchInitialScanInProgress
+            !harness.controller.folderWatchCoordinator.isFolderWatchInitialScanInProgress
         })
 
         #expect(harness.controller.documents.count == 3)
@@ -634,7 +634,7 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(openFileURLPaths.contains(harness.primaryFileURL.path))
         #expect(openFileURLPaths.contains(harness.secondaryFileURL.path))
         #expect(openFileURLPaths.contains(subfolderFileURL.path))
-        #expect(!harness.controller.didFolderWatchInitialScanFail)
+        #expect(!harness.controller.folderWatchCoordinator.didFolderWatchInitialScanFail)
     }
 
     @Test @MainActor func sidebarControllerFileSelectionBurstReusesInitialEmptyDocument() throws {
@@ -725,12 +725,12 @@ struct ReaderSidebarDocumentControllerTests {
         }
         harness.folderWatchControllerWatcher.markdownFilesToReturn = fileURLs
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         )
 
-        #expect(harness.controller.pendingFileSelectionRequest == nil)
+        #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest == nil)
         #expect(harness.controller.documents.count == fileCount)
 
         let loadedDocs = harness.controller.documents.filter { !$0.readerStore.isDeferredDocument }
@@ -824,12 +824,12 @@ struct ReaderSidebarDocumentControllerTests {
         }
         harness.folderWatchControllerWatcher.markdownFilesToReturn = fileURLs
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         )
 
-        #expect(harness.controller.pendingFileSelectionRequest == nil)
+        #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest == nil)
         #expect(harness.controller.documents.count == fileCount)
 
         // All files should be fully loaded (none deferred)
@@ -1081,7 +1081,7 @@ struct ReaderSidebarDocumentControllerTests {
             origin: .manual
         ))
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
         )
@@ -1120,7 +1120,7 @@ struct ReaderSidebarDocumentControllerTests {
             origin: .manual
         ))
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
         )
@@ -1187,7 +1187,7 @@ struct ReaderSidebarDocumentControllerTests {
             harness.secondaryFileURL
         ]
 
-        try harness.controller.startWatchingFolder(
+        try harness.controller.folderWatchCoordinator.startWatchingFolder(
             folderURL: harness.temporaryDirectoryURL,
             options: ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         )
@@ -1297,8 +1297,8 @@ struct ReaderSidebarDocumentControllerTests {
         )
 
         #expect(!controllerCreated)
-        #expect(controller.activeFolderWatchSession == nil)
-        #expect(!controller.isFolderWatchInitialScanInProgress)
+        #expect(controller.folderWatchCoordinator.activeFolderWatchSession == nil)
+        #expect(!controller.folderWatchCoordinator.isFolderWatchInitialScanInProgress)
         #expect(controller.documents.count == 1)
         _ = controller
     }


### PR DESCRIPTION
## Summary

Closes #292. Reduces `ReaderSidebarDocumentController` from 673 lines to **299 lines** by extracting three coordinator types:

- **`FolderWatchSessionCoordinator`** (248 lines) — owns lazy `ReaderFolderWatchController` lifecycle, 7 folder watch state properties, pass-through methods, and `ReaderFolderWatchControllerDelegate` conformance
- **`FileOpenPlanExecutor`** (222 lines) — owns `executePlan`, materialization strategy, deferred document materialization, newest-document selection
- **`DocumentCloseCoordinator`** (141 lines) — owns 5 close methods with shared list-mutation + selection-fixup pattern

Each coordinator communicates with the controller through a narrow delegate protocol. Views access folder watch state through `controller.folderWatchCoordinator`. Plan execution and close methods keep thin forwarding stubs on the controller.

## Test plan

- [ ] All 3 new types have independent unit tests (17 tests total)
- [ ] All existing sidebar tests pass unchanged (integration tests go through the controller's forwarding methods)
- [ ] Full test suite passes
- [ ] Build succeeds