### PR TITLE
Refine settings UX and theme selector responsiveness

### DIFF
--- a/docs/superpowers/plans/2026-04-14-theme-selector-redesign.md
+++ b/docs/superpowers/plans/2026-04-14-theme-selector-redesign.md
@@ -1,542 +1,65 @@
-# Theme Selector Redesign — Implementation Plan
+# Theme Selector Redesign — Implementation Plan (As Implemented)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+## Goal
 
-**Goal:** Replace the picker-based theme section in `ReaderSettingsView` with a three-column layout (reader themes with light/dark tabs | syntax themes | live preview) and a dedicated Apply button.
+Replace picker-only theme controls in `ReaderSettingsView` with a clearer, staged,
+three-column selector that supports browsing reader and syntax themes with live
+preview before applying.
 
-**Architecture:** A staging view model (`ThemeSelectorViewModel`) holds candidate reader/syntax theme selections. The preview reads from staged values. Apply writes to `ReaderSettingsStore`, which triggers the existing rendering pipeline. The view replaces only the "Theme" `Section` inside the existing `ReaderSettingsView` `Form`.
+## Final Architecture
 
-**Tech Stack:** SwiftUI (macOS), `@Observable`, existing `ReaderSettingsStore` / `ReaderThemeKind` / `SyntaxThemeKind` / `ThemeDefinition` types.
+- `ThemeSelectorView` owns staging state directly via `@State`.
+- `ThemeSelectorView` renders:
+  - reader-theme column (with light/dark segmentation)
+  - syntax-theme column (or disabled state when theme controls syntax)
+  - preview column (`ThemePreviewCard`)
+  - apply/reset bar with unsaved state and locked-window hint
+- `ReaderSettingsStore` remains the write target for committed changes:
+  - `updateTheme(...)`
+  - `updateSyntaxTheme(...)`
 
-**Worktree:** `.worktrees/theme-selector-redesign` on branch `feature/297-theme-selector-redesign` (based on `develop`).
+## Layout Strategy
 
----
-
-## File Structure
-
-| Action | Path | Responsibility |
-|--------|------|---------------|
-| Create | `minimark/Views/ThemeSelectorView.swift` | Three-column layout, apply/reset bar, staging wiring |
-| Create | `minimark/Views/ThemeCardView.swift` | Reusable card component for list items |
-| Modify | `minimark/Views/ReaderSettingsView.swift` | Replace "Theme" section with `ThemeSelectorView`; keep `ThemePreviewCard` for reuse |
-| Unchanged | `minimark/Stores/ReaderSettingsStore.swift` | Existing `updateTheme` / `updateSyntaxTheme` called as-is |
-| Unchanged | All theme model files | No changes to `ReaderTheme`, `SyntaxTheme`, `ThemeDefinition`, etc. |
-
----
-
-### Task 1: Create `ThemeCardView`
-
-**Files:**
-- Create: `minimark/Views/ThemeCardView.swift`
-
-- [ ] **Step 1: Create the file with the reader theme card**
+The shipped layout uses minimum widths rather than ratio-based geometry:
 
 ```swift
-import SwiftUI
-
-struct ReaderThemeCard: View {
-    let kind: ReaderThemeKind
-    let isSelected: Bool
-    let action: () -> Void
-
-    private var theme: ReaderTheme {
-        ReaderTheme.theme(for: kind)
-    }
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color(hex: theme.backgroundHex) ?? Color(nsColor: .controlBackgroundColor))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .stroke(Color(hex: theme.foregroundHex)?.opacity(0.2) ?? .clear, lineWidth: 1)
-                    )
-                    .frame(width: 28, height: 28)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(kind.displayName)
-                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
+struct ThemeSelectorColumnWidths {
+    static let readerMin: CGFloat = 180
+    static let syntaxMin: CGFloat = 180
+    static let previewMin: CGFloat = 320
 }
 ```
 
