### PR TITLE
Fix Swift concurrency warnings for approachable-concurrency mode

### DIFF
--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -13,7 +13,7 @@ protocol FolderChangeWatching: AnyObject, Sendable {
 
     func stopWatching()
 
-    func markdownFiles(
+    nonisolated func markdownFiles(
         in folderURL: URL,
         includeSubfolders: Bool,
         excludedSubdirectoryURLs: [URL]

--- a/minimark/Services/FolderWatchDirectoryScanCache.swift
+++ b/minimark/Services/FolderWatchDirectoryScanCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+nonisolated struct FolderWatchDirectoryScanCacheKey: Hashable, Sendable {
+    let folderPath: String
+    let folderFingerprint: String
+}
+
+nonisolated private struct FolderWatchDirectoryScanCacheEntry: Sendable {
+    let result: FolderWatchDirectoryScanResult
+    let insertedAt: Date
+}
+
+actor FolderWatchDirectoryScanCache {
+    private let maximumEntries = 4
+    private let maximumEntryAge: TimeInterval = 30
+    private var entriesByKey: [FolderWatchDirectoryScanCacheKey: FolderWatchDirectoryScanCacheEntry] = [:]
+    private var keyOrder: [FolderWatchDirectoryScanCacheKey] = []
+
+    func cachedResult(for key: FolderWatchDirectoryScanCacheKey) -> FolderWatchDirectoryScanResult? {
+        guard let entry = entriesByKey[key] else {
+            return nil
+        }
+
+        if Date().timeIntervalSince(entry.insertedAt) > maximumEntryAge {
+            remove(key)
+            return nil
+        }
+
+        touch(key)
+        return entry.result
+    }
+
+    func store(_ result: FolderWatchDirectoryScanResult, for key: FolderWatchDirectoryScanCacheKey) {
+        entriesByKey[key] = FolderWatchDirectoryScanCacheEntry(result: result, insertedAt: Date())
+        touch(key)
+
+        while keyOrder.count > maximumEntries,
+              let oldestKey = keyOrder.first {
+            keyOrder.removeFirst()
+            entriesByKey.removeValue(forKey: oldestKey)
+        }
+    }
+
+    private func remove(_ key: FolderWatchDirectoryScanCacheKey) {
+        entriesByKey.removeValue(forKey: key)
+        keyOrder.removeAll(where: { $0 == key })
+    }
+
+    private func touch(_ key: FolderWatchDirectoryScanCacheKey) {
+        keyOrder.removeAll(where: { $0 == key })
+        keyOrder.append(key)
+    }
+}

--- a/minimark/Services/FolderWatchDirectoryScanModel.swift
+++ b/minimark/Services/FolderWatchDirectoryScanModel.swift
@@ -35,6 +35,7 @@ final class FolderWatchDirectoryScanModel: ObservableObject {
         static let maximumTraversalDepth = ReaderFolderWatchPerformancePolicy.maximumIncludedSubfolderDepth
         static let maximumVisitedDirectories = 20_000
         static let maximumSupportedSubdirectoryCount = ReaderFolderWatchPerformancePolicy.maximumSupportedSubdirectoryCount
+        static let cacheableSubdirectoryThreshold = 2_000
     }
 
     @Published private(set) var isLoading = false
@@ -46,7 +47,6 @@ final class FolderWatchDirectoryScanModel: ObservableObject {
 
     private var activeTask: Task<Void, Never>?
     private static let cache = FolderWatchDirectoryScanCache()
-    private static let cacheableSubdirectoryThreshold = 2_000
 
     func reset() {
         activeTask?.cancel()
@@ -187,7 +187,7 @@ final class FolderWatchDirectoryScanModel: ObservableObject {
             return false
         }
 
-        return rootNode.subdirectoryCount <= cacheableSubdirectoryThreshold
+        return rootNode.subdirectoryCount <= ScanLimit.cacheableSubdirectoryThreshold
     }
 
     nonisolated private static func cacheKey(for normalizedFolderURL: URL) -> FolderWatchDirectoryScanCacheKey? {
@@ -305,58 +305,7 @@ struct FolderWatchDirectoryScanResult: Sendable {
     let didExceedSupportedSubdirectoryLimit: Bool
 }
 
-struct DirectoryScanTraversalState: Sendable {
+nonisolated struct DirectoryScanTraversalState: Sendable {
     var didExceedSupportedSubdirectoryLimit = false
 }
 
-private struct FolderWatchDirectoryScanCacheKey: Hashable, Sendable {
-    let folderPath: String
-    let folderFingerprint: String
-}
-
-private struct FolderWatchDirectoryScanCacheEntry: Sendable {
-    let result: FolderWatchDirectoryScanResult
-    let insertedAt: Date
-}
-
-private actor FolderWatchDirectoryScanCache {
-    private let maximumEntries = 4
-    private let maximumEntryAge: TimeInterval = 30
-    private var entriesByKey: [FolderWatchDirectoryScanCacheKey: FolderWatchDirectoryScanCacheEntry] = [:]
-    private var keyOrder: [FolderWatchDirectoryScanCacheKey] = []
-
-    func cachedResult(for key: FolderWatchDirectoryScanCacheKey) -> FolderWatchDirectoryScanResult? {
-        guard let entry = entriesByKey[key] else {
-            return nil
-        }
-
-        if Date().timeIntervalSince(entry.insertedAt) > maximumEntryAge {
-            remove(key)
-            return nil
-        }
-
-        touch(key)
-        return entry.result
-    }
-
-    func store(_ result: FolderWatchDirectoryScanResult, for key: FolderWatchDirectoryScanCacheKey) {
-        entriesByKey[key] = FolderWatchDirectoryScanCacheEntry(result: result, insertedAt: Date())
-        touch(key)
-
-        while keyOrder.count > maximumEntries,
-              let oldestKey = keyOrder.first {
-            keyOrder.removeFirst()
-            entriesByKey.removeValue(forKey: oldestKey)
-        }
-    }
-
-    private func remove(_ key: FolderWatchDirectoryScanCacheKey) {
-        entriesByKey.removeValue(forKey: key)
-        keyOrder.removeAll(where: { $0 == key })
-    }
-
-    private func touch(_ key: FolderWatchDirectoryScanCacheKey) {
-        keyOrder.removeAll(where: { $0 == key })
-        keyOrder.append(key)
-    }
-}

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -7,7 +7,7 @@ final class ReaderSidebarDocumentController {
     struct Document: Identifiable, Equatable {
         let id: UUID
         let readerStore: ReaderStore
-        internal(set) var normalizedFileURL: URL?
+        var normalizedFileURL: URL?
 
         static func == (lhs: Document, rhs: Document) -> Bool {
             lhs.id == rhs.id

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -269,7 +269,8 @@ final class ReaderFolderWatchController {
 
         if includeSubfolders {
             Task.detached(priority: .utility) {
-                let urls = (try? folderWatcher.markdownFiles(
+                let urls = (try? Self.scanMarkdownFiles(
+                    using: folderWatcher,
                     in: folderURL,
                     includeSubfolders: true,
                     excludedSubdirectoryURLs: excludedURLs
@@ -357,7 +358,8 @@ final class ReaderFolderWatchController {
         initialMarkdownScanTask = Task.detached(priority: .utility) { [weak self] in
             let markdownScanResult: Result<[URL], Error>
             do {
-                let markdownURLs = try folderWatcher.markdownFiles(
+                let markdownURLs = try Self.scanMarkdownFiles(
+                    using: folderWatcher,
                     in: folderURL,
                     includeSubfolders: includeSubfolders,
                     excludedSubdirectoryURLs: excludedSubdirectoryURLs
@@ -458,5 +460,18 @@ final class ReaderFolderWatchController {
         }
         .sorted { $0.modDate > $1.modDate }
         .map(\.url)
+    }
+
+    nonisolated private static func scanMarkdownFiles(
+        using watcher: FolderChangeWatching,
+        in folderURL: URL,
+        includeSubfolders: Bool,
+        excludedSubdirectoryURLs: [URL]
+    ) throws -> [URL] {
+        try watcher.markdownFiles(
+            in: folderURL,
+            includeSubfolders: includeSubfolders,
+            excludedSubdirectoryURLs: excludedSubdirectoryURLs
+        )
     }
 }

--- a/minimark/Stores/SidebarObservationManager.swift
+++ b/minimark/Stores/SidebarObservationManager.swift
@@ -108,16 +108,16 @@ final class SidebarObservationManager {
     }
 
     private final class ObservationContinuationBox: @unchecked Sendable {
-        private var continuation: UnsafeContinuation<Bool, Never>?
-        private let lock = NSLock()
+        private nonisolated(unsafe) var continuation: UnsafeContinuation<Bool, Never>?
+        private nonisolated let lock = NSLock()
 
-        func store(_ continuation: UnsafeContinuation<Bool, Never>) {
+        nonisolated func store(_ continuation: UnsafeContinuation<Bool, Never>) {
             lock.lock()
             self.continuation = continuation
             lock.unlock()
         }
 
-        func resume(returning value: Bool) {
+        nonisolated func resume(returning value: Bool) {
             lock.lock()
             let c = continuation
             continuation = nil

--- a/minimark/Stores/WindowAppearanceController.swift
+++ b/minimark/Stores/WindowAppearanceController.swift
@@ -13,12 +13,12 @@ final class WindowAppearanceController {
     var effectiveFontSize: Double { effectiveAppearance.baseFontSize }
     var effectiveSyntaxTheme: SyntaxThemeKind { effectiveAppearance.syntaxTheme }
 
-    private static let _lockedWindowCount = Mutex(0)
+    nonisolated private static let _lockedWindowCount = Mutex(0)
     static var lockedWindowCount: Int { _lockedWindowCount.withLock { $0 } }
 
     /// Tracks whether this instance contributed to `_lockedWindowCount`.
     /// Must be `nonisolated(unsafe)` so `deinit` (which is nonisolated) can read it.
-    private nonisolated(unsafe) var _isLockedForDeinit = false
+    @ObservationIgnored private nonisolated(unsafe) var _isLockedForDeinit = false
 
     private let settingsStore: ReaderSettingsReading
     private var cancellable: AnyCancellable?

--- a/minimark/Support/ReaderFolderWatchAutoOpenWarningCoordinator.swift
+++ b/minimark/Support/ReaderFolderWatchAutoOpenWarningCoordinator.swift
@@ -7,7 +7,7 @@ final class ReaderFolderWatchAutoOpenWarningCoordinator {
     var activeFlow: FolderWatchAutoOpenWarningFlow?
 
     private var queuedWarning: ReaderFolderWatchAutoOpenWarning?
-    private nonisolated(unsafe) var presentationTask: Task<Void, Never>?
+    @ObservationIgnored private nonisolated(unsafe) var presentationTask: Task<Void, Never>?
 
     deinit {
         presentationTask?.cancel()


### PR DESCRIPTION
## Summary

- Resolves all Swift concurrency warnings caused by `SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor` (approachable concurrency)
- Adds explicit `nonisolated` annotations where types and methods genuinely operate outside the main actor
- Extracts scan cache types to a dedicated file to break inherited `@MainActor` on `Hashable` conformance
- Zero warnings, 895 tests passing

## Changes

| File | Change |
|------|--------|
| `FolderWatchDirectoryScanCache.swift` (new) | Extracted cache actor + key/entry structs as `nonisolated` types |
| `FolderWatchDirectoryScanModel.swift` | `nonisolated struct` for `DirectoryScanTraversalState`; moved constant to nonisolated enum |
| `FolderChangeWatcher.swift` | `nonisolated` on `markdownFiles` protocol requirement |
| `ReaderSidebarFolderWatchOwnership.swift` | `nonisolated static` helper for detached-task `markdownFiles` calls |
| `SidebarObservationManager.swift` | `nonisolated` on `ObservationContinuationBox` methods + `nonisolated(unsafe)` on lock-protected property |
| `WindowAppearanceController.swift` | `nonisolated static let` for Mutex property; `@ObservationIgnored` for deinit-accessed property |
| `ReaderFolderWatchAutoOpenWarningCoordinator.swift` | `@ObservationIgnored` for deinit-accessed property |
| `ReaderSidebarDocumentController.swift` | Removed redundant `internal(set)` |

## Test plan

- [x] Clean build with zero concurrency warnings
- [x] All 895 unit tests pass