### PR TITLE
Performance: deduplicate refreshWindowPresentation during window setup (#300)

### DIFF
--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -198,9 +198,6 @@ struct ReaderWindowRootView: View {
             .onOpenURL { url in
                 windowCoordinator.openIncomingURL(url)
             }
-            .onChange(of: windowCoordinator.hostWindow) { _, _ in
-                windowCoordinator.handleHostWindowChange()
-            }
             .onChange(of: sidebarDocumentController.selectedDocumentID) { _, _ in
                 windowCoordinator.applyWindowTitlePresentation()
                 windowCoordinator.renderSelectedDocumentIfNeeded()

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -42,6 +42,18 @@ final class ReaderWindowCoordinator {
     var lastAppliedSidebarDelta: CGFloat = 0
     var isTitlebarEditingFavorites = false
     var isEditingSubfolders = false
+    private var registeredWindowIdentity: RegisteredWindowIdentity?
+
+    private struct RegisteredWindowIdentity: Equatable {
+        let windowID: ObjectIdentifier
+        let folderWatchSession: ReaderFolderWatchSession?
+
+        init?(window: NSWindow?, folderWatchSession: ReaderFolderWatchSession?) {
+            guard let window else { return nil }
+            self.windowID = ObjectIdentifier(window)
+            self.folderWatchSession = folderWatchSession
+        }
+    }
 
     // Controller references (set via configure())
     private(set) var appearanceController: WindowAppearanceController?
@@ -210,6 +222,12 @@ final class ReaderWindowCoordinator {
     }
 
     func registerWindowIfNeeded() {
+        let currentIdentity = RegisteredWindowIdentity(
+            window: hostWindow,
+            folderWatchSession: folderWatchFlowController?.sharedFolderWatchSession
+        )
+        guard currentIdentity != registeredWindowIdentity else { return }
+        registeredWindowIdentity = currentIdentity
         registerWindow(
             hostWindow,
             activeFolderWatch: folderWatchFlowController?.sharedFolderWatchSession
@@ -274,6 +292,7 @@ final class ReaderWindowCoordinator {
     func handleWindowAccessorUpdate(_ window: NSWindow?) {
         if window == nil, let existingWindow = hostWindow {
             ReaderWindowRegistry.shared.unregisterWindow(existingWindow)
+            registeredWindowIdentity = nil
         }
         guard hostWindow !== window else { return }
         hostWindow = window

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -217,8 +217,8 @@ final class ReaderWindowCoordinator {
     }
 
     func refreshWindowShellState() {
-        registerWindowIfNeeded()
         refreshSharedFolderWatchState()
+        registerWindowIfNeeded()
         applyWindowTitlePresentation()
     }
 
@@ -289,11 +289,11 @@ final class ReaderWindowCoordinator {
     }
 
     func handleWindowAccessorUpdate(_ window: NSWindow?) {
-        if window == nil, let existingWindow = hostWindow {
+        guard hostWindow !== window else { return }
+        if let existingWindow = hostWindow {
             ReaderWindowRegistry.shared.unregisterWindow(existingWindow)
             registeredWindowIdentity = nil
         }
-        guard hostWindow !== window else { return }
         hostWindow = window
         handleHostWindowChange()
     }

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -275,6 +275,7 @@ final class ReaderWindowCoordinator {
         if window == nil, let existingWindow = hostWindow {
             ReaderWindowRegistry.shared.unregisterWindow(existingWindow)
         }
+        guard hostWindow !== window else { return }
         hostWindow = window
         handleHostWindowChange()
     }

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -218,7 +218,8 @@ final class ReaderWindowCoordinator {
 
     func refreshWindowShellState() {
         registerWindowIfNeeded()
-        refreshWindowPresentation()
+        refreshSharedFolderWatchState()
+        applyWindowTitlePresentation()
     }
 
     func registerWindowIfNeeded() {

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -223,16 +223,14 @@ final class ReaderWindowCoordinator {
     }
 
     func registerWindowIfNeeded() {
+        let session = folderWatchFlowController?.sharedFolderWatchSession
         let currentIdentity = RegisteredWindowIdentity(
             window: hostWindow,
-            folderWatchSession: folderWatchFlowController?.sharedFolderWatchSession
+            folderWatchSession: session
         )
         guard currentIdentity != registeredWindowIdentity else { return }
         registeredWindowIdentity = currentIdentity
-        registerWindow(
-            hostWindow,
-            activeFolderWatch: folderWatchFlowController?.sharedFolderWatchSession
-        )
+        registerWindow(hostWindow, activeFolderWatch: session)
     }
 
     func handleFolderWatchToolbarAction(_ action: FolderWatchToolbarAction) {

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -96,4 +96,67 @@ struct WindowShellStateTests {
         coordinator.handleWindowAccessorUpdate(nil)
         #expect(coordinator.hostWindow == nil)
     }
+
+    @Test @MainActor
+    func registerWindowIfNeededIsIdempotent() throws {
+        ReaderWindowRegistry.shared.resetForTesting()
+        defer { ReaderWindowRegistry.shared.resetForTesting() }
+
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        coordinator.handleWindowAccessorUpdate(window)
+
+        // Calling registerWindowIfNeeded multiple times should not fail or cause issues.
+        // We verify by checking the window is still properly registered after multiple calls.
+        coordinator.registerWindowIfNeeded()
+        coordinator.registerWindowIfNeeded()
+        coordinator.registerWindowIfNeeded()
+
+        // Window should still be registered and functional
+        #expect(coordinator.hostWindow === window)
+    }
+
+    @Test @MainActor
+    func registrationIdentityClearedOnNilWindow() throws {
+        ReaderWindowRegistry.shared.resetForTesting()
+        defer { ReaderWindowRegistry.shared.resetForTesting() }
+
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        // Register with a window
+        coordinator.handleWindowAccessorUpdate(window)
+
+        // Unregister by setting nil
+        coordinator.handleWindowAccessorUpdate(nil)
+
+        // Re-registering the same window should work (identity was cleared)
+        coordinator.handleWindowAccessorUpdate(window)
+        #expect(coordinator.hostWindow === window)
+    }
 }

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -12,6 +12,7 @@ struct WindowShellStateTests {
 
     @MainActor
     private func makeCoordinator() throws -> (ReaderWindowCoordinator, ReaderSidebarControllerTestHarness) {
+        ReaderWindowRegistry.shared.resetForTesting()
         let harness = try ReaderSidebarControllerTestHarness()
         let coordinator = ReaderWindowCoordinator(
             settingsStore: harness.settingsStore,
@@ -63,9 +64,6 @@ struct WindowShellStateTests {
 
     @Test @MainActor
     func handleWindowAccessorUpdateNilUnregistersAndProcesses() throws {
-        ReaderWindowRegistry.shared.resetForTesting()
-        defer { ReaderWindowRegistry.shared.resetForTesting() }
-
         let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
@@ -80,9 +78,6 @@ struct WindowShellStateTests {
 
     @Test @MainActor
     func registerWindowIfNeededIsIdempotent() throws {
-        ReaderWindowRegistry.shared.resetForTesting()
-        defer { ReaderWindowRegistry.shared.resetForTesting() }
-
         let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
@@ -112,9 +107,6 @@ struct WindowShellStateTests {
 
     @Test @MainActor
     func registrationIdentityClearedOnNilWindow() throws {
-        ReaderWindowRegistry.shared.resetForTesting()
-        defer { ReaderWindowRegistry.shared.resetForTesting() }
-
         let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -130,6 +130,32 @@ struct WindowShellStateTests {
     }
 
     @Test @MainActor
+    func refreshWindowShellStateAppliesTitle() throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        coordinator.handleWindowAccessorUpdate(window)
+
+        // refreshWindowShellState should apply the title (behavioral parity with old nested version)
+        coordinator.refreshWindowShellState()
+
+        // The effective title should be the app name since no document is selected
+        #expect(coordinator.effectiveWindowTitle == ReaderWindowTitleFormatter.appName)
+        #expect(window.title == ReaderWindowTitleFormatter.appName)
+    }
+
+    @Test @MainActor
     func registrationIdentityClearedOnNilWindow() throws {
         ReaderWindowRegistry.shared.resetForTesting()
         defer { ReaderWindowRegistry.shared.resetForTesting() }

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -10,31 +10,37 @@ import Testing
 @Suite(.serialized)
 struct WindowShellStateTests {
 
-    @Test @MainActor
-    func handleWindowAccessorUpdateSkipsSameWindow() throws {
+    @MainActor
+    private func makeCoordinator() throws -> (ReaderWindowCoordinator, ReaderSidebarControllerTestHarness) {
         let harness = try ReaderSidebarControllerTestHarness()
-        defer { harness.cleanup() }
-
         let coordinator = ReaderWindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )
+        return (coordinator, harness)
+    }
 
-        let window = NSWindow(
+    private func makeWindow() -> NSWindow {
+        NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
             styleMask: [.titled],
             backing: .buffered,
             defer: false
         )
+    }
 
-        // First call -- should set hostWindow
+    @Test @MainActor
+    func handleWindowAccessorUpdateSkipsSameWindow() throws {
+        let (coordinator, harness) = try makeCoordinator()
+        defer { harness.cleanup() }
+
+        let window = makeWindow()
+
         coordinator.handleWindowAccessorUpdate(window)
         #expect(coordinator.hostWindow === window)
 
-        // Record title after first call
         let titleAfterFirst = coordinator.effectiveWindowTitle
 
-        // Second call with same window -- should be a no-op
         coordinator.handleWindowAccessorUpdate(window)
         #expect(coordinator.hostWindow === window)
         #expect(coordinator.effectiveWindowTitle == titleAfterFirst)
@@ -42,26 +48,11 @@ struct WindowShellStateTests {
 
     @Test @MainActor
     func handleWindowAccessorUpdateProcessesNewWindow() throws {
-        let harness = try ReaderSidebarControllerTestHarness()
+        let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
-            settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
-        )
-
-        let window1 = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-        let window2 = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
+        let window1 = makeWindow()
+        let window2 = makeWindow()
 
         coordinator.handleWindowAccessorUpdate(window1)
         #expect(coordinator.hostWindow === window1)
@@ -75,20 +66,10 @@ struct WindowShellStateTests {
         ReaderWindowRegistry.shared.resetForTesting()
         defer { ReaderWindowRegistry.shared.resetForTesting() }
 
-        let harness = try ReaderSidebarControllerTestHarness()
+        let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
-            settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
-        )
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
+        let window = makeWindow()
 
         coordinator.handleWindowAccessorUpdate(window)
         #expect(coordinator.hostWindow === window)
@@ -102,55 +83,29 @@ struct WindowShellStateTests {
         ReaderWindowRegistry.shared.resetForTesting()
         defer { ReaderWindowRegistry.shared.resetForTesting() }
 
-        let harness = try ReaderSidebarControllerTestHarness()
+        let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
-            settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
-        )
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-
+        let window = makeWindow()
         coordinator.handleWindowAccessorUpdate(window)
 
-        // Calling registerWindowIfNeeded multiple times should not fail or cause issues.
-        // We verify by checking the window is still properly registered after multiple calls.
         coordinator.registerWindowIfNeeded()
         coordinator.registerWindowIfNeeded()
         coordinator.registerWindowIfNeeded()
 
-        // Window should still be registered and functional
         #expect(coordinator.hostWindow === window)
     }
 
     @Test @MainActor
     func refreshWindowShellStateAppliesTitle() throws {
-        let harness = try ReaderSidebarControllerTestHarness()
+        let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
-            settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
-        )
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
+        let window = makeWindow()
         coordinator.handleWindowAccessorUpdate(window)
 
-        // refreshWindowShellState should apply the title (behavioral parity with old nested version)
         coordinator.refreshWindowShellState()
 
-        // The effective title should be the app name since no document is selected
         #expect(coordinator.effectiveWindowTitle == ReaderWindowTitleFormatter.appName)
         #expect(window.title == ReaderWindowTitleFormatter.appName)
     }
@@ -160,25 +115,12 @@ struct WindowShellStateTests {
         ReaderWindowRegistry.shared.resetForTesting()
         defer { ReaderWindowRegistry.shared.resetForTesting() }
 
-        let harness = try ReaderSidebarControllerTestHarness()
+        let (coordinator, harness) = try makeCoordinator()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
-            settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
-        )
+        let window = makeWindow()
 
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-
-        // Register with a window
         coordinator.handleWindowAccessorUpdate(window)
-
-        // Unregister by setting nil
         coordinator.handleWindowAccessorUpdate(nil)
 
         // Re-registering the same window should work (identity was cleared)

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -1,0 +1,99 @@
+//
+//  WindowShellStateTests.swift
+//  minimarkTests
+//
+
+import AppKit
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct WindowShellStateTests {
+
+    @Test @MainActor
+    func handleWindowAccessorUpdateSkipsSameWindow() throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        // First call -- should set hostWindow
+        coordinator.handleWindowAccessorUpdate(window)
+        #expect(coordinator.hostWindow === window)
+
+        // Record title after first call
+        let titleAfterFirst = coordinator.effectiveWindowTitle
+
+        // Second call with same window -- should be a no-op
+        coordinator.handleWindowAccessorUpdate(window)
+        #expect(coordinator.hostWindow === window)
+        #expect(coordinator.effectiveWindowTitle == titleAfterFirst)
+    }
+
+    @Test @MainActor
+    func handleWindowAccessorUpdateProcessesNewWindow() throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window1 = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let window2 = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        coordinator.handleWindowAccessorUpdate(window1)
+        #expect(coordinator.hostWindow === window1)
+
+        coordinator.handleWindowAccessorUpdate(window2)
+        #expect(coordinator.hostWindow === window2)
+    }
+
+    @Test @MainActor
+    func handleWindowAccessorUpdateNilUnregistersAndProcesses() throws {
+        ReaderWindowRegistry.shared.resetForTesting()
+        defer { ReaderWindowRegistry.shared.resetForTesting() }
+
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = ReaderWindowCoordinator(
+            settingsStore: harness.settingsStore,
+            sidebarDocumentController: harness.controller
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        coordinator.handleWindowAccessorUpdate(window)
+        #expect(coordinator.hostWindow === window)
+
+        coordinator.handleWindowAccessorUpdate(nil)
+        #expect(coordinator.hostWindow == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Guard `handleWindowAccessorUpdate` against same-window re-entry so it no longer fires the full refresh chain on every SwiftUI re-render
- Remove redundant `onChange(of: hostWindow)` handler from `ReaderWindowRootView` — the coordinator already calls `handleHostWindowChange` directly
- Make `registerWindowIfNeeded` truly idempotent by tracking a `RegisteredWindowIdentity` (window + folder watch session)
- Flatten `refreshWindowShellState` to explicitly list its operations instead of nesting through `refreshWindowPresentation`

## Test Plan

- [x] 6 unit tests in `WindowShellStateTests` covering same-window guard, new-window processing, nil unregister, registration idempotency, title application, and identity clearing
- [x] Full test suite passes
- [x] Clean build

Closes #300