-- [ ] **Step 2: Add the syntax theme card in the same file**
-
-```swift
-struct SyntaxThemeCard: View {
-    let kind: SyntaxThemeKind
-    let isSelected: Bool
-    let action: () -> Void
-
-    private var palette: SyntaxThemePreviewPalette {
-        kind.previewPalette
-    }
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: palette.keywordHex) ?? .gray,
-                                Color(hex: palette.stringHex) ?? .gray,
-                                Color(hex: palette.numberHex) ?? .gray,
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: 28, height: 18)
-
-                Text(kind.displayName)
-                    .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-}
-```
-
-- [ ] **Step 3: Build the project to verify compilation**
-
-Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
-
-Expected: Build succeeds (the new views are not yet referenced, but must compile on their own — they reference existing types).
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add minimark/Views/ThemeCardView.swift
-git commit -m "Add ReaderThemeCard and SyntaxThemeCard components"
-```
-
----
-
-### Task 2: Create `ThemeSelectorView` — staging view with three-column layout
-
-**Files:**
-- Create: `minimark/Views/ThemeSelectorView.swift`
-
-This is the largest task. The view manages its own staging state inline (no separate ViewModel file — the state is simple enough to keep in the view, matching the codebase pattern where views like `FolderWatchOptionsSheet.swift` embed a `FolderWatchOptionsViewModel` in the same file).
-
-- [ ] **Step 1: Create `ThemeSelectorView` with staging state and full layout**
-
-```swift
-import SwiftUI
-
-private enum ColumnLayout {
-    static let selectorRatio: CGFloat = 0.25
-    static let previewRatio: CGFloat = 0.50
-}
-
-struct ThemeSelectorView: View {
-    private let settingsStore: ReaderSettingsStore
-
-    @State private var stagedReaderTheme: ReaderThemeKind
-    @State private var stagedSyntaxTheme: SyntaxThemeKind
-    @State private var selectedBackgroundTab: BackgroundTab = .light
-
-    init(settingsStore: ReaderSettingsStore) {
-        self.settingsStore = settingsStore
-        self._stagedReaderTheme = State(initialValue: settingsStore.currentSettings.readerTheme)
-        self._stagedSyntaxTheme = State(initialValue: settingsStore.currentSettings.syntaxTheme)
-        self._selectedBackgroundTab = State(
-            initialValue: settingsStore.currentSettings.readerTheme.isDark ? .dark : .light
-        )
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            threeColumnLayout
-            applyBar
-        }
-    }
-
-    // MARK: - Three-Column Layout
-
-    private var threeColumnLayout: some View {
-        GeometryReader { geometry in
-            let totalWidth = geometry.size.width
-            let selectorWidth = totalWidth * ColumnLayout.selectorRatio
-            let previewWidth = totalWidth * ColumnLayout.previewRatio
-
-            HStack(spacing: 12) {
-                readerThemesColumn
-                    .frame(width: selectorWidth)
-
-                syntaxThemesColumn
-                    .frame(width: selectorWidth)
-
-                previewColumn
-                    .frame(width: previewWidth)
-            }
-        }
-        .frame(minHeight: 340)
-    }
-
-    // MARK: - Reader Themes Column
-
-    private var readerThemesColumn: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Reader Theme")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            Picker("Background", selection: $selectedBackgroundTab) {
-                Text("Light").tag(BackgroundTab.light)
-                Text("Dark").tag(BackgroundTab.dark)
-            }
-            .pickerStyle(.segmented)
-            .onChange(of: selectedBackgroundTab) { _, newTab in
-                if !filteredReaderThemes.contains(stagedReaderTheme) {
-                    stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme
-                }
-            }
-
-            ScrollView {
-                VStack(spacing: 4) {
-                    ForEach(filteredReaderThemes, id: \.self) { kind in
-                        ReaderThemeCard(
-                            kind: kind,
-                            isSelected: kind == stagedReaderTheme
-                        ) {
-                            stagedReaderTheme = kind
-                        }
-                    }
-                }
-            }
-        }
-        .padding(12)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-    }
-
-    // MARK: - Syntax Themes Column
-
-    private var syntaxThemesColumn: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Syntax Theme")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            if syntaxHighlightingControlledByTheme {
-                Spacer()
-                VStack(spacing: 8) {
-                    Image(systemName: "paintbrush.fill")
-                        .font(.title2)
-                        .foregroundStyle(.secondary)
-                    Text("Syntax highlighting is controlled by the active theme.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity)
-                Spacer()
-            } else {
-                ScrollView {
-                    VStack(spacing: 4) {
-                        ForEach(SyntaxThemeKind.allCases, id: \.self) { kind in
-                            SyntaxThemeCard(
-                                kind: kind,
-                                isSelected: kind == stagedSyntaxTheme
-                            ) {
-                                stagedSyntaxTheme = kind
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .padding(12)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-    }
-
-    // MARK: - Preview Column
-
-    private var previewColumn: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Preview")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            ThemePreviewCard(settings: previewSettings)
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Theme preview")
-        }
-        .padding(12)
-        .background(Color(nsColor: .controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-    }
-
-    // MARK: - Apply Bar
-
-    private var applyBar: some View {
-        HStack {
-            Text("Current: \(appliedReaderTheme.displayName) + \(appliedSyntaxTheme.displayName)")
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-
-            Spacer()
-
-            if WindowAppearanceController.lockedWindowCount > 0 {
-                HStack(spacing: 4) {
-                    Image(systemName: "lock.fill")
-                        .font(.system(size: 9))
-                    Text("Some windows locked")
-                }
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-            }
-
-            if hasUnsavedChanges {
-                Text("Unsaved changes")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.orange)
-            }
-
-            Button("Reset") {
-                stagedReaderTheme = appliedReaderTheme
-                stagedSyntaxTheme = appliedSyntaxTheme
-                selectedBackgroundTab = appliedReaderTheme.isDark ? .dark : .light
-            }
-            .disabled(!hasUnsavedChanges)
-
-            Button("Apply") {
-                applyStagedChanges()
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(!hasUnsavedChanges)
-        }
-        .padding(.horizontal, 4)
-        .padding(.top, 12)
-    }
-
-    // MARK: - Computed
-
-    private var filteredReaderThemes: [ReaderThemeKind] {
-        ReaderThemeKind.allCases.filter {
-            selectedBackgroundTab == .light ? !$0.isDark : $0.isDark
-        }
-    }
-
-    private var syntaxHighlightingControlledByTheme: Bool {
-        stagedReaderTheme.themeDefinition.providesSyntaxHighlighting
-    }
-
-    private var hasUnsavedChanges: Bool {
-        stagedReaderTheme != appliedReaderTheme || stagedSyntaxTheme != appliedSyntaxTheme
-    }
-
-    private var appliedReaderTheme: ReaderThemeKind {
-        settingsStore.currentSettings.readerTheme
-    }
-
-    private var appliedSyntaxTheme: SyntaxThemeKind {
-        settingsStore.currentSettings.syntaxTheme
-    }
-
-    private var previewSettings: ReaderSettings {
-        var settings = settingsStore.currentSettings
-        settings.readerTheme = stagedReaderTheme
-        settings.syntaxTheme = stagedSyntaxTheme
-        return settings
-    }
-
-    // MARK: - Actions
-
-    private func applyStagedChanges() {
-        if stagedReaderTheme != appliedReaderTheme {
-            settingsStore.updateTheme(stagedReaderTheme)
-        }
-        if stagedSyntaxTheme != appliedSyntaxTheme {
-            settingsStore.updateSyntaxTheme(stagedSyntaxTheme)
-        }
-    }
-}
-
-private enum BackgroundTab: String, CaseIterable {
-    case light
-    case dark
-}
-```
-
-- [ ] **Step 2: Build the project to verify compilation**
-
-Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
-
-Expected: Build succeeds.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add minimark/Views/ThemeSelectorView.swift
-git commit -m "Add ThemeSelectorView with three-column layout and staging"
-```
-
----
-
-### Task 3: Integrate `ThemeSelectorView` into `ReaderSettingsView`
-
-**Files:**
-- Modify: `minimark/Views/ReaderSettingsView.swift`
-
-Replace the "Theme" section (lines 37–73) with the new `ThemeSelectorView`. Remove the standalone "Preview" section (lines 136–140) since preview is now embedded in the selector. Remove the now-unused `syntaxHighlightingControlledByTheme` and `lockedWindowsHint` computed properties from `ReaderSettingsView` (they are now handled inside `ThemeSelectorView`).
-
-- [ ] **Step 1: Replace the Theme section and remove the Preview section**
-
-In `ReaderSettingsView.swift`, replace the entire `Section("Theme")` block (lines 37–73) with:
-
-```swift
-            Section("Theme") {
-                Picker("App theme", selection: Binding(
-                    get: { settingsStore.currentSettings.appAppearance },
-                    set: { settingsStore.updateAppAppearance($0) }
-                )) {
-                    ForEach(AppAppearance.allCases, id: \.self) { appearance in
-                        Text(appearance.displayName).tag(appearance)
-                    }
-                }
-
-                ThemeSelectorView(settingsStore: settingsStore)
-            }
-```
-
-Then remove the `Section("Preview")` block (lines 136–140):
-
-```swift
-            Section("Preview") {
-                ThemePreviewCard(settings: settingsStore.currentSettings)
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Theme preview")
-            }
-```
-
-Remove the now-unused `lockedWindowsHint` computed property (lines 153–164) and `syntaxHighlightingControlledByTheme` computed property (lines 166–168).
-
-- [ ] **Step 2: Make `ThemePreviewCard` internal (remove `private`)**
-
-Change `private struct ThemePreviewCard` (line 237) to `struct ThemePreviewCard` so `ThemeSelectorView` can reference it.
-
-- [ ] **Step 3: Build the project**
-
-Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
-
-Expected: Build succeeds.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add minimark/Views/ReaderSettingsView.swift
-git commit -m "Integrate ThemeSelectorView into ReaderSettingsView"
-```
-
----
-
-### Task 4: Adjust settings window minimum size
-
-**Files:**
-- Modify: `minimark/Views/ReaderSettingsView.swift`
-
-The three-column layout needs more horizontal space than the previous picker-based form.
-
-- [ ] **Step 1: Update the minimum width**
-
-In `ReaderSettingsView`, change the frame modifier from:
-
-```swift
-.frame(minWidth: 560, minHeight: 720)
-```
-
-to:
-
-```swift
-.frame(minWidth: 780, minHeight: 720)
-```
-
-- [ ] **Step 2: Build and verify**
-
-Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
-
-Expected: Build succeeds.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add minimark/Views/ReaderSettingsView.swift
-git commit -m "Increase settings window min width for three-column theme layout"
-```
-
----
-
-### Task 5: Build verification and manual smoke test
-
-- [ ] **Step 1: Full clean build**
-
-Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' clean build`
-
-Expected: Build succeeds with no warnings related to the changed files.
-
-- [ ] **Step 2: Run unit tests**
-
-Run: `xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests`
-
-Expected: All existing tests pass (no test changes expected — the theme models and store are untouched).
-
-- [ ] **Step 3: Final commit (if any fixups needed)**
-
-If any issues were found and fixed, commit them.
-
----
-
-## Self-Review
-
-**Spec coverage:**
-- Three-column layout (25/25/50): Task 2 (`ColumnLayout` enum) ✓
-- Reader themes with light/dark tabs: Task 2 (`BackgroundTab` + filtered list) ✓
-- Scrollable lists: Task 2 (`ScrollView` in each column) ✓
-- Theme cards with color swatch + name: Task 1 (`ReaderThemeCard`, `SyntaxThemeCard`) ✓
-- Preview updates instantly: Task 2 (`previewSettings` computed from staged values) ✓
-- Apply/Reset bar with unsaved indicator: Task 2 (`applyBar`) ✓
-- Syntax column disabled message: Task 2 (`syntaxHighlightingControlledByTheme` branch) ✓
-- Locked windows hint: Task 2 (in `applyBar`) ✓
-- Column proportions configurable: Task 2 (`ColumnLayout` enum) ✓
-
-**Placeholder scan:** No TBDs, no "TODO", no "implement later". All code shown in full.
-
-**Type consistency:** `ReaderThemeKind`, `SyntaxThemeKind`, `ReaderSettings`, `ReaderSettingsStore`, `ThemeDefinition`, `SyntaxThemePreviewPalette`, `ThemePreviewCard` — all reference existing types correctly. `BackgroundTab` is defined in Task 2. `ColumnLayout` is defined in Task 2.
+Each column expands with `.frame(minWidth: ..., maxWidth: .infinity)`.
+
+## Files and Responsibilities
+
+| Path | Responsibility |
+|------|----------------|
+| `minimark/Views/ThemeSelectorView.swift` | Staged state, three-column layout, apply/reset behavior |
+| `minimark/Views/ThemeCardView.swift` | Reader and syntax card rows |
+| `minimark/Views/ReaderSettingsView.swift` | Hosts selector in custom sectioned settings layout |
+| `minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift` | Verifies column width constants and preview sample behavior |
+
+## Notable Decisions
+
+1. Keep state local to `ThemeSelectorView`.
+   - A separate `ThemeSelectorViewModel` was not introduced because the staged state
+     surface is small and view-local.
+2. Use minimum-width constraints instead of 25/25/50 ratio constants.
+   - This behaves better under resizing while keeping usability minimums.
+3. Keep the custom `ScrollView`-based settings containers in `ReaderSettingsView`.
+   - No return to `Form` / `.grouped` style.
+
+## Accessibility Notes
+
+Controls in the redesigned settings rows use meaningful labels (including visually
+hidden labels on pickers/toggle) so VoiceOver can identify them.
+
+## Verification Checklist
+
+- Build succeeds for `minimark` scheme in Debug.
+- Theme selector columns respect configured minimum widths.
+- Staged theme changes update preview immediately.
+- Apply writes changes via existing store update methods.
+- Reset restores staged values from currently applied settings.

--- a/docs/superpowers/plans/2026-04-14-theme-selector-redesign.md
+++ b/docs/superpowers/plans/2026-04-14-theme-selector-redesign.md
@@ -1,0 +1,542 @@
+# Theme Selector Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the picker-based theme section in `ReaderSettingsView` with a three-column layout (reader themes with light/dark tabs | syntax themes | live preview) and a dedicated Apply button.
+
+**Architecture:** A staging view model (`ThemeSelectorViewModel`) holds candidate reader/syntax theme selections. The preview reads from staged values. Apply writes to `ReaderSettingsStore`, which triggers the existing rendering pipeline. The view replaces only the "Theme" `Section` inside the existing `ReaderSettingsView` `Form`.
+
+**Tech Stack:** SwiftUI (macOS), `@Observable`, existing `ReaderSettingsStore` / `ReaderThemeKind` / `SyntaxThemeKind` / `ThemeDefinition` types.
+
+**Worktree:** `.worktrees/theme-selector-redesign` on branch `feature/297-theme-selector-redesign` (based on `develop`).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| Create | `minimark/Views/ThemeSelectorView.swift` | Three-column layout, apply/reset bar, staging wiring |
+| Create | `minimark/Views/ThemeCardView.swift` | Reusable card component for list items |
+| Modify | `minimark/Views/ReaderSettingsView.swift` | Replace "Theme" section with `ThemeSelectorView`; keep `ThemePreviewCard` for reuse |
+| Unchanged | `minimark/Stores/ReaderSettingsStore.swift` | Existing `updateTheme` / `updateSyntaxTheme` called as-is |
+| Unchanged | All theme model files | No changes to `ReaderTheme`, `SyntaxTheme`, `ThemeDefinition`, etc. |
+
+---
+
+### Task 1: Create `ThemeCardView`
+
+**Files:**
+- Create: `minimark/Views/ThemeCardView.swift`
+
+- [ ] **Step 1: Create the file with the reader theme card**
+
+```swift
+import SwiftUI
+
+struct ReaderThemeCard: View {
+    let kind: ReaderThemeKind
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var theme: ReaderTheme {
+        ReaderTheme.theme(for: kind)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color(hex: theme.backgroundHex) ?? Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(Color(hex: theme.foregroundHex)?.opacity(0.2) ?? .clear, lineWidth: 1)
+                    )
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(kind.displayName)
+                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 2: Add the syntax theme card in the same file**
+
+```swift
+struct SyntaxThemeCard: View {
+    let kind: SyntaxThemeKind
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var palette: SyntaxThemePreviewPalette {
+        kind.previewPalette
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color(hex: palette.keywordHex) ?? .gray,
+                                Color(hex: palette.stringHex) ?? .gray,
+                                Color(hex: palette.numberHex) ?? .gray,
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: 28, height: 18)
+
+                Text(kind.displayName)
+                    .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 3: Build the project to verify compilation**
+
+Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
+
+Expected: Build succeeds (the new views are not yet referenced, but must compile on their own — they reference existing types).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add minimark/Views/ThemeCardView.swift
+git commit -m "Add ReaderThemeCard and SyntaxThemeCard components"
+```
+
+---
+
+### Task 2: Create `ThemeSelectorView` — staging view with three-column layout
+
+**Files:**
+- Create: `minimark/Views/ThemeSelectorView.swift`
+
+This is the largest task. The view manages its own staging state inline (no separate ViewModel file — the state is simple enough to keep in the view, matching the codebase pattern where views like `FolderWatchOptionsSheet.swift` embed a `FolderWatchOptionsViewModel` in the same file).
+
+- [ ] **Step 1: Create `ThemeSelectorView` with staging state and full layout**
+
+```swift
+import SwiftUI
+
+private enum ColumnLayout {
+    static let selectorRatio: CGFloat = 0.25
+    static let previewRatio: CGFloat = 0.50
+}
+
+struct ThemeSelectorView: View {
+    private let settingsStore: ReaderSettingsStore
+
+    @State private var stagedReaderTheme: ReaderThemeKind
+    @State private var stagedSyntaxTheme: SyntaxThemeKind
+    @State private var selectedBackgroundTab: BackgroundTab = .light
+
+    init(settingsStore: ReaderSettingsStore) {
+        self.settingsStore = settingsStore
+        self._stagedReaderTheme = State(initialValue: settingsStore.currentSettings.readerTheme)
+        self._stagedSyntaxTheme = State(initialValue: settingsStore.currentSettings.syntaxTheme)
+        self._selectedBackgroundTab = State(
+            initialValue: settingsStore.currentSettings.readerTheme.isDark ? .dark : .light
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            threeColumnLayout
+            applyBar
+        }
+    }
+
+    // MARK: - Three-Column Layout
+
+    private var threeColumnLayout: some View {
+        GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let selectorWidth = totalWidth * ColumnLayout.selectorRatio
+            let previewWidth = totalWidth * ColumnLayout.previewRatio
+
+            HStack(spacing: 12) {
+                readerThemesColumn
+                    .frame(width: selectorWidth)
+
+                syntaxThemesColumn
+                    .frame(width: selectorWidth)
+
+                previewColumn
+                    .frame(width: previewWidth)
+            }
+        }
+        .frame(minHeight: 340)
+    }
+
+    // MARK: - Reader Themes Column
+
+    private var readerThemesColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Reader Theme")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Picker("Background", selection: $selectedBackgroundTab) {
+                Text("Light").tag(BackgroundTab.light)
+                Text("Dark").tag(BackgroundTab.dark)
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: selectedBackgroundTab) { _, newTab in
+                if !filteredReaderThemes.contains(stagedReaderTheme) {
+                    stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme
+                }
+            }
+
+            ScrollView {
+                VStack(spacing: 4) {
+                    ForEach(filteredReaderThemes, id: \.self) { kind in
+                        ReaderThemeCard(
+                            kind: kind,
+                            isSelected: kind == stagedReaderTheme
+                        ) {
+                            stagedReaderTheme = kind
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    // MARK: - Syntax Themes Column
+
+    private var syntaxThemesColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Syntax Theme")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            if syntaxHighlightingControlledByTheme {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "paintbrush.fill")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                    Text("Syntax highlighting is controlled by the active theme.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(spacing: 4) {
+                        ForEach(SyntaxThemeKind.allCases, id: \.self) { kind in
+                            SyntaxThemeCard(
+                                kind: kind,
+                                isSelected: kind == stagedSyntaxTheme
+                            ) {
+                                stagedSyntaxTheme = kind
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    // MARK: - Preview Column
+
+    private var previewColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preview")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ThemePreviewCard(settings: previewSettings)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Theme preview")
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    // MARK: - Apply Bar
+
+    private var applyBar: some View {
+        HStack {
+            Text("Current: \(appliedReaderTheme.displayName) + \(appliedSyntaxTheme.displayName)")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if WindowAppearanceController.lockedWindowCount > 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9))
+                    Text("Some windows locked")
+                }
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+            }
+
+            if hasUnsavedChanges {
+                Text("Unsaved changes")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.orange)
+            }
+
+            Button("Reset") {
+                stagedReaderTheme = appliedReaderTheme
+                stagedSyntaxTheme = appliedSyntaxTheme
+                selectedBackgroundTab = appliedReaderTheme.isDark ? .dark : .light
+            }
+            .disabled(!hasUnsavedChanges)
+
+            Button("Apply") {
+                applyStagedChanges()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!hasUnsavedChanges)
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 12)
+    }
+
+    // MARK: - Computed
+
+    private var filteredReaderThemes: [ReaderThemeKind] {
+        ReaderThemeKind.allCases.filter {
+            selectedBackgroundTab == .light ? !$0.isDark : $0.isDark
+        }
+    }
+
+    private var syntaxHighlightingControlledByTheme: Bool {
+        stagedReaderTheme.themeDefinition.providesSyntaxHighlighting
+    }
+
+    private var hasUnsavedChanges: Bool {
+        stagedReaderTheme != appliedReaderTheme || stagedSyntaxTheme != appliedSyntaxTheme
+    }
+
+    private var appliedReaderTheme: ReaderThemeKind {
+        settingsStore.currentSettings.readerTheme
+    }
+
+    private var appliedSyntaxTheme: SyntaxThemeKind {
+        settingsStore.currentSettings.syntaxTheme
+    }
+
+    private var previewSettings: ReaderSettings {
+        var settings = settingsStore.currentSettings
+        settings.readerTheme = stagedReaderTheme
+        settings.syntaxTheme = stagedSyntaxTheme
+        return settings
+    }
+
+    // MARK: - Actions
+
+    private func applyStagedChanges() {
+        if stagedReaderTheme != appliedReaderTheme {
+            settingsStore.updateTheme(stagedReaderTheme)
+        }
+        if stagedSyntaxTheme != appliedSyntaxTheme {
+            settingsStore.updateSyntaxTheme(stagedSyntaxTheme)
+        }
+    }
+}
+
+private enum BackgroundTab: String, CaseIterable {
+    case light
+    case dark
+}
+```
+
+- [ ] **Step 2: Build the project to verify compilation**
+
+Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add minimark/Views/ThemeSelectorView.swift
+git commit -m "Add ThemeSelectorView with three-column layout and staging"
+```
+
+---
+
+### Task 3: Integrate `ThemeSelectorView` into `ReaderSettingsView`
+
+**Files:**
+- Modify: `minimark/Views/ReaderSettingsView.swift`
+
+Replace the "Theme" section (lines 37–73) with the new `ThemeSelectorView`. Remove the standalone "Preview" section (lines 136–140) since preview is now embedded in the selector. Remove the now-unused `syntaxHighlightingControlledByTheme` and `lockedWindowsHint` computed properties from `ReaderSettingsView` (they are now handled inside `ThemeSelectorView`).
+
+- [ ] **Step 1: Replace the Theme section and remove the Preview section**
+
+In `ReaderSettingsView.swift`, replace the entire `Section("Theme")` block (lines 37–73) with:
+
+```swift
+            Section("Theme") {
+                Picker("App theme", selection: Binding(
+                    get: { settingsStore.currentSettings.appAppearance },
+                    set: { settingsStore.updateAppAppearance($0) }
+                )) {
+                    ForEach(AppAppearance.allCases, id: \.self) { appearance in
+                        Text(appearance.displayName).tag(appearance)
+                    }
+                }
+
+                ThemeSelectorView(settingsStore: settingsStore)
+            }
+```
+
+Then remove the `Section("Preview")` block (lines 136–140):
+
+```swift
+            Section("Preview") {
+                ThemePreviewCard(settings: settingsStore.currentSettings)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel("Theme preview")
+            }
+```
+
+Remove the now-unused `lockedWindowsHint` computed property (lines 153–164) and `syntaxHighlightingControlledByTheme` computed property (lines 166–168).
+
+- [ ] **Step 2: Make `ThemePreviewCard` internal (remove `private`)**
+
+Change `private struct ThemePreviewCard` (line 237) to `struct ThemePreviewCard` so `ThemeSelectorView` can reference it.
+
+- [ ] **Step 3: Build the project**
+
+Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add minimark/Views/ReaderSettingsView.swift
+git commit -m "Integrate ThemeSelectorView into ReaderSettingsView"
+```
+
+---
+
+### Task 4: Adjust settings window minimum size
+
+**Files:**
+- Modify: `minimark/Views/ReaderSettingsView.swift`
+
+The three-column layout needs more horizontal space than the previous picker-based form.
+
+- [ ] **Step 1: Update the minimum width**
+
+In `ReaderSettingsView`, change the frame modifier from:
+
+```swift
+.frame(minWidth: 560, minHeight: 720)
+```
+
+to:
+
+```swift
+.frame(minWidth: 780, minHeight: 720)
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add minimark/Views/ReaderSettingsView.swift
+git commit -m "Increase settings window min width for three-column theme layout"
+```
+
+---
+
+### Task 5: Build verification and manual smoke test
+
+- [ ] **Step 1: Full clean build**
+
+Run: `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' clean build`
+
+Expected: Build succeeds with no warnings related to the changed files.
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests`
+
+Expected: All existing tests pass (no test changes expected — the theme models and store are untouched).
+
+- [ ] **Step 3: Final commit (if any fixups needed)**
+
+If any issues were found and fixed, commit them.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Three-column layout (25/25/50): Task 2 (`ColumnLayout` enum) ✓
+- Reader themes with light/dark tabs: Task 2 (`BackgroundTab` + filtered list) ✓
+- Scrollable lists: Task 2 (`ScrollView` in each column) ✓
+- Theme cards with color swatch + name: Task 1 (`ReaderThemeCard`, `SyntaxThemeCard`) ✓
+- Preview updates instantly: Task 2 (`previewSettings` computed from staged values) ✓
+- Apply/Reset bar with unsaved indicator: Task 2 (`applyBar`) ✓
+- Syntax column disabled message: Task 2 (`syntaxHighlightingControlledByTheme` branch) ✓
+- Locked windows hint: Task 2 (in `applyBar`) ✓
+- Column proportions configurable: Task 2 (`ColumnLayout` enum) ✓
+
+**Placeholder scan:** No TBDs, no "TODO", no "implement later". All code shown in full.
+
+**Type consistency:** `ReaderThemeKind`, `SyntaxThemeKind`, `ReaderSettings`, `ReaderSettingsStore`, `ThemeDefinition`, `SyntaxThemePreviewPalette`, `ThemePreviewCard` — all reference existing types correctly. `BackgroundTab` is defined in Task 2. `ColumnLayout` is defined in Task 2.

--- a/docs/superpowers/specs/2026-04-14-theme-selector-redesign.md
+++ b/docs/superpowers/specs/2026-04-14-theme-selector-redesign.md
@@ -2,118 +2,82 @@
 
 ## Problem
 
-The current theme selector in `ReaderSettingsView.swift` uses standard macOS `Picker` dropdowns for reader themes and syntax themes. This provides a poor browsing experience — you can't see what a theme looks like without selecting it, and the small preview card at the bottom of the form is disconnected from the selection controls.
+The previous settings UI used compact `Picker` controls for reader and syntax themes.
+That made browsing themes slow because users could not compare options visually before
+committing a change.
 
-## Design
+## Implemented Design
 
-Replace the picker-based theme section with a **three-column layout** inline in the existing settings view:
+The Theme section now uses a dedicated three-column selector embedded in
+`ReaderSettingsView`:
 
-```
-┌──────────────┬──────────────┬──────────────────────────┐
-│ Reader Theme │ Syntax Theme │        Preview           │
-│  (25%)       │  (25%)       │        (50%)             │
-│              │              │                          │
-│ ☀ Light      │ ■ Monokai   │  Chapter One             │
-│ 🌙 Dark      │ ■ Dracula   │  It was a bright cold... │
-│              │ ■ Nord      │                          │
-│ ■ White/Black│ ■ GitHub    │  func greet(name:) {     │
-│ ■ Light Gray │ ■ One Light │    print("Hello")        │
-│ ■ Newspaper  │ ■ One Dark  │  }                       │
-│ ■ Focus      │             │                          │
-├──────────────┴──────────────┴──────────────────────────┤
-│ Current: White/Black + Monokai      [Reset]  [Apply]   │
-└─────────────────────────────────────────────────────────┘
-```
+1. Reader theme column with light/dark filtering tabs.
+2. Syntax theme column with cards (or a disabled explanatory state when syntax is
+   controlled by the selected reader theme).
+3. Live preview column showing staged changes immediately.
 
-### Column Layout
+An apply bar below the columns shows current applied values, unsaved state,
+window-lock hints, and `Reset` / `Apply` actions.
 
-Proportions are defined in a single configurable constant for easy adjustment:
+## Column Sizing Strategy
+
+The implementation uses minimum widths, not fixed proportional ratios.
+Columns are configured through `ThemeSelectorColumnWidths` in
+`minimark/Views/ThemeSelectorView.swift`:
 
 ```swift
-private enum ColumnLayout {
-    static let selectorRatio: CGFloat = 0.25
-    static let previewRatio: CGFloat = 0.50
+struct ThemeSelectorColumnWidths {
+    static let readerMin: CGFloat = 180
+    static let syntaxMin: CGFloat = 180
+    static let previewMin: CGFloat = 320
 }
 ```
 
-### Column 1: Reader Themes
+Each column uses `.frame(minWidth: ..., maxWidth: .infinity)` so the layout can
+expand with the available window width while preserving practical minimums.
 
-- **Segmented control** at the top: ☀ Light / 🌙 Dark, filtering the 11 `ReaderThemeKind` cases by `hasLightBackground`.
-- **Scrollable list** of theme cards below. Each card shows:
-  - A color swatch filled with the theme's background color.
-  - Theme display name.
-  - Short description tagline.
-- Selected theme highlighted with a purple border.
-- Clicking a theme **stages** it (updates the preview instantly but does not apply to reader windows).
+## State and Data Flow
 
-### Column 2: Syntax Themes
+Staging state is held directly in `ThemeSelectorView` via `@State`:
 
-- **Scrollable list** of all 12 `SyntaxThemeKind` cases. Each card shows:
-  - A gradient color strip representing the palette.
-  - Theme name.
-- Selected theme highlighted with a purple border.
-- **When the staged reader theme provides its own syntax highlighting** (`providesSyntaxHighlighting == true`), the entire column is replaced with a centered disabled-state message: *"Syntax highlighting is controlled by the active theme."* The staged syntax selection is preserved but hidden.
+- `stagedReaderTheme`
+- `stagedSyntaxTheme`
+- `selectedBackgroundTab`
 
-### Column 3: Preview
+Behavior:
 
-- Renders the existing `ThemePreviewCard` content (heading, body text, code block with syntax-colored tokens) using the **staged** reader theme and syntax theme.
-- Updates instantly as the user browses — no need to press Apply to see the preview.
+- Preview reads staged values immediately.
+- `Apply` writes staged values to `ReaderSettingsStore` via
+  `updateTheme` / `updateSyntaxTheme`.
+- `Reset` restores staged values from currently applied settings.
 
-### Apply / Reset Bar
+No separate `ThemeSelectorViewModel` file is used.
 
-- Spans the full width below the three columns.
-- **"Unsaved changes" indicator** appears when staged values differ from the currently applied values.
-- **Apply button**: writes staged values to `ReaderSettingsStore`, which triggers the existing Combine pipeline to update all unlocked reader windows.
-- **Reset button**: reverts staged values back to the currently applied values.
-- **Current state label**: shows the currently applied reader + syntax theme names.
+## Preview Behavior
 
-### Staging Mechanism
+`ThemePreviewCard` is used by `ThemeSelectorView` and now includes explicit reader
+text-color samples in addition to heading/body/code examples.
 
-A new `@Observable` view model (e.g. `ThemeSelectorViewModel`) holds:
+## Settings Layout
 
-```swift
-@ObservationIgnored private let settingsStore: ReaderSettingsStore
-var stagedReaderTheme: ReaderThemeKind
-var stagedSyntaxTheme: SyntaxThemeKind
-var hasUnsavedChanges: Bool { ... }
-```
+`ReaderSettingsView` uses a custom `ScrollView` + section container layout for this
+redesign, not the prior `Form` / `.grouped` structure.
 
-- Initialized from `settingsStore.currentSettings`.
-- The preview reads from staged values.
-- Apply writes staged values back to `settingsStore.updateTheme()` / `settingsStore.updateSyntaxTheme()`.
-- Reset copies current settings back to staged values.
+Accessibility labels are preserved on controls, including row pickers and toggle in
+the redesigned layout.
 
-### Theme-Controlled Syntax Behavior
+## Files Changed
 
-When the staged reader theme's `ThemeDefinition.providesSyntaxHighlighting` is true:
-- The syntax column shows a disabled overlay with explanation text.
-- The previously staged syntax theme is preserved internally so it restores if the user switches back to a theme that doesn't control syntax.
+| File | Role |
+|------|------|
+| `minimark/Views/ReaderSettingsView.swift` | Integrates settings sections and embeds `ThemeSelectorView` |
+| `minimark/Views/ThemeSelectorView.swift` | Three-column selector, staged state, apply/reset behavior |
+| `minimark/Views/ThemeCardView.swift` | Reusable reader and syntax theme card rows |
+| `minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift` | Verifies column minimum widths and preview sample output |
 
-### Locked Windows Hint
+## Constraints Preserved
 
-The existing locked windows hint from `ReaderSettingsView` is preserved and displayed in the apply bar area.
-
-## Files to Modify
-
-| File | Change |
-|------|--------|
-| `minimark/Views/ReaderSettingsView.swift` | Replace picker section with new three-column `ThemeSelectorView` |
-| `minimark/Views/ThemeSelectorView.swift` (new) | Main three-column layout, staging logic, apply/reset |
-| `minimark/Views/ThemeCardView.swift` (new) | Reusable card component for theme list items |
-| `minimark/ViewModels/ThemeSelectorViewModel.swift` (new) | Staging state, apply/reset actions |
-
-## Files Unchanged
-
-- `ReaderSettingsStore.swift` — existing `updateTheme` / `updateSyntaxTheme` methods used as-is.
-- All theme model files (`ReaderTheme.swift`, `SyntaxTheme.swift`, `ThemeDefinition.swift`, etc.).
-- All specialized theme files (Amber, Green, etc.).
-- Rendering pipeline (`ReaderStore+Rendering.swift`, `ReaderCSSFactory.swift`, etc.).
-- `ThemePreviewCard` — reused as-is inside the preview column.
-
-## Constraints
-
-- Column proportions must be a single easily-configurable constant, not scattered magic numbers.
-- No changes to the rendering or persistence pipeline — the staging VM calls the same `settingsStore` methods.
-- Preserve the existing `syntaxHighlightingControlledByTheme` behavior.
-- Preserve the locked windows hint.
-- Must work within the existing `Form` / `.grouped` settings style on macOS.
+- No rendering pipeline changes required.
+- Existing `ReaderSettingsStore` update methods remain the integration point.
+- Syntax-theme override behavior from reader theme definitions remains intact.
+- Locked-window hint remains visible in the apply bar.

--- a/docs/superpowers/specs/2026-04-14-theme-selector-redesign.md
+++ b/docs/superpowers/specs/2026-04-14-theme-selector-redesign.md
@@ -1,0 +1,119 @@
+# Theme Selector Redesign
+
+## Problem
+
+The current theme selector in `ReaderSettingsView.swift` uses standard macOS `Picker` dropdowns for reader themes and syntax themes. This provides a poor browsing experience — you can't see what a theme looks like without selecting it, and the small preview card at the bottom of the form is disconnected from the selection controls.
+
+## Design
+
+Replace the picker-based theme section with a **three-column layout** inline in the existing settings view:
+
+```
+┌──────────────┬──────────────┬──────────────────────────┐
+│ Reader Theme │ Syntax Theme │        Preview           │
+│  (25%)       │  (25%)       │        (50%)             │
+│              │              │                          │
+│ ☀ Light      │ ■ Monokai   │  Chapter One             │
+│ 🌙 Dark      │ ■ Dracula   │  It was a bright cold... │
+│              │ ■ Nord      │                          │
+│ ■ White/Black│ ■ GitHub    │  func greet(name:) {     │
+│ ■ Light Gray │ ■ One Light │    print("Hello")        │
+│ ■ Newspaper  │ ■ One Dark  │  }                       │
+│ ■ Focus      │             │                          │
+├──────────────┴──────────────┴──────────────────────────┤
+│ Current: White/Black + Monokai      [Reset]  [Apply]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Column Layout
+
+Proportions are defined in a single configurable constant for easy adjustment:
+
+```swift
+private enum ColumnLayout {
+    static let selectorRatio: CGFloat = 0.25
+    static let previewRatio: CGFloat = 0.50
+}
+```
+
+### Column 1: Reader Themes
+
+- **Segmented control** at the top: ☀ Light / 🌙 Dark, filtering the 11 `ReaderThemeKind` cases by `hasLightBackground`.
+- **Scrollable list** of theme cards below. Each card shows:
+  - A color swatch filled with the theme's background color.
+  - Theme display name.
+  - Short description tagline.
+- Selected theme highlighted with a purple border.
+- Clicking a theme **stages** it (updates the preview instantly but does not apply to reader windows).
+
+### Column 2: Syntax Themes
+
+- **Scrollable list** of all 12 `SyntaxThemeKind` cases. Each card shows:
+  - A gradient color strip representing the palette.
+  - Theme name.
+- Selected theme highlighted with a purple border.
+- **When the staged reader theme provides its own syntax highlighting** (`providesSyntaxHighlighting == true`), the entire column is replaced with a centered disabled-state message: *"Syntax highlighting is controlled by the active theme."* The staged syntax selection is preserved but hidden.
+
+### Column 3: Preview
+
+- Renders the existing `ThemePreviewCard` content (heading, body text, code block with syntax-colored tokens) using the **staged** reader theme and syntax theme.
+- Updates instantly as the user browses — no need to press Apply to see the preview.
+
+### Apply / Reset Bar
+
+- Spans the full width below the three columns.
+- **"Unsaved changes" indicator** appears when staged values differ from the currently applied values.
+- **Apply button**: writes staged values to `ReaderSettingsStore`, which triggers the existing Combine pipeline to update all unlocked reader windows.
+- **Reset button**: reverts staged values back to the currently applied values.
+- **Current state label**: shows the currently applied reader + syntax theme names.
+
+### Staging Mechanism
+
+A new `@Observable` view model (e.g. `ThemeSelectorViewModel`) holds:
+
+```swift
+@ObservationIgnored private let settingsStore: ReaderSettingsStore
+var stagedReaderTheme: ReaderThemeKind
+var stagedSyntaxTheme: SyntaxThemeKind
+var hasUnsavedChanges: Bool { ... }
+```
+
+- Initialized from `settingsStore.currentSettings`.
+- The preview reads from staged values.
+- Apply writes staged values back to `settingsStore.updateTheme()` / `settingsStore.updateSyntaxTheme()`.
+- Reset copies current settings back to staged values.
+
+### Theme-Controlled Syntax Behavior
+
+When the staged reader theme's `ThemeDefinition.providesSyntaxHighlighting` is true:
+- The syntax column shows a disabled overlay with explanation text.
+- The previously staged syntax theme is preserved internally so it restores if the user switches back to a theme that doesn't control syntax.
+
+### Locked Windows Hint
+
+The existing locked windows hint from `ReaderSettingsView` is preserved and displayed in the apply bar area.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `minimark/Views/ReaderSettingsView.swift` | Replace picker section with new three-column `ThemeSelectorView` |
+| `minimark/Views/ThemeSelectorView.swift` (new) | Main three-column layout, staging logic, apply/reset |
+| `minimark/Views/ThemeCardView.swift` (new) | Reusable card component for theme list items |
+| `minimark/ViewModels/ThemeSelectorViewModel.swift` (new) | Staging state, apply/reset actions |
+
+## Files Unchanged
+
+- `ReaderSettingsStore.swift` — existing `updateTheme` / `updateSyntaxTheme` methods used as-is.
+- All theme model files (`ReaderTheme.swift`, `SyntaxTheme.swift`, `ThemeDefinition.swift`, etc.).
+- All specialized theme files (Amber, Green, etc.).
+- Rendering pipeline (`ReaderStore+Rendering.swift`, `ReaderCSSFactory.swift`, etc.).
+- `ThemePreviewCard` — reused as-is inside the preview column.
+
+## Constraints
+
+- Column proportions must be a single easily-configurable constant, not scattered magic numbers.
+- No changes to the rendering or persistence pipeline — the staging VM calls the same `settingsStore` methods.
+- Preserve the existing `syntaxHighlightingControlledByTheme` behavior.
+- Preserve the locked windows hint.
+- Must work within the existing `Form` / `.grouped` settings style on macOS.

--- a/minimark/Commands/ReaderCommands.swift
+++ b/minimark/Commands/ReaderCommands.swift
@@ -139,6 +139,13 @@ struct ReaderCommands: Commands {
                 openWindow(id: AppWindowID.about.rawValue)
             }
         }
+
+        CommandGroup(replacing: .appSettings) {
+            Button("Settings...") {
+                openWindow(id: AppWindowID.settings.rawValue)
+            }
+            .keyboardShortcut(",", modifiers: [.command])
+        }
     }
 
     private func openMarkdown() {

--- a/minimark/Models/AppWindowID.swift
+++ b/minimark/Models/AppWindowID.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 enum AppWindowID: String {
+    case settings
     case about
 }

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -110,7 +110,7 @@ struct ReaderSettingsView: View {
 
         }
         .formStyle(.grouped)
-        .frame(minWidth: 560, minHeight: 720)
+        .frame(minWidth: 780, minHeight: 720)
         .padding(16)
         .task {
             notificationNotifier.refreshNotificationStatus()

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -44,32 +44,7 @@ struct ReaderSettingsView: View {
                     }
                 }
 
-                Picker("Reader theme", selection: Binding(
-                    get: { settingsStore.currentSettings.readerTheme },
-                    set: { settingsStore.updateTheme($0) }
-                )) {
-                    ForEach(ReaderThemeKind.allCases, id: \.self) { kind in
-                        Text(kind.displayName).tag(kind)
-                    }
-                }
-
-                Picker("Syntax theme", selection: Binding(
-                    get: { settingsStore.currentSettings.syntaxTheme },
-                    set: { settingsStore.updateSyntaxTheme($0) }
-                )) {
-                    ForEach(SyntaxThemeKind.allCases, id: \.self) { kind in
-                        Text(kind.displayName).tag(kind)
-                    }
-                }
-                .disabled(syntaxHighlightingControlledByTheme)
-
-                if syntaxHighlightingControlledByTheme {
-                    Text("Syntax highlighting is controlled by the active theme.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-
-                lockedWindowsHint
+                ThemeSelectorView(settingsStore: settingsStore)
             }
 
             Section("Window Layout") {
@@ -133,11 +108,6 @@ struct ReaderSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section("Preview") {
-                ThemePreviewCard(settings: settingsStore.currentSettings)
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Theme preview")
-            }
         }
         .formStyle(.grouped)
         .frame(minWidth: 560, minHeight: 720)
@@ -148,23 +118,6 @@ struct ReaderSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             notificationNotifier.refreshNotificationStatus()
         }
-    }
-
-    @ViewBuilder
-    private var lockedWindowsHint: some View {
-        if WindowAppearanceController.lockedWindowCount > 0 {
-            HStack(spacing: 4) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 9))
-                Text("Appearance is locked for some windows. Changes won't apply to them.")
-            }
-            .font(.callout)
-            .foregroundStyle(.secondary)
-        }
-    }
-
-    private var syntaxHighlightingControlledByTheme: Bool {
-        settingsStore.currentSettings.readerTheme.themeDefinition.providesSyntaxHighlighting
     }
 
     private var layoutHelpText: String {
@@ -234,7 +187,7 @@ extension Color {
 
 }
 
-private struct ThemePreviewCard: View {
+struct ThemePreviewCard: View {
     let settings: ReaderSettings
 
     private var theme: ReaderTheme {

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -14,28 +14,70 @@ struct ReaderSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section("Typography") {
-                HStack {
-                    Text("Font size")
-                    Slider(
-                        value: Binding(
-                            get: { settingsStore.currentSettings.baseFontSize },
-                            set: { settingsStore.updateBaseFontSize($0) }
-                        ),
-                        in: 10...48,
-                        step: 1
-                    )
-                    .accessibilityLabel("Font size")
-                    Text("\(Int(settingsStore.currentSettings.baseFontSize)) pt")
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                        .frame(width: 58, alignment: .trailing)
-                }
-            }
+        GeometryReader { geometry in
+            let contentWidth = min(max(geometry.size.width - 40, 0), 1040)
 
-            Section("Theme") {
-                Picker("App theme", selection: Binding(
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    typographySection
+                    themeSection
+                    windowLayoutSection
+                    changeHighlightingSection
+                    notificationsSection
+                }
+                .frame(width: contentWidth, alignment: .leading)
+                .frame(maxWidth: .infinity)
+                .padding(20)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .frame(minWidth: 780, minHeight: 720)
+        .task {
+            notificationNotifier.refreshNotificationStatus()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            notificationNotifier.refreshNotificationStatus()
+        }
+    }
+
+    private var typographySection: some View {
+        SettingsSectionContainer(title: "Typography") {
+            HStack(spacing: 14) {
+                Text("Font size")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 120, alignment: .leading)
+
+                Slider(
+                    value: Binding(
+                        get: { settingsStore.currentSettings.baseFontSize },
+                        set: { settingsStore.updateBaseFontSize($0) }
+                    ),
+                    in: 10...48,
+                    step: 1
+                )
+                .frame(maxWidth: 440)
+                .accessibilityLabel("Font size")
+
+                Text("\(Int(settingsStore.currentSettings.baseFontSize)) pt")
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 58, alignment: .trailing)
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var themeSection: some View {
+        SettingsSectionContainer(title: "Theme") {
+            HStack(spacing: 14) {
+                Text("App theme")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 120, alignment: .leading)
+
+                Spacer(minLength: 12)
+                Picker("", selection: Binding(
                     get: { settingsStore.currentSettings.appAppearance },
                     set: { settingsStore.updateAppAppearance($0) }
                 )) {
@@ -43,12 +85,25 @@ struct ReaderSettingsView: View {
                         Text(appearance.displayName).tag(appearance)
                     }
                 }
-
-                ThemeSelectorView(settingsStore: settingsStore)
+                .labelsHidden()
+                .frame(width: 190)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Section("Window Layout") {
-                Picker("Open multiple files in", selection: Binding(
+            ThemeSelectorView(settingsStore: settingsStore)
+                .frame(maxWidth: .infinity, minHeight: 420, alignment: .leading)
+        }
+    }
+
+    private var windowLayoutSection: some View {
+        SettingsSectionContainer(title: "Window Layout") {
+            HStack(spacing: 14) {
+                Text("Open multiple files in")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 180, alignment: .leading)
+
+                Spacer(minLength: 12)
+                Picker("", selection: Binding(
                     get: { settingsStore.currentSettings.multiFileDisplayMode },
                     set: { updateMultiFileDisplayMode($0) }
                 )) {
@@ -56,14 +111,27 @@ struct ReaderSettingsView: View {
                         Text(mode.displayName).tag(mode)
                     }
                 }
-
-                Text(layoutHelpText)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                .labelsHidden()
+                .frame(width: 190)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Section("Change Highlighting") {
-                Picker("Diff lookback", selection: Binding(
+            Text(layoutHelpText)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var changeHighlightingSection: some View {
+        SettingsSectionContainer(title: "Change Highlighting") {
+            HStack(spacing: 14) {
+                Text("Diff lookback")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 180, alignment: .leading)
+
+                Spacer(minLength: 12)
+                Picker("", selection: Binding(
                     get: { settingsStore.currentSettings.diffBaselineLookback },
                     set: { settingsStore.updateDiffBaselineLookback($0) }
                 )) {
@@ -71,52 +139,62 @@ struct ReaderSettingsView: View {
                         Text(lookback.displayName).tag(lookback)
                     }
                 }
-
-                Text("How far back MarkdownObserver looks for the previous version of a file when highlighting changes. Longer values show more accumulated changes, which works better with AI tools that make many incremental edits.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                .labelsHidden()
+                .frame(width: 190)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Section("Notifications") {
-                Toggle("System notifications", isOn: Binding(
+            Text("How far back MarkdownObserver looks for the previous version of a file when highlighting changes. Longer values show more accumulated changes, which works better with AI tools that make many incremental edits.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var notificationsSection: some View {
+        SettingsSectionContainer(title: "Notifications") {
+            HStack(spacing: 14) {
+                Text("System notifications")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 180, alignment: .leading)
+
+                Spacer(minLength: 12)
+
+                Toggle("", isOn: Binding(
                     get: { settingsStore.currentSettings.notificationsEnabled },
                     set: { updateNotificationsEnabled($0) }
                 ))
+                .labelsHidden()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-                NotificationStatusCard(status: notificationNotifier.notificationStatus)
+            NotificationStatusCard(status: notificationNotifier.notificationStatus)
 
-                HStack {
-                    if notificationNotifier.notificationStatus.canRequestAuthorization {
-                        Button("Allow Notifications") {
-                            notificationNotifier.requestAuthorizationIfNeeded()
-                        }
-                        .buttonStyle(.borderedProminent)
+            HStack(spacing: 10) {
+                if notificationNotifier.notificationStatus.canRequestAuthorization {
+                    Button("Allow Notifications") {
+                        notificationNotifier.requestAuthorizationIfNeeded()
                     }
-
-                    Button("Open Notification Settings") {
-                        notificationNotifier.openSystemNotificationSettings()
-                    }
-
-                    Button("Send Background Test") {
-                        notificationNotifier.sendTestNotification()
-                    }
-                    .disabled(!settingsStore.currentSettings.notificationsEnabled)
+                    .buttonStyle(.borderedProminent)
                 }
 
-                Text("Test notifications fire after 5 seconds so you can switch to another app and verify background delivery.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
+                Button("Open Notification Settings") {
+                    notificationNotifier.openSystemNotificationSettings()
+                }
 
-        }
-        .formStyle(.grouped)
-        .frame(minWidth: 780, minHeight: 720)
-        .padding(16)
-        .task {
-            notificationNotifier.refreshNotificationStatus()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            notificationNotifier.refreshNotificationStatus()
+                Button("Send Background Test") {
+                    notificationNotifier.sendTestNotification()
+                }
+                .disabled(!settingsStore.currentSettings.notificationsEnabled)
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("Test notifications fire after 5 seconds so you can switch to another app and verify background delivery.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -136,6 +214,31 @@ struct ReaderSettingsView: View {
         }
 
         notificationNotifier.requestAuthorizationIfNeeded()
+    }
+}
+
+private struct SettingsSectionContainer<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(title)
+                .font(.system(size: 15, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 10) {
+                content()
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.22), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -202,6 +305,10 @@ struct ThemePreviewCard: View {
         return settings.syntaxTheme.previewPalette
     }
 
+    private var readerColorSamples: [ThemePreviewColorSample] {
+        ThemePreviewReaderTextExamples.reader(theme: theme)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Live preview")
@@ -213,6 +320,8 @@ struct ThemePreviewCard: View {
             Text("Body text in the selected reader theme.")
                 .font(.system(size: settings.baseFontSize))
                 .foregroundStyle(color(theme.secondaryForegroundHex))
+
+            readerTextExamples
 
             RoundedRectangle(cornerRadius: 8)
                 .fill(color(syntaxPalette.blockBackgroundHex))
@@ -287,5 +396,48 @@ struct ThemePreviewCard: View {
     private func token(_ value: String, hex: String? = nil) -> Text {
         Text(value).foregroundStyle(color(hex ?? syntaxPalette.blockTextHex))
     }
+
+    private var readerTextExamples: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Reader text colors")
+                .font(.caption)
+                .foregroundStyle(color(theme.secondaryForegroundHex))
+
+            ForEach(readerColorSamples) { sample in
+                Text(sample.text)
+                    .font(sample.role == .heading
+                          ? .system(size: max(settings.baseFontSize + 1, 13), weight: .semibold)
+                          : .system(size: max(settings.baseFontSize - 1, 11)))
+                    .foregroundStyle(color(sample.hex))
+            }
+        }
+    }
 }
 
+struct ThemePreviewColorSample: Equatable, Identifiable, Sendable {
+    let text: String
+    let role: ThemePreviewTextRole
+    let hex: String
+
+    var id: String {
+        role.rawValue
+    }
+}
+
+enum ThemePreviewTextRole: String, Sendable {
+    case heading
+    case body
+    case secondary
+    case link
+}
+
+enum ThemePreviewReaderTextExamples {
+    static func reader(theme: ReaderTheme) -> [ThemePreviewColorSample] {
+        [
+            ThemePreviewColorSample(text: "Heading accent sample", role: .heading, hex: theme.h1Hex ?? theme.foregroundHex),
+            ThemePreviewColorSample(text: "Primary body sample text", role: .body, hex: theme.foregroundHex),
+            ThemePreviewColorSample(text: "Secondary helper sample", role: .secondary, hex: theme.secondaryForegroundHex),
+            ThemePreviewColorSample(text: "Link sample text", role: .link, hex: theme.linkHex)
+        ]
+    }
+}

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -77,7 +77,7 @@ struct ReaderSettingsView: View {
                     .frame(width: 120, alignment: .leading)
 
                 Spacer(minLength: 12)
-                Picker("", selection: Binding(
+                Picker("App theme", selection: Binding(
                     get: { settingsStore.currentSettings.appAppearance },
                     set: { settingsStore.updateAppAppearance($0) }
                 )) {
@@ -103,7 +103,7 @@ struct ReaderSettingsView: View {
                     .frame(width: 180, alignment: .leading)
 
                 Spacer(minLength: 12)
-                Picker("", selection: Binding(
+                Picker("Open multiple files in", selection: Binding(
                     get: { settingsStore.currentSettings.multiFileDisplayMode },
                     set: { updateMultiFileDisplayMode($0) }
                 )) {
@@ -131,7 +131,7 @@ struct ReaderSettingsView: View {
                     .frame(width: 180, alignment: .leading)
 
                 Spacer(minLength: 12)
-                Picker("", selection: Binding(
+                Picker("Diff lookback", selection: Binding(
                     get: { settingsStore.currentSettings.diffBaselineLookback },
                     set: { settingsStore.updateDiffBaselineLookback($0) }
                 )) {
@@ -160,7 +160,7 @@ struct ReaderSettingsView: View {
 
                 Spacer(minLength: 12)
 
-                Toggle("", isOn: Binding(
+                Toggle("System notifications", isOn: Binding(
                     get: { settingsStore.currentSettings.notificationsEnabled },
                     set: { updateNotificationsEnabled($0) }
                 ))

--- a/minimark/Views/ThemeCardView.swift
+++ b/minimark/Views/ThemeCardView.swift
@@ -5,27 +5,13 @@ struct ReaderThemeCard: View {
     let isSelected: Bool
     let action: () -> Void
 
-    private var theme: ReaderTheme {
-        ReaderTheme.theme(for: kind)
-    }
-
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color(hex: theme.backgroundHex) ?? Color(nsColor: .controlBackgroundColor))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .stroke(Color(hex: theme.foregroundHex)?.opacity(0.2) ?? .clear, lineWidth: 1)
-                    )
-                    .frame(width: 28, height: 28)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(kind.displayName)
-                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                }
+            HStack(spacing: 0) {
+                Text(kind.displayName)
+                    .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 8)
@@ -49,32 +35,13 @@ struct SyntaxThemeCard: View {
     let isSelected: Bool
     let action: () -> Void
 
-    private var palette: SyntaxThemePreviewPalette {
-        kind.previewPalette
-    }
-
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(hex: palette.keywordHex) ?? .gray,
-                                Color(hex: palette.stringHex) ?? .gray,
-                                Color(hex: palette.numberHex) ?? .gray,
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: 28, height: 18)
-
+            HStack(spacing: 0) {
                 Text(kind.displayName)
                     .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
-
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 8)

--- a/minimark/Views/ThemeCardView.swift
+++ b/minimark/Views/ThemeCardView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ReaderThemeCard: View {
+    let kind: ReaderThemeKind
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var theme: ReaderTheme {
+        ReaderTheme.theme(for: kind)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color(hex: theme.backgroundHex) ?? Color(nsColor: .controlBackgroundColor))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(Color(hex: theme.foregroundHex)?.opacity(0.2) ?? .clear, lineWidth: 1)
+                    )
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(kind.displayName)
+                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct SyntaxThemeCard: View {
+    let kind: SyntaxThemeKind
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var palette: SyntaxThemePreviewPalette {
+        kind.previewPalette
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color(hex: palette.keywordHex) ?? .gray,
+                                Color(hex: palette.stringHex) ?? .gray,
+                                Color(hex: palette.numberHex) ?? .gray,
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: 28, height: 18)
+
+                Text(kind.displayName)
+                    .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -56,7 +56,7 @@ struct ThemeSelectorView: View {
                 Text("Dark").tag(BackgroundTab.dark)
             }
             .pickerStyle(.segmented)
-            .onChange(of: selectedBackgroundTab) { _, newTab in
+            .onChange(of: selectedBackgroundTab) { _, _ in
                 if !filteredReaderThemes.contains(stagedReaderTheme) {
                     stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme
                 }

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
-private enum ColumnLayout {
-    static let selectorRatio: CGFloat = 0.25
-    static let previewRatio: CGFloat = 0.50
+struct ThemeSelectorColumnWidths {
+    static let readerMin: CGFloat = 180
+    static let syntaxMin: CGFloat = 180
+    static let previewMin: CGFloat = 320
 }
 
 struct ThemeSelectorView: View {
@@ -26,26 +27,22 @@ struct ThemeSelectorView: View {
             threeColumnLayout
             applyBar
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var threeColumnLayout: some View {
-        GeometryReader { geometry in
-            let totalWidth = geometry.size.width
-            let selectorWidth = totalWidth * ColumnLayout.selectorRatio
-            let previewWidth = totalWidth * ColumnLayout.previewRatio
+        HStack(alignment: .top, spacing: 12) {
+            readerThemesColumn
+                .frame(minWidth: ThemeSelectorColumnWidths.readerMin, maxWidth: .infinity)
 
-            HStack(spacing: 12) {
-                readerThemesColumn
-                    .frame(width: selectorWidth)
+            syntaxThemesColumn
+                .frame(minWidth: ThemeSelectorColumnWidths.syntaxMin, maxWidth: .infinity)
 
-                syntaxThemesColumn
-                    .frame(width: selectorWidth)
-
-                previewColumn
-                    .frame(width: previewWidth)
-            }
+            previewColumn
+                .frame(minWidth: ThemeSelectorColumnWidths.previewMin, maxWidth: .infinity)
+                .layoutPriority(1)
         }
-        .frame(minHeight: 340)
+        .frame(maxWidth: .infinity, minHeight: 340)
     }
 
     private var readerThemesColumn: some View {
@@ -76,9 +73,12 @@ struct ThemeSelectorView: View {
                         }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .frame(maxWidth: .infinity)
         }
         .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
@@ -114,10 +114,13 @@ struct ThemeSelectorView: View {
                             }
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .frame(maxWidth: .infinity)
             }
         }
         .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
@@ -128,11 +131,16 @@ struct ThemeSelectorView: View {
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.secondary)
 
-            ThemePreviewCard(settings: previewSettings)
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Theme preview")
+            ScrollView {
+                ThemePreviewCard(settings: previewSettings)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityLabel("Theme preview")
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+
+private enum ColumnLayout {
+    static let selectorRatio: CGFloat = 0.25
+    static let previewRatio: CGFloat = 0.50
+}
+
+struct ThemeSelectorView: View {
+    private let settingsStore: ReaderSettingsStore
+
+    @State private var stagedReaderTheme: ReaderThemeKind
+    @State private var stagedSyntaxTheme: SyntaxThemeKind
+    @State private var selectedBackgroundTab: BackgroundTab = .light
+
+    init(settingsStore: ReaderSettingsStore) {
+        self.settingsStore = settingsStore
+        self._stagedReaderTheme = State(initialValue: settingsStore.currentSettings.readerTheme)
+        self._stagedSyntaxTheme = State(initialValue: settingsStore.currentSettings.syntaxTheme)
+        self._selectedBackgroundTab = State(
+            initialValue: settingsStore.currentSettings.readerTheme.isDark ? .dark : .light
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            threeColumnLayout
+            applyBar
+        }
+    }
+
+    private var threeColumnLayout: some View {
+        GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let selectorWidth = totalWidth * ColumnLayout.selectorRatio
+            let previewWidth = totalWidth * ColumnLayout.previewRatio
+
+            HStack(spacing: 12) {
+                readerThemesColumn
+                    .frame(width: selectorWidth)
+
+                syntaxThemesColumn
+                    .frame(width: selectorWidth)
+
+                previewColumn
+                    .frame(width: previewWidth)
+            }
+        }
+        .frame(minHeight: 340)
+    }
+
+    private var readerThemesColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Reader Theme")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Picker("Background", selection: $selectedBackgroundTab) {
+                Text("Light").tag(BackgroundTab.light)
+                Text("Dark").tag(BackgroundTab.dark)
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: selectedBackgroundTab) { _, newTab in
+                if !filteredReaderThemes.contains(stagedReaderTheme) {
+                    stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme
+                }
+            }
+
+            ScrollView {
+                VStack(spacing: 4) {
+                    ForEach(filteredReaderThemes, id: \.self) { kind in
+                        ReaderThemeCard(
+                            kind: kind,
+                            isSelected: kind == stagedReaderTheme
+                        ) {
+                            stagedReaderTheme = kind
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var syntaxThemesColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Syntax Theme")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            if syntaxHighlightingControlledByTheme {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "paintbrush.fill")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                    Text("Syntax highlighting is controlled by the active theme.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(spacing: 4) {
+                        ForEach(SyntaxThemeKind.allCases, id: \.self) { kind in
+                            SyntaxThemeCard(
+                                kind: kind,
+                                isSelected: kind == stagedSyntaxTheme
+                            ) {
+                                stagedSyntaxTheme = kind
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var previewColumn: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preview")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ThemePreviewCard(settings: previewSettings)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Theme preview")
+        }
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var applyBar: some View {
+        HStack {
+            Text("Current: \(appliedReaderTheme.displayName) + \(appliedSyntaxTheme.displayName)")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if WindowAppearanceController.lockedWindowCount > 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9))
+                    Text("Some windows locked")
+                }
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+            }
+
+            if hasUnsavedChanges {
+                Text("Unsaved changes")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.orange)
+            }
+
+            Button("Reset") {
+                stagedReaderTheme = appliedReaderTheme
+                stagedSyntaxTheme = appliedSyntaxTheme
+                selectedBackgroundTab = appliedReaderTheme.isDark ? .dark : .light
+            }
+            .disabled(!hasUnsavedChanges)
+
+            Button("Apply") {
+                applyStagedChanges()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!hasUnsavedChanges)
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 12)
+    }
+
+    private var filteredReaderThemes: [ReaderThemeKind] {
+        ReaderThemeKind.allCases.filter {
+            selectedBackgroundTab == .light ? !$0.isDark : $0.isDark
+        }
+    }
+
+    private var syntaxHighlightingControlledByTheme: Bool {
+        stagedReaderTheme.themeDefinition.providesSyntaxHighlighting
+    }
+
+    private var hasUnsavedChanges: Bool {
+        stagedReaderTheme != appliedReaderTheme || stagedSyntaxTheme != appliedSyntaxTheme
+    }
+
+    private var appliedReaderTheme: ReaderThemeKind {
+        settingsStore.currentSettings.readerTheme
+    }
+
+    private var appliedSyntaxTheme: SyntaxThemeKind {
+        settingsStore.currentSettings.syntaxTheme
+    }
+
+    private var previewSettings: ReaderSettings {
+        var settings = settingsStore.currentSettings
+        settings.readerTheme = stagedReaderTheme
+        settings.syntaxTheme = stagedSyntaxTheme
+        return settings
+    }
+
+    private func applyStagedChanges() {
+        if stagedReaderTheme != appliedReaderTheme {
+            settingsStore.updateTheme(stagedReaderTheme)
+        }
+        if stagedSyntaxTheme != appliedSyntaxTheme {
+            settingsStore.updateSyntaxTheme(stagedSyntaxTheme)
+        }
+    }
+}
+
+private enum BackgroundTab: String, CaseIterable {
+    case light
+    case dark
+}

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -41,18 +41,18 @@ struct MarkdownObserverApp: App {
             ReaderCommands(settingsStore: settingsStore, multiFileDisplayMode: activeMultiFileDisplayMode)
         }
 
-        Settings {
+        Window("MarkdownObserver Settings", id: AppWindowID.settings.rawValue) {
             ReaderSettingsView(settingsStore: settingsStore)
             .appAppearance(appAppearance)
         }
-        .defaultSize(width: 640, height: 700)
-        .windowResizability(.contentSize)
+        .defaultSize(width: 1000, height: 720)
+        .windowResizability(.contentMinSize)
 
         Window("About MarkdownObserver", id: AppWindowID.about.rawValue) {
             AboutWindowView()
                 .appAppearance(appAppearance)
         }
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
     }
 }
 

--- a/minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift
+++ b/minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift
@@ -1,0 +1,22 @@
+import CoreGraphics
+import Testing
+@testable import minimark
+
+struct ThemeSelectorLayoutAndPreviewTests {
+    @Test
+    func themeSelectorUsesExpectedMinimumColumnWidths() {
+        #expect(ThemeSelectorColumnWidths.readerMin == 180)
+        #expect(ThemeSelectorColumnWidths.syntaxMin == 180)
+        #expect(ThemeSelectorColumnWidths.previewMin == 320)
+    }
+
+    @Test
+    func previewReaderTextExamplesIncludeKeyReaderColors() {
+        let readerSamples = ThemePreviewReaderTextExamples.reader(theme: ReaderTheme.theme(for: .monokai))
+
+        #expect(readerSamples.count == 4)
+        #expect(readerSamples.contains(where: { $0.role == .body && $0.hex == "#F8F8F2" }))
+        #expect(readerSamples.contains(where: { $0.role == .secondary && $0.hex == "#CFCFC2" }))
+        #expect(readerSamples.contains(where: { $0.role == .link && $0.hex == "#A6E22E" }))
+    }
+}


### PR DESCRIPTION
## Summary
- replace the default Settings scene with a dedicated resizable `MarkdownObserver Settings` window and route `Cmd+,` to it
- refine `ReaderSettingsView` spacing, section containers, label alignment, and control sizing so settings rows feel balanced at different window widths
- keep staged theme apply/reset behavior while improving theme selector resizing and preview clarity, plus add focused tests for layout constants and reader color example generation

## Test Plan
- [x] xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests/ThemeSelectorLayoutAndPreviewTests
- [x] xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests
- [x] xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug -destination 'platform=macOS' build