### PR TITLE
Split ReaderSettingsWriting into focused protocols (ISP) (#321)

### DIFF
--- a/minimark/Services/SecurityScopeResolver.swift
+++ b/minimark/Services/SecurityScopeResolver.swift
@@ -11,12 +11,12 @@ final class SecurityScopeResolver {
     var context = SecurityScopeContext()
 
     private let securityScope: SecurityScopedResourceAccessing
-    private let settingsStore: ReaderSettingsStoring
+    private let settingsStore: ReaderRecentWriting & ReaderTrustedFolderWriting
     private let requestWatchedFolderReauthorization: (URL) -> URL?
 
     init(
         securityScope: SecurityScopedResourceAccessing,
-        settingsStore: ReaderSettingsStoring,
+        settingsStore: ReaderRecentWriting & ReaderTrustedFolderWriting,
         requestWatchedFolderReauthorization: @escaping (URL) -> URL?
     ) {
         self.securityScope = securityScope

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -54,7 +54,7 @@ final class FavoriteWorkspaceController {
         return favorites.first { $0.matches(folderPath: normalizedPath, options: options) }
     }
 
-    func persistFinalState(to settingsStore: some ReaderSettingsStoring) {
+    func persistFinalState(to settingsStore: some ReaderFavoriteWriting) {
         guard let id = activeFavoriteID, let state = activeFavoriteWorkspaceState else { return }
         settingsStore.updateFavoriteWorkspaceState(id: id, workspaceState: state)
     }

--- a/minimark/Stores/ReaderDocumentController.swift
+++ b/minimark/Stores/ReaderDocumentController.swift
@@ -36,14 +36,14 @@ final class ReaderDocumentController {
 
     // MARK: - Dependencies
     let fileDependencies: ReaderFileDependencies
-    let settingsStore: ReaderSettingsStoring
+    let settingsStore: ReaderSettingsReading
     let settler: ReaderAutoOpenSettling
 
     @ObservationIgnored private var loadingOverlayHoldGeneration: UInt = 0
 
     init(
         fileDependencies: ReaderFileDependencies,
-        settingsStore: ReaderSettingsStoring,
+        settingsStore: ReaderSettingsReading,
         settler: ReaderAutoOpenSettling
     ) {
         self.fileDependencies = fileDependencies

--- a/minimark/Stores/ReaderRenderingController.swift
+++ b/minimark/Stores/ReaderRenderingController.swift
@@ -15,12 +15,12 @@ final class ReaderRenderingController {
     @ObservationIgnored var pendingDraftPreviewRenderTask: Task<Void, Never>?
 
     private let renderingDependencies: ReaderRenderingDependencies
-    private let settingsStore: ReaderSettingsStoring
+    private let settingsStore: ReaderSettingsReading
     private let securityScopeResolver: SecurityScopeResolver
 
     init(
         renderingDependencies: ReaderRenderingDependencies,
-        settingsStore: ReaderSettingsStoring,
+        settingsStore: ReaderSettingsReading,
         securityScopeResolver: SecurityScopeResolver
     ) {
         self.renderingDependencies = renderingDependencies

--- a/minimark/Stores/ReaderSettingsStore.swift
+++ b/minimark/Stores/ReaderSettingsStore.swift
@@ -152,7 +152,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     func resetFontSize()
 }
 
-@MainActor protocol ReaderSidebarConfigWriting: AnyObject {
+@MainActor protocol ReaderPreferencesWriting: AnyObject {
     func updateNotificationsEnabled(_ isEnabled: Bool)
     func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode)
     func updateSidebarSortMode(_ mode: ReaderSidebarSortMode)
@@ -206,7 +206,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
 }
 
 typealias ReaderSettingsWriting = ReaderThemeWriting
-    & ReaderSidebarConfigWriting
+    & ReaderPreferencesWriting
     & ReaderFavoriteWriting
     & ReaderRecentWriting
     & ReaderTrustedFolderWriting

--- a/minimark/Stores/ReaderSettingsStore.swift
+++ b/minimark/Stores/ReaderSettingsStore.swift
@@ -142,7 +142,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     func isHintDismissed(_ hint: FirstUseHint) -> Bool
 }
 
-@MainActor protocol ReaderSettingsWriting: AnyObject {
+@MainActor protocol ReaderThemeWriting: AnyObject {
     func updateAppAppearance(_ appearance: AppAppearance)
     func updateTheme(_ kind: ReaderThemeKind)
     func updateSyntaxTheme(_ kind: SyntaxThemeKind)
@@ -150,11 +150,17 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     func increaseFontSize(step: Double)
     func decreaseFontSize(step: Double)
     func resetFontSize()
+}
+
+@MainActor protocol ReaderSidebarConfigWriting: AnyObject {
     func updateNotificationsEnabled(_ isEnabled: Bool)
     func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode)
     func updateSidebarSortMode(_ mode: ReaderSidebarSortMode)
     func updateSidebarGroupSortMode(_ mode: ReaderSidebarSortMode)
     func updateDiffBaselineLookback(_ lookback: DiffBaselineLookback)
+}
+
+@MainActor protocol ReaderFavoriteWriting: AnyObject {
     func addFavoriteWatchedFolder(
         name: String,
         folderURL: URL,
@@ -177,16 +183,34 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     func updateFavoriteWorkspaceState(id: UUID, workspaceState: ReaderFavoriteWorkspaceState)
     func resolvedFavoriteWatchedFolderURL(for entry: ReaderFavoriteWatchedFolder) -> URL
     func clearFavoriteWatchedFolders()
+    func reorderFavoriteWatchedFolders(orderedIDs: [UUID])
+    func updateFavoriteWatchedFolderExclusions(id: UUID, excludedSubdirectoryPaths: [String])
+}
+
+@MainActor protocol ReaderRecentWriting: AnyObject {
     func addRecentWatchedFolder(_ folderURL: URL, options: ReaderFolderWatchOptions)
     func resolvedRecentWatchedFolderURL(matching folderURL: URL) -> URL?
     func clearRecentWatchedFolders()
     func addRecentManuallyOpenedFile(_ fileURL: URL)
     func resolvedRecentManuallyOpenedFileURL(matching fileURL: URL) -> URL?
     func clearRecentManuallyOpenedFiles()
+}
+
+@MainActor protocol ReaderTrustedFolderWriting: AnyObject {
     func addTrustedImageFolder(_ folderURL: URL)
     func resolvedTrustedImageFolderURL(containing fileURL: URL) -> URL?
+}
+
+@MainActor protocol ReaderHintWriting: AnyObject {
     func dismissHint(_ hint: FirstUseHint)
 }
+
+typealias ReaderSettingsWriting = ReaderThemeWriting
+    & ReaderSidebarConfigWriting
+    & ReaderFavoriteWriting
+    & ReaderRecentWriting
+    & ReaderTrustedFolderWriting
+    & ReaderHintWriting
 
 typealias ReaderSettingsStoring = ReaderSettingsReading & ReaderSettingsWriting
 

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -16,7 +16,7 @@ final class ReaderFolderWatchController {
     private static let scanProgressLingerDuration: Duration = .milliseconds(500)
 
     private let folderWatcher: FolderChangeWatching
-    private let settingsStore: ReaderSettingsStoring
+    private let settingsStore: ReaderSettingsReading & ReaderRecentWriting
     private let securityScope: SecurityScopedResourceAccessing
     private let systemNotifier: ReaderSystemNotifying
     private let folderWatchAutoOpenPlanner: ReaderFolderWatchAutoOpenPlanning
@@ -61,7 +61,7 @@ final class ReaderFolderWatchController {
 
     init(
         folderWatcher: FolderChangeWatching,
-        settingsStore: ReaderSettingsStoring,
+        settingsStore: ReaderSettingsReading & ReaderRecentWriting,
         securityScope: SecurityScopedResourceAccessing,
         systemNotifier: ReaderSystemNotifying,
         folderWatchAutoOpenPlanner: ReaderFolderWatchAutoOpenPlanning

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -36,7 +36,7 @@ final class ReaderStore {
     let renderingController: ReaderRenderingController
     let file: ReaderFileDependencies
     let folderWatch: ReaderFolderWatchDependencies
-    let settingsStore: ReaderSettingsStoring
+    let settingsStore: ReaderSettingsReading & ReaderRecentWriting
     let securityScopeResolver: SecurityScopeResolver
     @ObservationIgnored private var settingsCancellable: AnyCancellable?
 
@@ -59,7 +59,7 @@ final class ReaderStore {
         rendering: ReaderRenderingDependencies,
         file: ReaderFileDependencies,
         folderWatch: ReaderFolderWatchDependencies,
-        settingsStore: ReaderSettingsStoring,
+        settingsStore: ReaderSettingsReading & ReaderRecentWriting,
         securityScopeResolver: SecurityScopeResolver,
         diffBaselineTracker: DiffBaselineTracking? = nil
     ) {

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -434,11 +434,15 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
 
     func reorderFavoriteWatchedFolders(orderedIDs: [UUID]) {
         var next = subject.value
+        let existing = next.favoriteWatchedFolders
         let ordered = orderedIDs.compactMap { id in
-            next.favoriteWatchedFolders.first(where: { $0.id == id })
+            existing.first(where: { $0.id == id })
         }
-        next.favoriteWatchedFolders = ordered
-        recordedFavoriteWatchedFolders = ordered
+        let orderedIDSet = Set(ordered.map(\.id))
+        let remaining = existing.filter { !orderedIDSet.contains($0.id) }
+        let reordered = ordered + remaining
+        next.favoriteWatchedFolders = reordered
+        recordedFavoriteWatchedFolders = reordered
         subject.send(next)
     }
 
@@ -454,6 +458,9 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
             scope: existing.options.scope,
             excludedSubdirectoryPaths: excludedSubdirectoryPaths
         ).encodedForFolder(folderURL)
+        guard existing.options != normalizedOptions else {
+            return
+        }
         next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
             id: existing.id,
             name: existing.name,

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -431,6 +431,43 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
 
         return nil
     }
+
+    func reorderFavoriteWatchedFolders(orderedIDs: [UUID]) {
+        var next = subject.value
+        let ordered = orderedIDs.compactMap { id in
+            next.favoriteWatchedFolders.first(where: { $0.id == id })
+        }
+        next.favoriteWatchedFolders = ordered
+        recordedFavoriteWatchedFolders = ordered
+        subject.send(next)
+    }
+
+    func updateFavoriteWatchedFolderExclusions(id: UUID, excludedSubdirectoryPaths: [String]) {
+        var next = subject.value
+        guard let index = next.favoriteWatchedFolders.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let existing = next.favoriteWatchedFolders[index]
+        let folderURL = URL(fileURLWithPath: existing.folderPath, isDirectory: true)
+        let normalizedOptions = ReaderFolderWatchOptions(
+            openMode: existing.options.openMode,
+            scope: existing.options.scope,
+            excludedSubdirectoryPaths: excludedSubdirectoryPaths
+        ).encodedForFolder(folderURL)
+        next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
+            id: existing.id,
+            name: existing.name,
+            folderPath: existing.folderPath,
+            options: normalizedOptions,
+            bookmarkData: existing.bookmarkData,
+            openDocumentRelativePaths: existing.openDocumentRelativePaths,
+            allKnownRelativePaths: existing.allKnownRelativePaths,
+            workspaceState: existing.workspaceState,
+            createdAt: existing.createdAt
+        )
+        recordedFavoriteWatchedFolders = next.favoriteWatchedFolders
+        subject.send(next)
+    }
 }
 
 final class TestSettingsKeyValueStorage: ReaderSettingsKeyValueStoring {


### PR DESCRIPTION
## Summary

- Split monolithic `ReaderSettingsWriting` (29 methods) into 6 focused sub-protocols: `ReaderThemeWriting`, `ReaderSidebarConfigWriting`, `ReaderFavoriteWriting`, `ReaderRecentWriting`, `ReaderTrustedFolderWriting`, `ReaderHintWriting`
- `ReaderSettingsWriting` kept as composition typealias for backward compatibility
- Promoted `reorderFavoriteWatchedFolders` and `updateFavoriteWatchedFolderExclusions` from concrete-only methods to `ReaderFavoriteWriting` protocol
- Narrowed 6 controller/service consumers to depend only on the sub-protocols they actually use

## Consumer narrowing

| Consumer | Before | After |
|----------|--------|-------|
| `ReaderStore` | `ReaderSettingsStoring` | `ReaderSettingsReading & ReaderRecentWriting` |
| `ReaderDocumentController` | `ReaderSettingsStoring` | `ReaderSettingsReading` |
| `ReaderRenderingController` | `ReaderSettingsStoring` | `ReaderSettingsReading` |
| `ReaderFolderWatchController` | `ReaderSettingsStoring` | `ReaderSettingsReading & ReaderRecentWriting` |
| `SecurityScopeResolver` | `ReaderSettingsStoring` | `ReaderRecentWriting & ReaderTrustedFolderWriting` |
| `FavoriteWorkspaceController` | `some ReaderSettingsStoring` | `some ReaderFavoriteWriting` |

SwiftUI views keep concrete `ReaderSettingsStore` (required for `@Observable`).

## Test plan

- [x] Full build passes
- [x] All unit tests pass
- [x] Existing `TestReaderSettingsStore` updated with promoted methods

Closes #321