### PR TITLE
Performance: extract OpenDocumentPathTracker from per-render computed property

### DIFF
--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -43,10 +43,6 @@ struct ReaderWindowRootView: View {
         return effectiveMode.sidebarPlacement
     }
 
-    private var openSidebarDocumentPathSnapshot: Set<String> {
-        Set(windowCoordinator.currentSidebarOpenDocumentFileURLs().map(\.path))
-    }
-
     private var pendingFolderWatchOpenModeBinding: Binding<ReaderFolderWatchOpenMode> {
         Binding(
             get: { [folderWatchFlowController] in
@@ -222,7 +218,7 @@ struct ReaderWindowRootView: View {
                 windowCoordinator.refreshWindowShellRegistrationAndTitle()
                 windowCoordinator.syncSharedFavoriteOpenDocumentsIfNeeded()
             }
-            .onChange(of: openSidebarDocumentPathSnapshot) { _, _ in
+            .onChange(of: windowCoordinator.openDocumentPathTracker.openDocumentPaths) { _, _ in
                 windowCoordinator.syncSharedFavoriteOpenDocumentsIfNeeded()
             }
     }

--- a/minimark/Views/Window/Coordination/OpenDocumentPathTracker.swift
+++ b/minimark/Views/Window/Coordination/OpenDocumentPathTracker.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class OpenDocumentPathTracker {
+    private(set) var openDocumentPaths: Set<String> = []
+
+    func update(from documents: [ReaderSidebarDocumentController.Document]) {
+        let paths = Set(documents.compactMap { $0.normalizedFileURL?.path })
+        if paths != openDocumentPaths {
+            openDocumentPaths = paths
+        }
+    }
+}

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -28,6 +28,7 @@ final class ReaderWindowCoordinator {
     private let settingsStore: ReaderSettingsStore
     private let sidebarDocumentController: ReaderSidebarDocumentController
     private let folderWatchOpenCoordinator = ReaderFolderWatchOpenCoordinator()
+    let openDocumentPathTracker = OpenDocumentPathTracker()
 
     // Window presentation state
     var hostWindow: NSWindow?
@@ -330,6 +331,7 @@ final class ReaderWindowCoordinator {
             sidebarDocumentController.documents,
             rowStates: sidebarDocumentController.rowStates
         )
+        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
     }
 
     func handleWindowAppear() {
@@ -342,6 +344,7 @@ final class ReaderWindowCoordinator {
             rowStates: sidebarDocumentController.rowStates
         )
         groupStateController?.observeRowStates(from: sidebarDocumentController)
+        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
         DockTileController.shared.configureDockTileIfNeeded()
         let token = dockTileWindowToken
         sidebarDocumentController.onDockTileRowStatesChanged = { rowStates in

--- a/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
+++ b/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct OpenDocumentPathTrackerTests {
+    @MainActor
+    private func makeSettingsStore() -> ReaderSettingsStore {
+        ReaderSettingsStore(
+            storage: TestSettingsKeyValueStorage(),
+            storageKey: "path-tracker-tests.\(UUID().uuidString)"
+        )
+    }
+
+    @MainActor
+    private func makeDocument(
+        normalizedURL: URL? = nil,
+        settingsStore: ReaderSettingsStore
+    ) -> ReaderSidebarDocumentController.Document {
+        let store = ReaderStore(
+            rendering: ReaderRenderingDependencies(
+                renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
+            ),
+            file: ReaderFileDependencies(
+                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+            ),
+            folderWatch: ReaderFolderWatchDependencies(
+                autoOpenPlanner: ReaderFolderWatchAutoOpenPlanner(),
+                settler: ReaderAutoOpenSettler(settlingInterval: 1.0),
+                systemNotifier: TestReaderSystemNotifier()
+            ),
+            settingsStore: settingsStore,
+            securityScopeResolver: SecurityScopeResolver(
+                securityScope: TestSecurityScopeAccess(),
+                settingsStore: settingsStore,
+                requestWatchedFolderReauthorization: { _ in nil }
+            )
+        )
+        return ReaderSidebarDocumentController.Document(
+            id: UUID(), readerStore: store, normalizedFileURL: normalizedURL
+        )
+    }
+
+    @Test @MainActor
+    func updateSetsPathsFromDocuments() {
+        let settings = makeSettingsStore()
+        let tracker = OpenDocumentPathTracker()
+        let urlA = URL(fileURLWithPath: "/tmp/a.md")
+        let urlB = URL(fileURLWithPath: "/tmp/b.md")
+        let docs = [
+            makeDocument(normalizedURL: urlA, settingsStore: settings),
+            makeDocument(normalizedURL: urlB, settingsStore: settings),
+        ]
+
+        tracker.update(from: docs)
+
+        #expect(tracker.openDocumentPaths == Set(["/tmp/a.md", "/tmp/b.md"]))
+    }
+
+    @Test @MainActor
+    func updateSkipsDocumentsWithNilURL() {
+        let settings = makeSettingsStore()
+        let tracker = OpenDocumentPathTracker()
+        let url = URL(fileURLWithPath: "/tmp/a.md")
+        let docs = [
+            makeDocument(normalizedURL: url, settingsStore: settings),
+            makeDocument(settingsStore: settings),
+        ]
+
+        tracker.update(from: docs)
+
+        #expect(tracker.openDocumentPaths == Set(["/tmp/a.md"]))
+    }
+
+    @Test @MainActor
+    func updateClearsPreviousPathsOnNewList() {
+        let settings = makeSettingsStore()
+        let tracker = OpenDocumentPathTracker()
+
+        let urlA = URL(fileURLWithPath: "/tmp/a.md")
+        tracker.update(from: [makeDocument(normalizedURL: urlA, settingsStore: settings)])
+        #expect(tracker.openDocumentPaths == Set(["/tmp/a.md"]))
+
+        let urlB = URL(fileURLWithPath: "/tmp/b.md")
+        tracker.update(from: [makeDocument(normalizedURL: urlB, settingsStore: settings)])
+        #expect(tracker.openDocumentPaths == Set(["/tmp/b.md"]))
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts `openSidebarDocumentPathSnapshot` from a per-render computed property on `ReaderWindowRootView` into a dedicated `@Observable` type (`OpenDocumentPathTracker`)
- The tracker is owned by `ReaderWindowCoordinator` and updated only when the document list changes via `handleDocumentListChange()`, eliminating per-render `Set<String>` allocation
- The view's `onChange` now observes the tracker's stable tracked property instead of recomputing on every render pass

Closes #299

## Test Plan
- [ ] 3 new unit tests for `OpenDocumentPathTracker` (path extraction, nil filtering, replacement semantics)
- [ ] Full test suite passes
- [ ] Open a favorite workspace with multiple files, verify open documents persist correctly across app restarts