### PR TITLE
Render GitHub-flavored callout blocks (#314)

### DIFF
--- a/minimark/App/Resources/callout-blocks.css
+++ b/minimark/App/Resources/callout-blocks.css
@@ -1,0 +1,126 @@
+/* Callout blocks — GitHub-flavored blockquote alerts
+   Uses existing --reader-* CSS custom properties so theme colors apply automatically. */
+
+/* ── Base callout ───────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout {
+  border-left-width: 0.3em;
+  padding: 0.6em 1em;
+}
+
+/* ── Title row (icon + label) ───────────────────────────────────────── */
+
+.markdown-body blockquote.callout .callout-title {
+  font-weight: 600;
+  font-size: 0.95em;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.3em;
+}
+
+.markdown-body blockquote.callout .callout-title::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.4em;
+  vertical-align: -0.15em;
+  flex-shrink: 0;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
+
+/* ── Body text ──────────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout .callout-body {
+  color: var(--reader-blockquote-fg);
+}
+
+.markdown-body blockquote.callout .callout-body > :first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote.callout .callout-body > :last-child {
+  margin-bottom: 0;
+}
+
+/* ── Note (blue) ────────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout.callout-note {
+  border-left-color: var(--reader-link);
+  background: color-mix(in srgb, var(--reader-link) 8%, transparent);
+}
+
+.markdown-body blockquote.callout.callout-note .callout-title {
+  color: var(--reader-link);
+}
+
+.markdown-body blockquote.callout.callout-note .callout-title::before {
+  background-color: var(--reader-link);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3'%3E%3Ccircle cx='8' cy='8' r='6.35'/%3E%3Cpath d='M8 7v4M8 5.5v-.01'/%3E%3C/svg%3E");
+}
+
+/* ── Tip (green) ────────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout.callout-tip {
+  border-left-color: var(--reader-changed-added);
+  background: color-mix(in srgb, var(--reader-changed-added) 8%, transparent);
+}
+
+.markdown-body blockquote.callout.callout-tip .callout-title {
+  color: var(--reader-changed-added);
+}
+
+.markdown-body blockquote.callout.callout-tip .callout-title::before {
+  background-color: var(--reader-changed-added);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3'%3E%3Cpath d='M6 13h4M6.5 14.5h3M8 1.5a4.5 4.5 0 0 0-2.8 8c.5.4.8 1 .8 1.5h4c0-.5.3-1.1.8-1.5A4.5 4.5 0 0 0 8 1.5z'/%3E%3C/svg%3E");
+}
+
+/* ── Important (purple) ─────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout.callout-important {
+  border-left-color: var(--reader-syntax-keyword);
+  background: color-mix(in srgb, var(--reader-syntax-keyword) 8%, transparent);
+}
+
+.markdown-body blockquote.callout.callout-important .callout-title {
+  color: var(--reader-syntax-keyword);
+}
+
+.markdown-body blockquote.callout.callout-important .callout-title::before {
+  background-color: var(--reader-syntax-keyword);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3'%3E%3Cpath d='M3 2.5h10a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H9l-3 3v-3H3a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1z'/%3E%3C/svg%3E");
+}
+
+/* ── Warning (amber) ────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout.callout-warning {
+  border-left-color: var(--reader-changed-edited);
+  background: color-mix(in srgb, var(--reader-changed-edited) 8%, transparent);
+}
+
+.markdown-body blockquote.callout.callout-warning .callout-title {
+  color: var(--reader-changed-edited);
+}
+
+.markdown-body blockquote.callout.callout-warning .callout-title::before {
+  background-color: var(--reader-changed-edited);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3'%3E%3Cpath d='M7.13 2.24a1 1 0 0 1 1.74 0l5.5 9.5A1 1 0 0 1 13.5 13.5h-11a1 1 0 0 1-.87-1.76z'/%3E%3Cpath d='M8 6v3M8 11v.01'/%3E%3C/svg%3E");
+}
+
+/* ── Caution (red) ──────────────────────────────────────────────────── */
+
+.markdown-body blockquote.callout.callout-caution {
+  border-left-color: var(--reader-changed-deleted);
+  background: color-mix(in srgb, var(--reader-changed-deleted) 8%, transparent);
+}
+
+.markdown-body blockquote.callout.callout-caution .callout-title {
+  color: var(--reader-changed-deleted);
+}
+
+.markdown-body blockquote.callout.callout-caution .callout-title::before {
+  background-color: var(--reader-changed-deleted);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='currentColor' stroke-width='1.3'%3E%3Cpath d='M5.27 1.65h5.46a1 1 0 0 1 .71.29l2.62 2.62a1 1 0 0 1 .29.71v5.46a1 1 0 0 1-.29.71l-2.62 2.62a1 1 0 0 1-.71.29H5.27a1 1 0 0 1-.71-.29L1.94 11.4a1 1 0 0 1-.29-.71V5.27a1 1 0 0 1 .29-.71l2.62-2.62a1 1 0 0 1 .71-.29z'/%3E%3Cpath d='M8 5v3.5M8 10.5v.01'/%3E%3C/svg%3E");
+}

--- a/minimark/App/Resources/callout-blocks.css
+++ b/minimark/App/Resources/callout-blocks.css
@@ -31,20 +31,6 @@
   -webkit-mask-position: center;
 }
 
