### PR TITLE
Nudge syntax block background when it matches reader page background

### DIFF
--- a/minimark/Support/ReaderCSSThemeGenerator.swift
+++ b/minimark/Support/ReaderCSSThemeGenerator.swift
@@ -21,6 +21,12 @@ enum ReaderCSSThemeGenerator {
         let variables = theme.colors.cssVariables(baseFontSize: baseFontSize)
         let syntaxLayer = theme.providesSyntaxHighlighting ? (theme.syntaxCSS ?? syntaxTheme.css) : syntaxTheme.css
         let themeLayer = theme.customCSS ?? ""
+
+        let effectiveBg = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(theme: theme, syntaxTheme: syntaxTheme)
+        let needsOverride = !theme.providesSyntaxHighlighting
+            && effectiveBg != syntaxTheme.previewPalette.blockBackgroundHex
+        let backgroundAdjustment = needsOverride ? "pre { background: \(effectiveBg); }" : ""
+
         return """
         \(variables)
 
@@ -623,6 +629,8 @@ enum ReaderCSSThemeGenerator {
         }
 
         \(syntaxLayer)
+
+        \(backgroundAdjustment)
 
         \(themeLayer)
         """

--- a/minimark/Support/SyntaxBackgroundAdjuster.swift
+++ b/minimark/Support/SyntaxBackgroundAdjuster.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Nudges the syntax code-block background when it is nearly identical to
+/// the reader page background, so code blocks remain visually distinct.
+///
+/// Dark themes: code-block background becomes slightly brighter.
+/// Light themes: code-block background becomes slightly darker.
+enum SyntaxBackgroundAdjuster {
+
+    private static let maxChannelDelta = 5
+    private static let adjustmentStep = 8
+
+    /// Returns the effective code-block background hex for a given theme
+    /// and syntax theme combination. Adjusts when the two backgrounds are
+    /// too close; returns the original syntax background otherwise.
+    /// Themes that provide their own syntax highlighting are never adjusted.
+    static func effectiveBlockBackgroundHex(
+        theme: ThemeDefinition,
+        syntaxTheme: SyntaxThemeKind
+    ) -> String {
+        if theme.providesSyntaxHighlighting {
+            return theme.syntaxPreviewPalette?.blockBackgroundHex
+                ?? syntaxTheme.previewPalette.blockBackgroundHex
+        }
+
+        let palette = syntaxTheme.previewPalette
+        if let adjusted = adjustedBlockBackground(
+               readerBackgroundHex: theme.colors.backgroundHex,
+               syntaxBlockBackgroundHex: palette.blockBackgroundHex,
+               isLightBackground: theme.colors.hasLightBackground
+           ) {
+            return adjusted
+        }
+        return palette.blockBackgroundHex
+    }
+
+    /// Returns an adjusted hex colour string when the two backgrounds are
+    /// too close, or `nil` when no adjustment is needed.
+    static func adjustedBlockBackground(
+        readerBackgroundHex: String,
+        syntaxBlockBackgroundHex: String,
+        isLightBackground: Bool
+    ) -> String? {
+        guard let readerRGB = parseHex(readerBackgroundHex),
+              let syntaxRGB = parseHex(syntaxBlockBackgroundHex) else {
+            return nil
+        }
+
+        let maxDiff = max(
+            abs(readerRGB.r - syntaxRGB.r),
+            abs(readerRGB.g - syntaxRGB.g),
+            abs(readerRGB.b - syntaxRGB.b)
+        )
+
+        guard maxDiff <= maxChannelDelta else { return nil }
+
+        let step = isLightBackground ? -adjustmentStep : adjustmentStep
+        let adjusted = (
+            r: clamp(syntaxRGB.r + step),
+            g: clamp(syntaxRGB.g + step),
+            b: clamp(syntaxRGB.b + step)
+        )
+
+        return String(format: "#%02X%02X%02X", adjusted.r, adjusted.g, adjusted.b)
+    }
+
+    // MARK: - Hex parsing
+
+    private static func parseHex(_ hex: String) -> (r: Int, g: Int, b: Int)? {
+        let clean = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard clean.count == 6, let value = UInt32(clean, radix: 16) else { return nil }
+        return (
+            r: Int((value >> 16) & 0xFF),
+            g: Int((value >> 8) & 0xFF),
+            b: Int(value & 0xFF)
+        )
+    }
+
+    private static func clamp(_ value: Int) -> Int {
+        min(max(value, 0), 255)
+    }
+}

--- a/minimark/Support/SyntaxBackgroundAdjuster.swift
+++ b/minimark/Support/SyntaxBackgroundAdjuster.swift
@@ -34,7 +34,7 @@ enum SyntaxBackgroundAdjuster {
         return palette.blockBackgroundHex
     }
 
-    /// Returns an adjusted hex colour string when the two backgrounds are
+    /// Returns an adjusted hex color string when the two backgrounds are
     /// too close, or `nil` when no adjustment is needed.
     static func adjustedBlockBackground(
         readerBackgroundHex: String,

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -305,6 +305,13 @@ struct ThemePreviewCard: View {
         return settings.syntaxTheme.previewPalette
     }
 
+    private var effectiveBlockBackgroundHex: String {
+        SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
+            theme: settings.readerTheme.themeDefinition,
+            syntaxTheme: settings.syntaxTheme
+        )
+    }
+
     private var readerColorSamples: [ThemePreviewColorSample] {
         ThemePreviewReaderTextExamples.reader(theme: theme)
     }
@@ -324,7 +331,7 @@ struct ThemePreviewCard: View {
             readerTextExamples
 
             RoundedRectangle(cornerRadius: 8)
-                .fill(color(syntaxPalette.blockBackgroundHex))
+                .fill(color(effectiveBlockBackgroundHex))
                 .frame(maxWidth: .infinity, minHeight: 154, alignment: .topLeading)
                 .overlay(alignment: .topLeading) {
                     VStack(alignment: .leading, spacing: 6) {

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -57,6 +57,7 @@ struct ThemeSelectorView: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
+            .accessibilityLabel("Background")
             .onChange(of: selectedBackgroundTab) { _, _ in
                 if !filteredReaderThemes.contains(stagedReaderTheme) {
                     stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -56,6 +56,7 @@ struct ThemeSelectorView: View {
                 Text("Dark").tag(BackgroundTab.dark)
             }
             .pickerStyle(.segmented)
+            .labelsHidden()
             .onChange(of: selectedBackgroundTab) { _, _ in
                 if !filteredReaderThemes.contains(stagedReaderTheme) {
                     stagedReaderTheme = filteredReaderThemes.first ?? stagedReaderTheme

--- a/minimarkTests/Rendering/SyntaxBackgroundAdjusterTests.swift
+++ b/minimarkTests/Rendering/SyntaxBackgroundAdjusterTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import minimark
+
+final class SyntaxBackgroundAdjusterTests: XCTestCase {
+
+    // MARK: - Identical backgrounds
+
+    func testIdenticalDarkBackgroundsReturnBrighterHex() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#282828",
+            syntaxBlockBackgroundHex: "#282828",
+            isLightBackground: false
+        )
+        // 0x28 = 40, +8 = 48 = 0x30
+        XCTAssertEqual(result, "#303030")
+    }
+
+    func testIdenticalLightBackgroundsReturnDarkerHex() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#FBF1C7",
+            syntaxBlockBackgroundHex: "#FBF1C7",
+            isLightBackground: true
+        )
+        // 0xFB=251-8=243=0xF3, 0xF1=241-8=233=0xE9, 0xC7=199-8=191=0xBF
+        XCTAssertEqual(result, "#F3E9BF")
+    }
+
+    // MARK: - Near-identical backgrounds (within threshold)
+
+    func testNearIdenticalBackgroundsWithinThresholdAdjust() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#282828",
+            syntaxBlockBackgroundHex: "#2B2A28",
+            isLightBackground: false
+        )
+        // Max delta is 3 (0x2B-0x28), within threshold of 5
+        XCTAssertNotNil(result)
+    }
+
+    func testBackgroundsAtThresholdBoundaryAdjust() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#282828",
+            syntaxBlockBackgroundHex: "#2D2828",
+            isLightBackground: false
+        )
+        // Max delta is exactly 5, should still adjust
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - Sufficiently different backgrounds
+
+    func testDifferentBackgroundsReturnNil() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#282828",
+            syntaxBlockBackgroundHex: "#1D2021",
+            isLightBackground: false
+        )
+        // Max delta is 11 (0x28-0x1D), well above threshold
+        XCTAssertNil(result)
+    }
+
+    func testBackgroundsJustAboveThresholdReturnNil() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#282828",
+            syntaxBlockBackgroundHex: "#2E2828",
+            isLightBackground: false
+        )
+        // Max delta is 6, above threshold of 5
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Real theme pairings
+
+    func testGruvboxDarkReaderWithGruvboxDarkSyntax() {
+        let reader = ReaderTheme.theme(for: .gruvboxDark)
+        let syntax = SyntaxThemeKind.gruvboxDark.previewPalette
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: reader.backgroundHex,
+            syntaxBlockBackgroundHex: syntax.blockBackgroundHex,
+            isLightBackground: reader.hasLightBackground
+        )
+        XCTAssertNotNil(result, "Gruvbox Dark pairing should adjust (both #282828)")
+    }
+
+    func testMonokaiReaderWithMonokaiSyntax() {
+        let reader = ReaderTheme.theme(for: .monokai)
+        let syntax = SyntaxThemeKind.monokai.previewPalette
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: reader.backgroundHex,
+            syntaxBlockBackgroundHex: syntax.blockBackgroundHex,
+            isLightBackground: reader.hasLightBackground
+        )
+        XCTAssertNotNil(result, "Monokai pairing should adjust (both #272822)")
+    }
+
+    func testDraculaReaderWithDraculaSyntax() {
+        let reader = ReaderTheme.theme(for: .dracula)
+        let syntax = SyntaxThemeKind.dracula.previewPalette
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: reader.backgroundHex,
+            syntaxBlockBackgroundHex: syntax.blockBackgroundHex,
+            isLightBackground: reader.hasLightBackground
+        )
+        XCTAssertNotNil(result, "Dracula pairing should adjust (both #282A36)")
+    }
+
+    func testGruvboxDarkReaderWithOneDarkSyntaxNoAdjustment() {
+        let reader = ReaderTheme.theme(for: .gruvboxDark)
+        let syntax = SyntaxThemeKind.oneDark.previewPalette
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: reader.backgroundHex,
+            syntaxBlockBackgroundHex: syntax.blockBackgroundHex,
+            isLightBackground: reader.hasLightBackground
+        )
+        // Gruvbox Dark bg: #282828, One Dark bg: #282C34 — delta 12, no adjustment
+        XCTAssertNil(result)
+    }
+
+    // MARK: - effectiveBlockBackgroundHex
+
+    func testEffectiveHexReturnsThemePaletteForProvidesSyntaxHighlighting() {
+        let theme = ReaderThemeKind.amberTerminal.themeDefinition
+        let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
+            theme: theme,
+            syntaxTheme: .monokai
+        )
+        XCTAssertEqual(result, theme.syntaxPreviewPalette?.blockBackgroundHex)
+    }
+
+    func testEffectiveHexAdjustsForMatchingNonProvidesSyntaxTheme() {
+        let theme = ReaderThemeKind.gruvboxDark.themeDefinition
+        let original = SyntaxThemeKind.gruvboxDark.previewPalette.blockBackgroundHex
+        let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
+            theme: theme,
+            syntaxTheme: .gruvboxDark
+        )
+        XCTAssertNotEqual(result, original, "Should adjust when backgrounds match")
+    }
+
+    func testEffectiveHexReturnsOriginalWhenBackgroundsDiffer() {
+        let theme = ReaderThemeKind.gruvboxDark.themeDefinition
+        let original = SyntaxThemeKind.monokai.previewPalette.blockBackgroundHex
+        let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
+            theme: theme,
+            syntaxTheme: .monokai
+        )
+        XCTAssertEqual(result, original, "Should not adjust when backgrounds differ")
+    }
+
+    // MARK: - Edge cases
+
+    func testClampsAtBlackBoundary() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#030303",
+            syntaxBlockBackgroundHex: "#030303",
+            isLightBackground: true
+        )
+        // 3 - 8 = -5, clamped to 0
+        XCTAssertEqual(result, "#000000")
+    }
+
+    func testClampsAtWhiteBoundary() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#FCFCFC",
+            syntaxBlockBackgroundHex: "#FCFCFC",
+            isLightBackground: false
+        )
+        // 252 + 8 = 260, clamped to 255
+        XCTAssertEqual(result, "#FFFFFF")
+    }
+
+    func testInvalidHexReturnsNil() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "not-a-hex",
+            syntaxBlockBackgroundHex: "#282828",
+            isLightBackground: false
+        )
+        XCTAssertNil(result)
+    }
+
+    func testLowercaseHexParsesCorrectly() {
+        let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
+            readerBackgroundHex: "#abcdef",
+            syntaxBlockBackgroundHex: "#abcdef",
+            isLightBackground: true
+        )
+        XCTAssertNotNil(result)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SyntaxBackgroundAdjuster` that detects when reader page background and syntax code-block background are nearly identical (≤5 RGB channel delta) and nudges the code-block background — brighter for dark themes, darker for light themes
- Apply the adjustment in both rendered CSS (`ReaderCSSThemeGenerator`) and the settings live preview (`ThemePreviewCard`)
- Hide the redundant "Background" label on the Light/Dark segmented picker in theme settings

## Test plan
- [x] 17 unit tests covering hex parsing, threshold logic, clamping, real theme pairings, and `effectiveBlockBackgroundHex` for both normal and `providesSyntaxHighlighting` themes
- [ ] Verify visually with Gruvbox Dark + Gruvbox Dark, Monokai + Monokai, Dracula + Dracula — code blocks should have subtle contrast against page
- [ ] Verify terminal themes (Amber, Green, C64, Game Boy) are unaffected
- [ ] Verify settings preview matches rendered output

Closes #308