-/* ── Body text ──────────────────────────────────────────────────────── */
-
-.markdown-body blockquote.callout .callout-body {
-  color: var(--reader-blockquote-fg);
-}
-
-.markdown-body blockquote.callout .callout-body > :first-child {
-  margin-top: 0;
-}
-
-.markdown-body blockquote.callout .callout-body > :last-child {
-  margin-bottom: 0;
-}
-
 /* ── Note (blue) ────────────────────────────────────────────────────── */
 
 .markdown-body blockquote.callout.callout-note {

--- a/minimark/App/Resources/markdown-it-callouts.js
+++ b/minimark/App/Resources/markdown-it-callouts.js
@@ -91,6 +91,19 @@
   }
 
   /**
+   * Join a value onto a token's attribute, appending with a space if it
+   * already exists (like classList.add). Creates the attribute when absent.
+   */
+  function attrJoin(token, name, value) {
+    var idx = token.attrIndex(name);
+    if (idx < 0) {
+      token.attrPush([name, value]);
+    } else {
+      token.attrs[idx][1] = token.attrs[idx][1] + " " + value;
+    }
+  }
+
+  /**
    * Set an attribute on a token, creating or updating as needed.
    */
   function setAttr(token, name, value) {
@@ -206,8 +219,9 @@
 
       typeInfo = CALLOUT_TYPES[calloutInfo.type];
 
-      // Add class and data-callout attributes to the blockquote
-      setAttr(tokens[bqIdx], "class", "callout callout-" + typeInfo.cssClass);
+      // Add class and data-callout attributes to the blockquote.
+      // Use attrJoin for class to preserve any existing classes (e.g. from markdown-it-attrs).
+      attrJoin(tokens[bqIdx], "class", "callout callout-" + typeInfo.cssClass);
       setAttr(tokens[bqIdx], "data-callout", typeInfo.cssClass);
 
       // Transform the inline content to show the title

--- a/minimark/App/Resources/markdown-it-callouts.js
+++ b/minimark/App/Resources/markdown-it-callouts.js
@@ -1,0 +1,231 @@
+/**
+ * markdown-it-callouts
+ *
+ * A markdown-it plugin that transforms blockquotes with [!TYPE] markers
+ * into styled callout blocks, compatible with GitHub and Obsidian syntax.
+ *
+ * Usage:
+ *   md.use(markdownitCallouts);
+ *
+ * Input:
+ *   > [!WARNING] Watch out
+ *   > This will break things.
+ *
+ * Output:
+ *   <blockquote class="callout callout-warning" data-callout="warning">
+ *     <p><strong class="callout-title">Watch out</strong></p>
+ *     <p>This will break things.</p>
+ *   </blockquote>
+ */
+(function () {
+  "use strict";
+
+  // GitHub-native callout types: type -> { cssClass, defaultTitle }
+  var GITHUB_TYPES = {
+    NOTE:      { cssClass: "note",      defaultTitle: "Note" },
+    TIP:       { cssClass: "tip",       defaultTitle: "Tip" },
+    IMPORTANT: { cssClass: "important", defaultTitle: "Important" },
+    WARNING:   { cssClass: "warning",   defaultTitle: "Warning" },
+    CAUTION:   { cssClass: "caution",   defaultTitle: "Caution" }
+  };
+
+  // Obsidian aliases: type -> { cssClass, defaultTitle }
+  var OBSIDIAN_ALIASES = {
+    INFO:     { cssClass: "note",    defaultTitle: "Note" },
+    QUESTION: { cssClass: "note",    defaultTitle: "Question" },
+    EXAMPLE:  { cssClass: "tip",     defaultTitle: "Example" },
+    BUG:      { cssClass: "warning", defaultTitle: "Bug" },
+    DANGER:   { cssClass: "caution", defaultTitle: "Danger" },
+    ABSTRACT: { cssClass: "note",    defaultTitle: "Abstract" },
+    SUMMARY:  { cssClass: "note",    defaultTitle: "Summary" },
+    TLDR:     { cssClass: "note",    defaultTitle: "TL;DR" },
+    SUCCESS:  { cssClass: "tip",     defaultTitle: "Success" },
+    CHECK:    { cssClass: "tip",     defaultTitle: "Check" },
+    DONE:     { cssClass: "tip",     defaultTitle: "Done" },
+    FAILURE:  { cssClass: "caution", defaultTitle: "Failure" },
+    FAIL:     { cssClass: "caution", defaultTitle: "Fail" },
+    MISSING:  { cssClass: "caution", defaultTitle: "Missing" },
+    QUOTE:    { cssClass: "note",    defaultTitle: "Quote" },
+    CITE:     { cssClass: "note",    defaultTitle: "Cite" }
+  };
+
+  // Merged lookup table (all uppercase keys)
+  var CALLOUT_TYPES = {};
+  var key;
+  for (key in GITHUB_TYPES) {
+    if (GITHUB_TYPES.hasOwnProperty(key)) {
+      CALLOUT_TYPES[key] = GITHUB_TYPES[key];
+    }
+  }
+  for (key in OBSIDIAN_ALIASES) {
+    if (OBSIDIAN_ALIASES.hasOwnProperty(key)) {
+      CALLOUT_TYPES[key] = OBSIDIAN_ALIASES[key];
+    }
+  }
+
+  // Pattern: [!TYPE] optionally followed by a space and title text
+  var CALLOUT_RE = /^\[!([A-Za-z]+)\](?:\s+(.+))?$/;
+
+  /**
+   * Find the blockquote_open token that owns the given paragraph_open token.
+   * Walks backward through the token array looking for the nearest
+   * blockquote_open at one nesting level above the paragraph.
+   */
+  function findBlockquoteOpen(tokens, paragraphIdx) {
+    var targetLevel = tokens[paragraphIdx].level - 1;
+    for (var i = paragraphIdx - 1; i >= 0; i--) {
+      if (tokens[i].type === "blockquote_open" && tokens[i].level === targetLevel) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Check whether the paragraph at pIdx is the FIRST child of the
+   * blockquote at bqIdx. In markdown-it's token stream, the first
+   * paragraph_open follows immediately after blockquote_open.
+   */
+  function isFirstChild(tokens, bqIdx, pIdx) {
+    return bqIdx + 1 === pIdx;
+  }
+
+  /**
+   * Set an attribute on a token, creating or updating as needed.
+   */
+  function setAttr(token, name, value) {
+    var idx = token.attrIndex(name);
+    if (idx < 0) {
+      token.attrPush([name, value]);
+    } else {
+      token.attrs[idx][1] = value;
+    }
+  }
+
+  /**
+   * Extract the callout marker from the first inline token's content.
+   * Returns null if no marker is found, or an object with:
+   *   { type: "WARNING", match: matchArray }
+   */
+  function extractCalloutMarker(inlineToken) {
+    if (!inlineToken || inlineToken.type !== "inline" || !inlineToken.children) {
+      return null;
+    }
+
+    // The first text child holds the raw content
+    var firstChild = inlineToken.children[0];
+    if (!firstChild || firstChild.type !== "text") {
+      return null;
+    }
+
+    // In markdown-it, each line of a blockquote paragraph is a separate
+    // text child separated by softbreak tokens. The first text child
+    // holds the first line, which is where the [!TYPE] marker lives.
+    var match = CALLOUT_RE.exec(firstChild.content);
+    if (!match) {
+      return null;
+    }
+
+    var typeName = match[1].toUpperCase();
+    if (!CALLOUT_TYPES.hasOwnProperty(typeName)) {
+      return null;
+    }
+
+    return { type: typeName, match: match };
+  }
+
+  /**
+   * Transform the inline token's children to strip the [!TYPE] marker
+   * and wrap the title text in a <strong class="callout-title"> element.
+   *
+   * If the first paragraph contains additional lines (softbreaks), those
+   * lines are preserved after the title.
+   */
+  function transformInlineContent(inlineToken, calloutInfo, Token) {
+    var typeInfo = CALLOUT_TYPES[calloutInfo.type];
+    var customTitle = calloutInfo.match[2]; // text after [!TYPE], may be undefined
+    var titleText = customTitle ? customTitle.trim() : typeInfo.defaultTitle;
+
+    // Build title tokens: <strong class="callout-title">titleText</strong>
+    var strongOpen = new Token("html_inline", "", 0);
+    strongOpen.content = '<strong class="callout-title">';
+
+    var titleContent = new Token("text", "", 0);
+    titleContent.content = titleText;
+
+    var strongClose = new Token("html_inline", "", 0);
+    strongClose.content = "</strong>";
+
+    var titleTokens = [strongOpen, titleContent, strongClose];
+
+    // Preserve any children after the first text node (softbreaks, more text, etc.)
+    var remaining = inlineToken.children.slice(1);
+
+    inlineToken.children = titleTokens.concat(remaining);
+    inlineToken.content = "";
+  }
+
+  /**
+   * The core ruler function. Walks the token stream after inline parsing
+   * and transforms blockquotes with [!TYPE] markers.
+   */
+  function calloutCoreRule(state) {
+    var tokens = state.tokens;
+    var i, token, inlineToken, bqIdx, calloutInfo, typeInfo;
+
+    for (i = 0; i < tokens.length; i++) {
+      token = tokens[i];
+
+      // Look for paragraph_open inside a blockquote
+      if (token.type !== "paragraph_open") {
+        continue;
+      }
+
+      // The inline content follows the paragraph_open
+      if (i + 1 >= tokens.length) {
+        continue;
+      }
+      inlineToken = tokens[i + 1];
+
+      // Try to extract a callout marker
+      calloutInfo = extractCalloutMarker(inlineToken);
+      if (!calloutInfo) {
+        continue;
+      }
+
+      // Find the parent blockquote
+      bqIdx = findBlockquoteOpen(tokens, i);
+      if (bqIdx < 0) {
+        continue;
+      }
+
+      // Only transform if this paragraph is the FIRST content in the blockquote
+      if (!isFirstChild(tokens, bqIdx, i)) {
+        continue;
+      }
+
+      typeInfo = CALLOUT_TYPES[calloutInfo.type];
+
+      // Add class and data-callout attributes to the blockquote
+      setAttr(tokens[bqIdx], "class", "callout callout-" + typeInfo.cssClass);
+      setAttr(tokens[bqIdx], "data-callout", typeInfo.cssClass);
+
+      // Transform the inline content to show the title
+      transformInlineContent(inlineToken, calloutInfo, state.Token);
+    }
+  }
+
+  /**
+   * The plugin entry point. Registers the core ruler.
+   */
+  function calloutPlugin(md) {
+    md.core.ruler.after("inline", "callouts", calloutCoreRule);
+  }
+
+  // UMD export
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = calloutPlugin;
+  } else {
+    window.markdownitCallouts = calloutPlugin;
+  }
+})();

--- a/minimark/App/Resources/markdownobserver-runtime.js
+++ b/minimark/App/Resources/markdownobserver-runtime.js
@@ -143,6 +143,7 @@
     registerPlugin(md, window.markdownitFootnote);
     registerPlugin(md, window.markdownitDeflist);
     registerPlugin(md, window.markdownItAttrs);
+    registerPlugin(md, window.markdownitCallouts);
   }
 
   function installHeadingIDs(md) {

--- a/minimark/Support/ReaderBundledAssets.swift
+++ b/minimark/Support/ReaderBundledAssets.swift
@@ -7,6 +7,8 @@ struct ReaderRuntimeAssets: Equatable, Sendable {
     let footnoteScriptPath: String?
     let attrsScriptPath: String?
     let deflistScriptPath: String?
+    let calloutsScriptPath: String?
+    let calloutsCSSPath: String?
 }
 
 protocol ReaderRuntimeAssetResolving {
@@ -28,6 +30,8 @@ enum ReaderBundledAssets {
     static let footnoteScriptPath = "Contents/Resources/markdown-it-footnote.min.js"
     static let attrsScriptPath = "Contents/Resources/markdown-it-attrs.min.js"
     static let deflistScriptPath = "Contents/Resources/markdown-it-deflist.min.js"
+    static let calloutsScriptPath = "Contents/Resources/markdown-it-callouts.js"
+    static let calloutsCSSPath = "Contents/Resources/callout-blocks.css"
     static let mermaidScriptPath = "Contents/Resources/mermaid.min.js"
     static let mermaidCSSPath = "Contents/Resources/mermaid-diagrams.css"
 
@@ -43,7 +47,9 @@ enum ReaderBundledAssets {
             taskListsScriptPath: availableTaskListsScriptPath(),
             footnoteScriptPath: availableFootnoteScriptPath(),
             attrsScriptPath: availableAttrsScriptPath(),
-            deflistScriptPath: availableDeflistScriptPath()
+            deflistScriptPath: availableDeflistScriptPath(),
+            calloutsScriptPath: availableCalloutsScriptPath(),
+            calloutsCSSPath: availableCalloutsCSSPath()
         )
     }
 
@@ -69,6 +75,15 @@ enum ReaderBundledAssets {
 
     static func availableDeflistScriptPath() -> String? {
         availableScriptPath(deflistScriptPath)
+    }
+
+    static func availableCalloutsScriptPath() -> String? {
+        availableScriptPath(calloutsScriptPath)
+    }
+
+    static func availableCalloutsCSSPath() -> String? {
+        let fileURL = Bundle.main.bundleURL.appendingPathComponent(calloutsCSSPath)
+        return FileManager.default.fileExists(atPath: fileURL.path) ? calloutsCSSPath : nil
     }
 
     private static func availableScriptPath(_ path: String) -> String? {

--- a/minimark/Support/ReaderCSSFactory.swift
+++ b/minimark/Support/ReaderCSSFactory.swift
@@ -23,6 +23,7 @@ struct ReaderCSSFactory {
         let cssBase64 = Data(css.utf8).base64EncodedString()
         let themeJSBase64 = themeJavaScript.map { Data($0.utf8).base64EncodedString() }
         let runtimeScripts = makeRuntimeScripts(runtimeAssets: runtimeAssets)
+        let runtimeCSSLinks = makeRuntimeCSSLinks(runtimeAssets: runtimeAssets)
         let mathRuntimeScripts = makeMathRuntimeScripts()
         let bootstrapRuntime = makeBootstrapRuntime(
             payloadBase64: payloadBase64,
@@ -43,6 +44,7 @@ struct ReaderCSSFactory {
           \(css)
           </style>
           \(runtimeScripts)
+          \(runtimeCSSLinks)
           \(mathRuntimeScripts)
         </head>
         <body>
@@ -63,7 +65,8 @@ struct ReaderCSSFactory {
         runtimeAssets.taskListsScriptPath,
         runtimeAssets.footnoteScriptPath,
         runtimeAssets.attrsScriptPath,
-        runtimeAssets.deflistScriptPath
+        runtimeAssets.deflistScriptPath,
+        runtimeAssets.calloutsScriptPath
       ].compactMap { $0 })
 
       if let highlightScriptPath = runtimeAssets.highlightScriptPath {
@@ -78,6 +81,15 @@ struct ReaderCSSFactory {
     private func makeScriptTag(for path: String) -> String {
       let escapedPath = path.replacingOccurrences(of: "\"", with: "&quot;")
       return "<script src=\"\(escapedPath)\"></script>"
+    }
+
+    private func makeCSSLinkTag(for path: String) -> String {
+      let escapedPath = path.replacingOccurrences(of: "\"", with: "&quot;")
+      return "<link rel=\"stylesheet\" href=\"\(escapedPath)\" />"
+    }
+
+    private func makeRuntimeCSSLinks(runtimeAssets: ReaderRuntimeAssets) -> String {
+      [runtimeAssets.calloutsCSSPath].compactMap { $0 }.map(makeCSSLinkTag).joined(separator: "\n")
     }
 
     private func makeMathRuntimeScripts() -> String {

--- a/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
+++ b/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
@@ -1,0 +1,47 @@
+//
+//  CalloutBlockRenderingTests.swift
+//  minimarkTests
+//
+
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite
+struct CalloutBlockRenderingTests {
+    private let service = MarkdownRenderingService()
+    private let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+
+    private func renderHTML(_ markdown: String) throws -> String {
+        try service.render(
+            markdown: markdown,
+            changedRegions: [],
+            unsavedChangedRegions: [],
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15
+        ).htmlDocument
+    }
+
+    @Test func htmlDocumentIncludesCalloutsScript() throws {
+        let html = try renderHTML("# Hello")
+        #expect(html.contains("markdown-it-callouts.js"))
+    }
+
+    @Test func htmlDocumentIncludesCalloutCSS() throws {
+        let html = try renderHTML("# Hello")
+        #expect(html.contains("callout-blocks.css"))
+    }
+
+    @Test func runtimeAssetsIncludesCalloutsScriptPath() throws {
+        let assets = try ReaderBundledAssets.requiredRuntimeAssets()
+        #expect(assets.calloutsScriptPath != nil)
+        #expect(assets.calloutsScriptPath == ReaderBundledAssets.calloutsScriptPath)
+    }
+
+    @Test func runtimeAssetsIncludesCalloutsCSSPath() throws {
+        let assets = try ReaderBundledAssets.requiredRuntimeAssets()
+        #expect(assets.calloutsCSSPath != nil)
+        #expect(assets.calloutsCSSPath == ReaderBundledAssets.calloutsCSSPath)
+    }
+}

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -73,7 +73,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -158,7 +160,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -179,7 +183,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -201,7 +207,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -220,7 +228,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -240,7 +250,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 
@@ -425,7 +437,9 @@ struct RenderingAndDiffTests {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
 

--- a/minimarkTests/Rendering/ThemeDefinitionTests.swift
+++ b/minimarkTests/Rendering/ThemeDefinitionTests.swift
@@ -151,7 +151,9 @@ final class ThemeDefinitionTests: XCTestCase {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             ),
             themeJavaScript: "console.log('theme loaded');"
         )
@@ -170,7 +172,9 @@ final class ThemeDefinitionTests: XCTestCase {
                 taskListsScriptPath: nil,
                 footnoteScriptPath: nil,
                 attrsScriptPath: nil,
-                deflistScriptPath: nil
+                deflistScriptPath: nil,
+                calloutsScriptPath: nil,
+                calloutsCSSPath: nil
             )
         )
         XCTAssertFalse(html.contains("minimark-runtime-theme-js-base64"), "Should not include theme JS meta tag")


### PR DESCRIPTION
## Summary

- Add a markdown-it plugin that transforms `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` blockquotes into styled callout blocks with icons and accent colors
- Recognize Obsidian-style aliases (e.g. `> [!BUG]`, `> [!DANGER]`, `> [!EXAMPLE]`) mapped to the nearest GitHub type
- CSS styling derives colors from existing theme variables (`--reader-link`, `--reader-changed-*`, `--reader-syntax-keyword`) so callouts adapt to all themes automatically

## Test plan

- [ ] Unit tests verify callout JS and CSS are included in the HTML document and asset resolver
- [ ] Full test suite passes with no regressions
- [ ] Visual verification: all 5 GitHub types render with correct color, icon, and title
- [ ] Custom titles (`> [!WARNING] Watch out`) display custom text
- [ ] Obsidian aliases map to correct color/icon with their own default title
- [ ] Unknown types and plain blockquotes render unchanged
- [ ] Works across multiple themes

Closes #314