### PR TITLE
Simplify ReaderWindowCoordinator: extract 4 focused coordinators (#322)

### DIFF
--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -4,10 +4,36 @@ import Observation
 @MainActor
 @Observable
 final class FavoriteWorkspaceController {
+    private let settingsStore: any ReaderSettingsReading & ReaderFavoriteWriting
+
+    // Cross-references (set via configure())
+    private var sidebarDocumentController: ReaderSidebarDocumentController?
+    private var folderWatchFlowController: FolderWatchFlowController?
+    private var groupStateController: SidebarGroupStateController?
+    private var appearanceController: WindowAppearanceController?
+
     private(set) var activeFavoriteID: UUID?
     private(set) var activeFavoriteWorkspaceState: ReaderFavoriteWorkspaceState?
 
     var isActive: Bool { activeFavoriteID != nil }
+
+    init(settingsStore: some ReaderSettingsReading & ReaderFavoriteWriting) {
+        self.settingsStore = settingsStore
+    }
+
+    func configure(
+        sidebarDocumentController: ReaderSidebarDocumentController,
+        folderWatchFlowController: FolderWatchFlowController,
+        groupStateController: SidebarGroupStateController,
+        appearanceController: WindowAppearanceController
+    ) {
+        self.sidebarDocumentController = sidebarDocumentController
+        self.folderWatchFlowController = folderWatchFlowController
+        self.groupStateController = groupStateController
+        self.appearanceController = appearanceController
+    }
+
+    // MARK: - State Mutations
 
     func activate(id: UUID, workspaceState: ReaderFavoriteWorkspaceState) {
         activeFavoriteID = id
@@ -45,6 +71,8 @@ final class FavoriteWorkspaceController {
         activeFavoriteWorkspaceState?.manualGroupOrder = manualGroupOrder
     }
 
+    // MARK: - Matching
+
     func matchingFavorite(
         folderURL: URL,
         options: ReaderFolderWatchOptions,
@@ -54,8 +82,163 @@ final class FavoriteWorkspaceController {
         return favorites.first { $0.matches(folderPath: normalizedPath, options: options) }
     }
 
+    func matchingCurrentSession() -> ReaderFavoriteWatchedFolder? {
+        guard let session = folderWatchFlowController?.sharedFolderWatchSession else { return nil }
+        return matchingFavorite(
+            folderURL: session.folderURL,
+            options: session.options,
+            in: settingsStore.currentSettings.favoriteWatchedFolders
+        )
+    }
+
+    var isCurrentWatchAFavorite: Bool {
+        matchingCurrentSession() != nil
+    }
+
+    // MARK: - Open Document URLs
+
+    func openDocumentFileURLs() -> [URL] {
+        sidebarDocumentController?.documents.compactMap { $0.readerStore.document.fileURL } ?? []
+    }
+
+    // MARK: - Persistence
+
     func persistFinalState(to settingsStore: some ReaderFavoriteWriting) {
         guard let id = activeFavoriteID, let state = activeFavoriteWorkspaceState else { return }
         settingsStore.updateFavoriteWorkspaceState(id: id, workspaceState: state)
+    }
+
+    func persistFinalStateIfNeeded() {
+        persistFinalState(to: settingsStore)
+    }
+
+    // MARK: - Favorite Lifecycle
+
+    func saveAsFavorite(name: String, currentSidebarWidth: CGFloat) {
+        guard let session = folderWatchFlowController?.sharedFolderWatchSession,
+              let groupStateController else { return }
+        let groupSnapshot = groupStateController.persistenceSnapshot
+        var workspaceState = ReaderFavoriteWorkspaceState.from(
+            settings: settingsStore.currentSettings,
+            pinnedGroupIDs: groupSnapshot.pinnedGroupIDs,
+            collapsedGroupIDs: groupSnapshot.collapsedGroupIDs,
+            sidebarWidth: currentSidebarWidth
+        )
+        workspaceState.fileSortMode = groupSnapshot.fileSortMode
+        workspaceState.groupSortMode = groupSnapshot.sortMode
+        workspaceState.lockedAppearance = appearanceController?.lockedAppearance
+        workspaceState.manualGroupOrder = groupSnapshot.manualGroupOrder
+        settingsStore.addFavoriteWatchedFolder(
+            name: name,
+            folderURL: session.folderURL,
+            options: session.options,
+            openDocumentFileURLs: openDocumentFileURLs(),
+            workspaceState: workspaceState
+        )
+
+        if let created = matchingCurrentSession() {
+            activate(id: created.id, workspaceState: created.workspaceState)
+        }
+    }
+
+    func removeFromFavorites() {
+        guard let match = matchingCurrentSession() else { return }
+        settingsStore.removeFavoriteWatchedFolder(id: match.id)
+        deactivate()
+    }
+
+    /// Returns the sidebar width from the favorite's workspace state (so the caller can apply it to window state).
+    func startFavoriteWatch(_ entry: ReaderFavoriteWatchedFolder) -> CGFloat {
+        // Restore appearance FIRST
+        if let lockedAppearance = entry.workspaceState.lockedAppearance {
+            appearanceController?.restore(from: lockedAppearance)
+        } else if appearanceController?.isLocked == true {
+            appearanceController?.unlock()
+        }
+
+        // Activate and restore workspace state
+        activate(id: entry.id, workspaceState: entry.workspaceState)
+        groupStateController?.applyWorkspaceState(entry.workspaceState)
+
+        // Start watching folder (via FWFC)
+        let resolvedURL = settingsStore.resolvedFavoriteWatchedFolderURL(for: entry)
+        folderWatchFlowController?.startWatchingFolder(
+            folderURL: resolvedURL,
+            options: entry.options,
+            performInitialAutoOpen: false
+        )
+
+        // Open restored files
+        let restoredFileURLs = entry.existingOpenDocumentFileURLs(relativeTo: resolvedURL)
+        if let session = folderWatchFlowController?.sharedFolderWatchSession,
+           let fileOpenCoordinator = sidebarDocumentController?.fileOpenCoordinator,
+           !restoredFileURLs.isEmpty {
+            fileOpenCoordinator.open(FileOpenRequest(
+                fileURLs: restoredFileURLs,
+                origin: .folderWatchInitialBatchAutoOpen,
+                folderWatchSession: session,
+                slotStrategy: .reuseEmptySlotForFirst,
+                materializationStrategy: .deferThenMaterializeNewest(
+                    count: ReaderFolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount
+                )
+            ))
+        }
+
+        // Sync and discover
+        syncOpenDocumentsIfNeeded()
+
+        if entry.options.openMode == .openAllMarkdownFiles {
+            discoverNewFilesForFavorite(entry, resolvedFolderURL: resolvedURL)
+        }
+
+        return entry.workspaceState.sidebarWidth
+    }
+
+    func syncOpenDocumentsIfNeeded() {
+        guard let session = folderWatchFlowController?.sharedFolderWatchSession,
+              let favorite = matchingCurrentSession() else { return }
+
+        settingsStore.updateFavoriteWatchedFolderOpenDocuments(
+            id: favorite.id,
+            folderURL: session.folderURL,
+            openDocumentFileURLs: openDocumentFileURLs()
+        )
+    }
+
+    func clearAll() {
+        settingsStore.clearFavoriteWatchedFolders()
+    }
+
+    // MARK: - Private
+
+    private func discoverNewFilesForFavorite(
+        _ entry: ReaderFavoriteWatchedFolder,
+        resolvedFolderURL: URL
+    ) {
+        sidebarDocumentController?.folderWatchCoordinator.scanCurrentMarkdownFiles { [weak self] scannedURLs in
+            guard let self,
+                  let session = folderWatchFlowController?.sharedFolderWatchSession,
+                  let fileOpenCoordinator = sidebarDocumentController?.fileOpenCoordinator else {
+                return
+            }
+
+            let newFileURLs = entry.newFileURLs(fromScanned: scannedURLs, relativeTo: resolvedFolderURL)
+            if !newFileURLs.isEmpty {
+                fileOpenCoordinator.open(FileOpenRequest(
+                    fileURLs: newFileURLs,
+                    origin: .folderWatchInitialBatchAutoOpen,
+                    folderWatchSession: session,
+                    slotStrategy: .alwaysAppend,
+                    materializationStrategy: .deferOnly
+                ))
+                sidebarDocumentController?.selectDocumentWithNewestModificationDate()
+            }
+
+            settingsStore.updateFavoriteWatchedFolderKnownDocuments(
+                id: entry.id,
+                folderURL: resolvedFolderURL,
+                knownDocumentFileURLs: scannedURLs
+            )
+        }
     }
 }

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -7,10 +7,10 @@ final class FavoriteWorkspaceController {
     private let settingsStore: any ReaderSettingsReading & ReaderFavoriteWriting
 
     // Cross-references (set via configure())
-    private var sidebarDocumentController: ReaderSidebarDocumentController?
-    private var folderWatchFlowController: FolderWatchFlowController?
-    private var groupStateController: SidebarGroupStateController?
-    private var appearanceController: WindowAppearanceController?
+    private weak var sidebarDocumentController: ReaderSidebarDocumentController?
+    private weak var folderWatchFlowController: FolderWatchFlowController?
+    private weak var groupStateController: SidebarGroupStateController?
+    private weak var appearanceController: WindowAppearanceController?
 
     private(set) var activeFavoriteID: UUID?
     private(set) var activeFavoriteWorkspaceState: ReaderFavoriteWorkspaceState?

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -22,10 +22,27 @@ final class FolderWatchFlowController {
         pendingFolderWatchRequest?.folderURL
     }
 
+    private let settingsStore: ReaderSettingsStore
     private let sidebarDocumentController: ReaderSidebarDocumentController
 
-    init(sidebarDocumentController: ReaderSidebarDocumentController) {
+    // Cross-references (set via configure())
+    private(set) var favoriteWorkspaceController: FavoriteWorkspaceController?
+    private(set) var groupStateController: SidebarGroupStateController?
+    private(set) var appearanceController: WindowAppearanceController?
+
+    init(settingsStore: ReaderSettingsStore, sidebarDocumentController: ReaderSidebarDocumentController) {
+        self.settingsStore = settingsStore
         self.sidebarDocumentController = sidebarDocumentController
+    }
+
+    func configure(
+        favoriteWorkspaceController: FavoriteWorkspaceController,
+        groupStateController: SidebarGroupStateController,
+        appearanceController: WindowAppearanceController
+    ) {
+        self.favoriteWorkspaceController = favoriteWorkspaceController
+        self.groupStateController = groupStateController
+        self.appearanceController = appearanceController
     }
 
     // MARK: - Presentation State
@@ -42,7 +59,7 @@ final class FolderWatchFlowController {
         presentOptions(for: folderURL, options: .default)
     }
 
-    func prepareRecentWatch(_ entry: ReaderRecentWatchedFolder, settingsStore: ReaderSettingsStore) {
+    func prepareRecentWatch(_ entry: ReaderRecentWatchedFolder) {
         let resolvedFolderURL = settingsStore.resolvedRecentWatchedFolderURL(matching: entry.folderURL) ?? entry.folderURL
         presentOptions(for: resolvedFolderURL, options: entry.options)
     }
@@ -85,18 +102,147 @@ final class FolderWatchFlowController {
         }
     }
 
-    func openSelectedAutoOpenFiles(using fileOpenCoordinator: FileOpenCoordinator) {
+    func openSelectedAutoOpenFilesAndRefresh() {
         let selectedFileURLs = warningCoordinator.selectedFileURLs()
         guard !selectedFileURLs.isEmpty else {
             dismissAutoOpenWarning()
             return
         }
         dismissAutoOpenWarning()
-        fileOpenCoordinator.open(FileOpenRequest(
+        sidebarDocumentController.fileOpenCoordinator.open(FileOpenRequest(
             fileURLs: selectedFileURLs,
             origin: .manual,
             slotStrategy: .alwaysAppend
         ))
+    }
+
+    func handleAutoOpenWarningChangeForWindow(
+        _ warning: ReaderFolderWatchAutoOpenWarning?,
+        hostWindow: NSWindow?
+    ) {
+        handleAutoOpenWarningChange(warning) { self.isWarningPresentationAllowed(hostWindow: hostWindow) }
+    }
+
+    func refreshAutoOpenWarningPresentationForWindow(hostWindow: NSWindow?) {
+        refreshAutoOpenWarningPresentation { self.isWarningPresentationAllowed(hostWindow: hostWindow) }
+    }
+
+    // MARK: - Folder Watch Lifecycle
+
+    /// Starts watching a folder, optionally deactivating the current favorite.
+    /// Returns `true` if a favorite was deactivated (so the caller can reset sidebar width).
+    @discardableResult
+    func startWatchingFolder(
+        folderURL: URL,
+        options: ReaderFolderWatchOptions,
+        performInitialAutoOpen: Bool = true
+    ) -> Bool {
+        var didDeactivateFavorite = false
+
+        if favoriteWorkspaceController?.activeFavoriteID != nil {
+            let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
+            let matchesActiveFavorite = settingsStore.currentSettings.favoriteWatchedFolders.contains {
+                $0.id == favoriteWorkspaceController?.activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
+            }
+            if !matchesActiveFavorite {
+                favoriteWorkspaceController?.persistFinalState(to: settingsStore)
+                favoriteWorkspaceController?.deactivate()
+                groupStateController?.pinnedGroupIDs = []
+                groupStateController?.collapsedGroupIDs = []
+                didDeactivateFavorite = true
+                Task { @MainActor [appearanceController] in
+                    if appearanceController?.isLocked == true {
+                        appearanceController?.unlock()
+                    }
+                }
+            }
+        }
+
+        do {
+            try sidebarDocumentController.folderWatchCoordinator.startWatchingFolder(
+                folderURL: folderURL,
+                options: options,
+                performInitialAutoOpen: performInitialAutoOpen
+            )
+        } catch {
+            sidebarDocumentController.selectedReaderStore.presentError(error)
+        }
+
+        return didDeactivateFavorite
+    }
+
+    /// Stops the folder watch session and cleans up associated state.
+    /// Does NOT reset `sidebarWidth` or call `refreshWindowPresentation()` — the caller handles those.
+    func stopFolderWatchSession() {
+        dismissAutoOpenWarning()
+        favoriteWorkspaceController?.persistFinalState(to: settingsStore)
+        favoriteWorkspaceController?.deactivate()
+        groupStateController?.pinnedGroupIDs = []
+        groupStateController?.collapsedGroupIDs = []
+        sidebarDocumentController.folderWatchCoordinator.stopFolderWatch()
+        cancelPendingWatch()
+    }
+
+    /// Confirms a pending folder watch request and starts watching.
+    /// Returns `true` if a favorite was deactivated.
+    @discardableResult
+    func confirmFolderWatch(_ options: ReaderFolderWatchOptions) -> Bool {
+        guard let folderURL = pendingFolderWatchRequest?.folderURL else {
+            return false
+        }
+
+        let deactivated = startWatchingFolder(folderURL: folderURL, options: options)
+        cancelPendingWatch()
+        return deactivated
+    }
+
+    /// Updates folder watch exclusions, closing/opening documents as needed.
+    /// Returns `true` on success.
+    @discardableResult
+    func updateFolderWatchExclusions(_ newExcludedPaths: [String]) -> Bool {
+        guard let session = sharedFolderWatchSession else { return false }
+
+        let normalizedOld = Set(
+            session.options.encodedForFolder(session.folderURL).excludedSubdirectoryPaths
+        )
+        let normalizedNew = Set(
+            ReaderFolderWatchOptions(
+                openMode: session.options.openMode,
+                scope: session.options.scope,
+                excludedSubdirectoryPaths: newExcludedPaths
+            ).encodedForFolder(session.folderURL).excludedSubdirectoryPaths
+        )
+
+        guard normalizedOld != normalizedNew else { return true }
+
+        syncFavoriteExclusionsIfNeeded(newExcludedPaths)
+
+        do {
+            try sidebarDocumentController.folderWatchCoordinator.updateFolderWatchExcludedSubdirectories(newExcludedPaths)
+        } catch {
+            sidebarDocumentController.selectedReaderStore.presentError(error)
+            return false
+        }
+
+        let newlyExcludedPaths = normalizedNew.subtracting(normalizedOld)
+        if !newlyExcludedPaths.isEmpty {
+            closeDocumentsInExcludedPaths(Array(newlyExcludedPaths))
+        }
+
+        let newlyIncludedPaths = normalizedOld.subtracting(normalizedNew)
+        if !newlyIncludedPaths.isEmpty, session.options.openMode == .openAllMarkdownFiles {
+            openFilesInNewlyIncludedPaths(Array(newlyIncludedPaths))
+        }
+
+        return true
+    }
+
+    private func syncFavoriteExclusionsIfNeeded(_ excludedPaths: [String]) {
+        guard let favoriteID = favoriteWorkspaceController?.activeFavoriteID else { return }
+        settingsStore.updateFavoriteWatchedFolderExclusions(
+            id: favoriteID,
+            excludedSubdirectoryPaths: excludedPaths
+        )
     }
 
     // MARK: - Exclusions
@@ -132,9 +278,9 @@ final class FolderWatchFlowController {
     }
 
     func openFilesInNewlyIncludedPaths(
-        _ includedPaths: [String],
-        fileOpenCoordinator: FileOpenCoordinator
+        _ includedPaths: [String]
     ) {
+        let fileOpenCoordinator = sidebarDocumentController.fileOpenCoordinator
         let includedPrefixes = includedPaths.map { path in
             let normalized = ReaderFileRouting.normalizedFileURL(
                 URL(fileURLWithPath: path, isDirectory: true)

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -26,9 +26,9 @@ final class FolderWatchFlowController {
     private let sidebarDocumentController: ReaderSidebarDocumentController
 
     // Cross-references (set via configure())
-    private(set) var favoriteWorkspaceController: FavoriteWorkspaceController?
-    private(set) var groupStateController: SidebarGroupStateController?
-    private(set) var appearanceController: WindowAppearanceController?
+    private(set) weak var favoriteWorkspaceController: FavoriteWorkspaceController?
+    private(set) weak var groupStateController: SidebarGroupStateController?
+    private(set) weak var appearanceController: WindowAppearanceController?
 
     init(settingsStore: ReaderSettingsStore, sidebarDocumentController: ReaderSidebarDocumentController) {
         self.settingsStore = settingsStore

--- a/minimark/Stores/RecentHistoryCoordinator.swift
+++ b/minimark/Stores/RecentHistoryCoordinator.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class RecentHistoryCoordinator {
+    private let settingsStore: ReaderSettingsStore
+    private var folderWatchFlowController: FolderWatchFlowController?
+
+    init(settingsStore: ReaderSettingsStore) {
+        self.settingsStore = settingsStore
+    }
+
+    func configure(folderWatchFlowController: FolderWatchFlowController) {
+        self.folderWatchFlowController = folderWatchFlowController
+    }
+
+    // MARK: - Recent Folder Watch
+
+    func startRecentFolderWatch(_ entry: ReaderRecentWatchedFolder) {
+        folderWatchFlowController?.prepareRecentWatch(entry)
+    }
+
+    func clearRecentWatchedFolders() {
+        settingsStore.clearRecentWatchedFolders()
+    }
+
+    // MARK: - Recent Files
+
+    func clearRecentManuallyOpenedFiles() {
+        settingsStore.clearRecentManuallyOpenedFiles()
+    }
+
+    func openRecentFile(
+        _ entry: ReaderRecentOpenedFile,
+        using fileOpenCoordinator: FileOpenCoordinator,
+        session: ReaderFolderWatchSession?
+    ) {
+        let resolvedURL = settingsStore.resolvedRecentManuallyOpenedFileURL(matching: entry.fileURL) ?? entry.fileURL
+        fileOpenCoordinator.open(FileOpenRequest(
+            fileURLs: [resolvedURL],
+            origin: .manual,
+            folderWatchSession: session,
+            slotStrategy: .replaceSelectedSlot
+        ))
+    }
+
+    // MARK: - Notification Handling
+
+    func handleOpenRecentFileNotification(
+        _ notification: Notification,
+        hostWindowNumber: Int?,
+        openDocumentInCurrentWindow: (URL) -> Void
+    ) {
+        guard let payload = ReaderCommandNotification.Payload(notification: notification),
+              payload.targetWindowNumber == hostWindowNumber else { return }
+        guard let entry = payload.recentFileEntry else { return }
+        let resolvedURL = settingsStore.resolvedRecentManuallyOpenedFileURL(matching: entry.fileURL) ?? entry.fileURL
+        openDocumentInCurrentWindow(resolvedURL)
+    }
+
+    func handlePrepareRecentWatchedFolderNotification(
+        _ notification: Notification,
+        hostWindowNumber: Int?
+    ) {
+        guard let payload = ReaderCommandNotification.Payload(notification: notification),
+              payload.targetWindowNumber == hostWindowNumber else { return }
+        guard let entry = payload.recentWatchedFolderEntry else { return }
+        startRecentFolderWatch(entry)
+    }
+}

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -11,7 +11,7 @@ struct ReaderWindowRootView: View {
     @State var windowCoordinator: ReaderWindowCoordinator
     @State var appearanceController: WindowAppearanceController
     @State var groupStateController = SidebarGroupStateController()
-    @State var favoriteWorkspaceController = FavoriteWorkspaceController()
+    @State var favoriteWorkspaceController: FavoriteWorkspaceController
     @State var folderWatchFlowController: FolderWatchFlowController
     @State var recentHistoryCoordinator: RecentHistoryCoordinator
     @State var uiTestLaunchCoordinator = UITestLaunchCoordinator()
@@ -34,6 +34,9 @@ struct ReaderWindowRootView: View {
         )
         _appearanceController = State(
             wrappedValue: WindowAppearanceController(settingsStore: settingsStore)
+        )
+        _favoriteWorkspaceController = State(
+            wrappedValue: FavoriteWorkspaceController(settingsStore: settingsStore)
         )
         _folderWatchFlowController = State(
             wrappedValue: FolderWatchFlowController(settingsStore: settingsStore, sidebarDocumentController: sidebarDocumentController)
@@ -218,10 +221,10 @@ struct ReaderWindowRootView: View {
             }
             .onChange(of: folderWatchFlowController.sharedFolderWatchSession) { _, _ in
                 windowCoordinator.refreshWindowShellRegistrationAndTitle()
-                windowCoordinator.syncSharedFavoriteOpenDocumentsIfNeeded()
+                favoriteWorkspaceController.syncOpenDocumentsIfNeeded()
             }
             .onChange(of: windowCoordinator.openDocumentPathTracker.openDocumentPaths) { _, _ in
-                windowCoordinator.syncSharedFavoriteOpenDocumentsIfNeeded()
+                favoriteWorkspaceController.syncOpenDocumentsIfNeeded()
             }
     }
 
@@ -284,6 +287,12 @@ struct ReaderWindowRootView: View {
                 folderWatchFlowController.sharedFolderWatchSession != nil
             }
         ))
+        favoriteWorkspaceController.configure(
+            sidebarDocumentController: sidebarDocumentController,
+            folderWatchFlowController: folderWatchFlowController,
+            groupStateController: groupStateController,
+            appearanceController: appearanceController
+        )
         folderWatchFlowController.configure(
             favoriteWorkspaceController: favoriteWorkspaceController,
             groupStateController: groupStateController,

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -35,7 +35,7 @@ struct ReaderWindowRootView: View {
             wrappedValue: WindowAppearanceController(settingsStore: settingsStore)
         )
         _folderWatchFlowController = State(
-            wrappedValue: FolderWatchFlowController(sidebarDocumentController: sidebarDocumentController)
+            wrappedValue: FolderWatchFlowController(settingsStore: settingsStore, sidebarDocumentController: sidebarDocumentController)
         )
     }
 
@@ -131,12 +131,12 @@ struct ReaderWindowRootView: View {
         @Bindable var folderWatchFlow = folderWatchFlowController
         return view
             .sheet(item: $warningCoord.activeFlow, onDismiss: {
-                windowCoordinator.dismissFolderWatchAutoOpenWarning()
+                folderWatchFlowController.dismissAutoOpenWarning()
             }) { flow in
                 FolderWatchAutoOpenWarningFlowSheet(
                     flow: flow,
                     onKeepCurrentFiles: {
-                        windowCoordinator.dismissFolderWatchAutoOpenWarning()
+                        folderWatchFlowController.dismissAutoOpenWarning()
                     },
                     onOpenSelectedFiles: {
                         windowCoordinator.openSelectedFolderWatchAutoOpenFiles()
@@ -270,8 +270,8 @@ struct ReaderWindowRootView: View {
             startWatchingFolder: { [windowCoordinator] folderURL, options in
                 windowCoordinator.startWatchingFolder(folderURL: folderURL, options: options)
             },
-            presentFolderWatchOptions: { [windowCoordinator] folderURL, options in
-                windowCoordinator.presentFolderWatchOptions(for: folderURL, options: options)
+            presentFolderWatchOptions: { [folderWatchFlowController] folderURL, options in
+                folderWatchFlowController.presentOptions(for: folderURL, options: options)
             },
             openFileRequest: { [windowCoordinator] request in
                 windowCoordinator.openFileRequest(request)
@@ -280,6 +280,11 @@ struct ReaderWindowRootView: View {
                 folderWatchFlowController.sharedFolderWatchSession != nil
             }
         ))
+        folderWatchFlowController.configure(
+            favoriteWorkspaceController: favoriteWorkspaceController,
+            groupStateController: groupStateController,
+            appearanceController: appearanceController
+        )
         windowCoordinator.configure(
             appearanceController: appearanceController,
             groupStateController: groupStateController,
@@ -402,6 +407,6 @@ struct ReaderWindowRootView: View {
             title: "Choose Folder to Watch",
             message: "Select a folder, then choose watch options."
         ) else { return }
-        windowCoordinator.prepareFolderWatchOptions(for: folderURL)
+        folderWatchFlowController.prepareOptions(for: folderURL)
     }
 }

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -13,6 +13,7 @@ struct ReaderWindowRootView: View {
     @State var groupStateController = SidebarGroupStateController()
     @State var favoriteWorkspaceController = FavoriteWorkspaceController()
     @State var folderWatchFlowController: FolderWatchFlowController
+    @State var recentHistoryCoordinator: RecentHistoryCoordinator
     @State var uiTestLaunchCoordinator = UITestLaunchCoordinator()
 
     init(
@@ -36,6 +37,9 @@ struct ReaderWindowRootView: View {
         )
         _folderWatchFlowController = State(
             wrappedValue: FolderWatchFlowController(settingsStore: settingsStore, sidebarDocumentController: sidebarDocumentController)
+        )
+        _recentHistoryCoordinator = State(
+            wrappedValue: RecentHistoryCoordinator(settingsStore: settingsStore)
         )
     }
 
@@ -285,12 +289,14 @@ struct ReaderWindowRootView: View {
             groupStateController: groupStateController,
             appearanceController: appearanceController
         )
+        recentHistoryCoordinator.configure(folderWatchFlowController: folderWatchFlowController)
         windowCoordinator.configure(
             appearanceController: appearanceController,
             groupStateController: groupStateController,
             favoriteWorkspaceController: favoriteWorkspaceController,
             folderWatchFlowController: folderWatchFlowController,
-            uiTestLaunchCoordinator: uiTestLaunchCoordinator
+            uiTestLaunchCoordinator: uiTestLaunchCoordinator,
+            recentHistoryCoordinator: recentHistoryCoordinator
         )
         windowCoordinator.applyInitialSeedIfNeeded(seed: seed)
         windowCoordinator.refreshSharedFolderWatchState()
@@ -299,10 +305,18 @@ struct ReaderWindowRootView: View {
     private func commandNotificationAwareView<Content: View>(_ view: Content) -> some View {
         view
             .onReceive(NotificationCenter.default.publisher(for: ReaderCommandNotification.openRecentFile)) { notification in
-                windowCoordinator.handleOpenRecentFileNotification(notification)
+                recentHistoryCoordinator.handleOpenRecentFileNotification(
+                    notification,
+                    hostWindowNumber: windowCoordinator.hostWindow?.windowNumber
+                ) { fileURL in
+                    windowCoordinator.openDocumentInCurrentWindow(fileURL)
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: ReaderCommandNotification.prepareRecentWatchedFolder)) { notification in
-                windowCoordinator.handlePrepareRecentWatchedFolderNotification(notification)
+                recentHistoryCoordinator.handlePrepareRecentWatchedFolderNotification(
+                    notification,
+                    hostWindowNumber: windowCoordinator.hostWindow?.windowNumber
+                )
             }
     }
 

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -273,18 +273,18 @@ struct ReaderWindowRootView: View {
         guard !windowCoordinator.hasOpenedInitialFile else { return }
         windowCoordinator.hasOpenedInitialFile = true
         uiTestLaunchCoordinator.configure(actions: UITestLaunchCoordinator.Actions(
-            hostWindow: { [windowCoordinator] in windowCoordinator.hostWindow },
-            startWatchingFolder: { [windowCoordinator] folderURL, options in
-                windowCoordinator.startWatchingFolder(folderURL: folderURL, options: options)
+            hostWindow: { [weak windowCoordinator] in windowCoordinator?.hostWindow },
+            startWatchingFolder: { [weak windowCoordinator] folderURL, options in
+                windowCoordinator?.startWatchingFolder(folderURL: folderURL, options: options)
             },
-            presentFolderWatchOptions: { [folderWatchFlowController] folderURL, options in
-                folderWatchFlowController.presentOptions(for: folderURL, options: options)
+            presentFolderWatchOptions: { [weak folderWatchFlowController] folderURL, options in
+                folderWatchFlowController?.presentOptions(for: folderURL, options: options)
             },
-            openFileRequest: { [windowCoordinator] request in
-                windowCoordinator.openFileRequest(request)
+            openFileRequest: { [weak windowCoordinator] request in
+                windowCoordinator?.openFileRequest(request)
             },
-            isSessionActive: { [folderWatchFlowController] in
-                folderWatchFlowController.sharedFolderWatchSession != nil
+            isSessionActive: { [weak folderWatchFlowController] in
+                folderWatchFlowController?.sharedFolderWatchSession != nil
             }
         ))
         favoriteWorkspaceController.configure(

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -13,6 +13,7 @@ struct ReaderWindowRootView: View {
     @State var groupStateController = SidebarGroupStateController()
     @State var favoriteWorkspaceController = FavoriteWorkspaceController()
     @State var folderWatchFlowController: FolderWatchFlowController
+    @State var uiTestLaunchCoordinator = UITestLaunchCoordinator()
 
     init(
         seed: ReaderWindowSeed?,
@@ -264,11 +265,27 @@ struct ReaderWindowRootView: View {
     private func performInitialSetupIfNeeded() {
         guard !windowCoordinator.hasOpenedInitialFile else { return }
         windowCoordinator.hasOpenedInitialFile = true
+        uiTestLaunchCoordinator.configure(actions: UITestLaunchCoordinator.Actions(
+            hostWindow: { [windowCoordinator] in windowCoordinator.hostWindow },
+            startWatchingFolder: { [windowCoordinator] folderURL, options in
+                windowCoordinator.startWatchingFolder(folderURL: folderURL, options: options)
+            },
+            presentFolderWatchOptions: { [windowCoordinator] folderURL, options in
+                windowCoordinator.presentFolderWatchOptions(for: folderURL, options: options)
+            },
+            openFileRequest: { [windowCoordinator] request in
+                windowCoordinator.openFileRequest(request)
+            },
+            isSessionActive: { [folderWatchFlowController] in
+                folderWatchFlowController.sharedFolderWatchSession != nil
+            }
+        ))
         windowCoordinator.configure(
             appearanceController: appearanceController,
             groupStateController: groupStateController,
             favoriteWorkspaceController: favoriteWorkspaceController,
-            folderWatchFlowController: folderWatchFlowController
+            folderWatchFlowController: folderWatchFlowController,
+            uiTestLaunchCoordinator: uiTestLaunchCoordinator
         )
         windowCoordinator.applyInitialSeedIfNeeded(seed: seed)
         windowCoordinator.refreshSharedFolderWatchState()

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -286,7 +286,7 @@ final class ReaderWindowCoordinator {
             return
         }
 
-        prepareRecentFolderWatch(entry)
+        folderWatchFlowController?.prepareRecentWatch(entry)
     }
 
     func handleWindowAccessorUpdate(_ window: NSWindow?) {
@@ -471,8 +471,8 @@ final class ReaderWindowCoordinator {
             resolveRecentWatchedFolderURL: { entry in
                 settingsStore.resolvedRecentWatchedFolderURL(matching: entry.folderURL) ?? entry.folderURL
             },
-            prepareRecentFolderWatch: { folderURL, options in
-                presentFolderWatchOptions(for: folderURL, options: options)
+            prepareRecentFolderWatch: { [weak self] folderURL, options in
+                self?.folderWatchFlowController?.presentOptions(for: folderURL, options: options)
             }
         )
     }
@@ -494,23 +494,7 @@ final class ReaderWindowCoordinator {
         applyWindowTitlePresentation()
     }
 
-    func prepareFolderWatchOptions(for folderURL: URL) {
-        folderWatchFlowController?.prepareOptions(for: folderURL)
-    }
-
-    func presentFolderWatchOptions(for folderURL: URL, options: ReaderFolderWatchOptions) {
-        folderWatchFlowController?.presentOptions(for: folderURL, options: options)
-    }
-
-    func prepareRecentFolderWatch(_ entry: ReaderRecentWatchedFolder) {
-        folderWatchFlowController?.prepareRecentWatch(entry, settingsStore: settingsStore)
-    }
-
-    func updatePendingFolderWatchRequest(
-        _ update: (inout FolderWatchFlowController.PendingFolderWatchRequest) -> Void
-    ) {
-        folderWatchFlowController?.updatePendingRequest(update)
-    }
+    // Folder watch presentation and options are managed directly by FolderWatchFlowController.
 
     // MARK: - Sidebar Command Flow
 
@@ -709,7 +693,7 @@ final class ReaderWindowCoordinator {
     }
 
     func startRecentFolderWatch(_ entry: ReaderRecentWatchedFolder) {
-        prepareRecentFolderWatch(entry)
+        folderWatchFlowController?.prepareRecentWatch(entry)
     }
 
     func clearRecentWatchedFolders() {
@@ -725,39 +709,14 @@ final class ReaderWindowCoordinator {
         options: ReaderFolderWatchOptions,
         performInitialAutoOpen: Bool = true
     ) {
-        // Clear active favorite - if this is a favorite watch, startFavoriteWatch sets these BEFORE calling this method
-        if favoriteWorkspaceController?.activeFavoriteID != nil {
-            // Only clear if this is NOT being called from startFavoriteWatch
-            // (startFavoriteWatch sets activeFavoriteID before calling startWatchingFolder)
-            // We can detect this by checking if the folder matches the active favorite
-            let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
-            let matchesActiveFavorite = settingsStore.currentSettings.favoriteWatchedFolders.contains {
-                $0.id == favoriteWorkspaceController?.activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
-            }
-            if !matchesActiveFavorite {
-                favoriteWorkspaceController?.persistFinalState(to: settingsStore)
-                favoriteWorkspaceController?.deactivate()
-                groupStateController?.pinnedGroupIDs = []
-                groupStateController?.collapsedGroupIDs = []
-                sidebarWidth = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
-                Task { @MainActor [appearanceController] in
-                    if appearanceController?.isLocked == true {
-                        appearanceController?.unlock()
-                    }
-                }
-            }
+        let deactivated = folderWatchFlowController?.startWatchingFolder(
+            folderURL: folderURL,
+            options: options,
+            performInitialAutoOpen: performInitialAutoOpen
+        ) ?? false
+        if deactivated {
+            sidebarWidth = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
         }
-
-        do {
-            try sidebarDocumentController.folderWatchCoordinator.startWatchingFolder(
-                folderURL: folderURL,
-                options: options,
-                performInitialAutoOpen: performInitialAutoOpen
-            )
-        } catch {
-            sidebarDocumentController.selectedReaderStore.presentError(error)
-        }
-
         refreshWindowPresentation()
     }
 
@@ -819,50 +778,9 @@ final class ReaderWindowCoordinator {
 
     @discardableResult
     func updateFolderWatchExclusions(_ newExcludedPaths: [String]) -> Bool {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession else { return false }
-
-        let normalizedOld = Set(
-            session.options.encodedForFolder(session.folderURL).excludedSubdirectoryPaths
-        )
-        let normalizedNew = Set(
-            ReaderFolderWatchOptions(
-                openMode: session.options.openMode,
-                scope: session.options.scope,
-                excludedSubdirectoryPaths: newExcludedPaths
-            ).encodedForFolder(session.folderURL).excludedSubdirectoryPaths
-        )
-
-        guard normalizedOld != normalizedNew else { return true }
-
-        syncFavoriteExclusionsIfNeeded(newExcludedPaths)
-
-        do {
-            try sidebarDocumentController.folderWatchCoordinator.updateFolderWatchExcludedSubdirectories(newExcludedPaths)
-        } catch {
-            sidebarDocumentController.selectedReaderStore.presentError(error)
-            return false
-        }
-
-        let newlyExcludedPaths = normalizedNew.subtracting(normalizedOld)
-        if !newlyExcludedPaths.isEmpty {
-            folderWatchFlowController?.closeDocumentsInExcludedPaths(Array(newlyExcludedPaths))
-        }
-
-        let newlyIncludedPaths = normalizedOld.subtracting(normalizedNew)
-        if !newlyIncludedPaths.isEmpty, session.options.openMode == .openAllMarkdownFiles {
-            folderWatchFlowController?.openFilesInNewlyIncludedPaths(Array(newlyIncludedPaths), fileOpenCoordinator: fileOpenCoordinator)
-        }
-
+        let result = folderWatchFlowController?.updateFolderWatchExclusions(newExcludedPaths) ?? false
         refreshWindowPresentation()
-        return true
-    }
-
-    private func syncFavoriteExclusionsIfNeeded(_ excludedPaths: [String]) {
-        guard let favoriteID = favoriteWorkspaceController?.activeFavoriteID else { return }
-        settingsStore.updateFavoriteWatchedFolderExclusions(
-            id: favoriteID,
-            excludedSubdirectoryPaths: excludedPaths
-        )
+        return result
     }
 
     func persistFinalWorkspaceStateIfNeeded() {
@@ -871,54 +789,31 @@ final class ReaderWindowCoordinator {
 
     // MARK: - Warning Flow
 
-    func cancelFolderWatch() {
-        folderWatchFlowController?.cancelPendingWatch()
-    }
-
     func confirmFolderWatch(_ options: ReaderFolderWatchOptions) {
-        guard let folderURL = folderWatchFlowController?.pendingFolderWatchRequest?.folderURL else {
-            return
+        let deactivated = folderWatchFlowController?.confirmFolderWatch(options) ?? false
+        if deactivated {
+            sidebarWidth = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
         }
-
-        startWatchingFolder(folderURL: folderURL, options: options)
-        cancelFolderWatch()
+        refreshWindowPresentation()
     }
 
     func stopFolderWatch() {
-        dismissFolderWatchAutoOpenWarning()
-        favoriteWorkspaceController?.persistFinalState(to: settingsStore)
-        favoriteWorkspaceController?.deactivate()
-        groupStateController?.pinnedGroupIDs = []
-        groupStateController?.collapsedGroupIDs = []
+        folderWatchFlowController?.stopFolderWatchSession()
         sidebarWidth = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
-        sidebarDocumentController.folderWatchCoordinator.stopFolderWatch()
         refreshWindowPresentation()
-        cancelFolderWatch()
     }
 
     func handleFolderWatchAutoOpenWarningChange(_ warning: ReaderFolderWatchAutoOpenWarning?) {
-        folderWatchFlowController?.handleAutoOpenWarningChange(warning) { [weak self] in
-            self?.isFolderWatchWarningPresentationAllowed() ?? false
-        }
+        folderWatchFlowController?.handleAutoOpenWarningChangeForWindow(warning, hostWindow: hostWindow)
     }
 
     func refreshFolderWatchAutoOpenWarningPresentation() {
-        folderWatchFlowController?.refreshAutoOpenWarningPresentation { [weak self] in
-            self?.isFolderWatchWarningPresentationAllowed() ?? false
-        }
-    }
-
-    func dismissFolderWatchAutoOpenWarning() {
-        folderWatchFlowController?.dismissAutoOpenWarning()
+        folderWatchFlowController?.refreshAutoOpenWarningPresentationForWindow(hostWindow: hostWindow)
     }
 
     func openSelectedFolderWatchAutoOpenFiles() {
-        folderWatchFlowController?.openSelectedAutoOpenFiles(using: fileOpenCoordinator)
+        folderWatchFlowController?.openSelectedAutoOpenFilesAndRefresh()
         refreshWindowPresentation()
-    }
-
-    func isFolderWatchWarningPresentationAllowed() -> Bool {
-        folderWatchFlowController?.isWarningPresentationAllowed(hostWindow: hostWindow) ?? false
     }
 
     // MARK: - Action Dispatch

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -59,6 +59,7 @@ final class ReaderWindowCoordinator {
     private(set) var favoriteWorkspaceController: FavoriteWorkspaceController?
     private(set) var folderWatchFlowController: FolderWatchFlowController?
     private(set) var uiTestLaunchCoordinator: UITestLaunchCoordinator?
+    private(set) var recentHistoryCoordinator: RecentHistoryCoordinator?
 
     private var fileOpenCoordinator: FileOpenCoordinator {
         sidebarDocumentController.fileOpenCoordinator
@@ -69,13 +70,15 @@ final class ReaderWindowCoordinator {
         groupStateController: SidebarGroupStateController,
         favoriteWorkspaceController: FavoriteWorkspaceController,
         folderWatchFlowController: FolderWatchFlowController,
-        uiTestLaunchCoordinator: UITestLaunchCoordinator
+        uiTestLaunchCoordinator: UITestLaunchCoordinator,
+        recentHistoryCoordinator: RecentHistoryCoordinator
     ) {
         self.appearanceController = appearanceController
         self.groupStateController = groupStateController
         self.favoriteWorkspaceController = favoriteWorkspaceController
         self.folderWatchFlowController = folderWatchFlowController
         self.uiTestLaunchCoordinator = uiTestLaunchCoordinator
+        self.recentHistoryCoordinator = recentHistoryCoordinator
         configureStoreCallbacks(
             lockedAppearanceProvider: { [weak appearanceController] in appearanceController?.lockedAppearance }
         ) { [weak self] fileURL, folderWatchSession, origin, initialDiffBaselineMarkdown in
@@ -241,11 +244,11 @@ final class ReaderWindowCoordinator {
         case .startFavoriteWatch(let favorite):
             startFavoriteWatch(favorite)
         case .startRecentFolderWatch(let recent):
-            startRecentFolderWatch(recent)
+            recentHistoryCoordinator?.startRecentFolderWatch(recent)
         case .editFavoriteWatchedFolders:
             isTitlebarEditingFavorites = true
         case .clearRecentWatchedFolders:
-            clearRecentWatchedFolders()
+            recentHistoryCoordinator?.clearRecentWatchedFolders()
         }
     }
 
@@ -260,33 +263,6 @@ final class ReaderWindowCoordinator {
         case .dismiss:
             isTitlebarEditingFavorites = false
         }
-    }
-
-    func handleOpenRecentFileNotification(_ notification: Notification) {
-        guard let payload = ReaderCommandNotification.Payload(notification: notification),
-              payload.targetWindowNumber == hostWindow?.windowNumber else {
-            return
-        }
-
-        guard let entry = payload.recentFileEntry else {
-            return
-        }
-
-        let resolvedURL = settingsStore.resolvedRecentManuallyOpenedFileURL(matching: entry.fileURL) ?? entry.fileURL
-        openDocumentInCurrentWindow(resolvedURL)
-    }
-
-    func handlePrepareRecentWatchedFolderNotification(_ notification: Notification) {
-        guard let payload = ReaderCommandNotification.Payload(notification: notification),
-              payload.targetWindowNumber == hostWindow?.windowNumber else {
-            return
-        }
-
-        guard let entry = payload.recentWatchedFolderEntry else {
-            return
-        }
-
-        folderWatchFlowController?.prepareRecentWatch(entry)
     }
 
     func handleWindowAccessorUpdate(_ window: NSWindow?) {
@@ -692,18 +668,6 @@ final class ReaderWindowCoordinator {
         settingsStore.clearFavoriteWatchedFolders()
     }
 
-    func startRecentFolderWatch(_ entry: ReaderRecentWatchedFolder) {
-        folderWatchFlowController?.prepareRecentWatch(entry)
-    }
-
-    func clearRecentWatchedFolders() {
-        settingsStore.clearRecentWatchedFolders()
-    }
-
-    func clearRecentManuallyOpenedFiles() {
-        settingsStore.clearRecentManuallyOpenedFiles()
-    }
-
     func startWatchingFolder(
         folderURL: URL,
         options: ReaderFolderWatchOptions,
@@ -848,19 +812,14 @@ final class ReaderWindowCoordinator {
         case .reorderFavoriteWatchedFolders(let ids):
             settingsStore.reorderFavoriteWatchedFolders(orderedIDs: ids)
         case .startRecentManuallyOpenedFile(let entry):
-            let resolvedURL = settingsStore.resolvedRecentManuallyOpenedFileURL(matching: entry.fileURL) ?? entry.fileURL
-            fileOpenCoordinator.open(FileOpenRequest(
-                fileURLs: [resolvedURL], origin: .manual,
-                folderWatchSession: folderWatchFlowController?.sharedFolderWatchSession,
-                slotStrategy: .replaceSelectedSlot
-            ))
+            recentHistoryCoordinator?.openRecentFile(entry, using: fileOpenCoordinator, session: folderWatchFlowController?.sharedFolderWatchSession)
             applyWindowTitlePresentation()
         case .startRecentFolderWatch(let entry):
-            startRecentFolderWatch(entry)
+            recentHistoryCoordinator?.startRecentFolderWatch(entry)
         case .clearRecentWatchedFolders:
-            clearRecentWatchedFolders()
+            recentHistoryCoordinator?.clearRecentWatchedFolders()
         case .clearRecentManuallyOpenedFiles:
-            clearRecentManuallyOpenedFiles()
+            recentHistoryCoordinator?.clearRecentManuallyOpenedFiles()
         case .editSubfolders:
             isEditingSubfolders = true
         case .saveSourceDraft:

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -36,8 +36,6 @@ final class ReaderWindowCoordinator {
     var hasOpenedInitialFile = false
     var effectiveWindowTitle = ReaderWindowTitleFormatter.appName
     let dockTileWindowToken = UUID()
-    var hasAppliedUITestLaunchConfiguration = false
-    var uiTestWatchFlowTask: Task<Void, Never>?
     var sidebarWidth: CGFloat = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
     var lastAppliedSidebarDelta: CGFloat = 0
     var isTitlebarEditingFavorites = false
@@ -60,6 +58,7 @@ final class ReaderWindowCoordinator {
     private(set) var groupStateController: SidebarGroupStateController?
     private(set) var favoriteWorkspaceController: FavoriteWorkspaceController?
     private(set) var folderWatchFlowController: FolderWatchFlowController?
+    private(set) var uiTestLaunchCoordinator: UITestLaunchCoordinator?
 
     private var fileOpenCoordinator: FileOpenCoordinator {
         sidebarDocumentController.fileOpenCoordinator
@@ -69,12 +68,14 @@ final class ReaderWindowCoordinator {
         appearanceController: WindowAppearanceController,
         groupStateController: SidebarGroupStateController,
         favoriteWorkspaceController: FavoriteWorkspaceController,
-        folderWatchFlowController: FolderWatchFlowController
+        folderWatchFlowController: FolderWatchFlowController,
+        uiTestLaunchCoordinator: UITestLaunchCoordinator
     ) {
         self.appearanceController = appearanceController
         self.groupStateController = groupStateController
         self.favoriteWorkspaceController = favoriteWorkspaceController
         self.folderWatchFlowController = folderWatchFlowController
+        self.uiTestLaunchCoordinator = uiTestLaunchCoordinator
         configureStoreCallbacks(
             lockedAppearanceProvider: { [weak appearanceController] in appearanceController?.lockedAppearance }
         ) { [weak self] fileURL, folderWatchSession, origin, initialDiffBaselineMarkdown in
@@ -300,7 +301,7 @@ final class ReaderWindowCoordinator {
 
     func handleHostWindowChange() {
         refreshWindowShellState()
-        applyUITestLaunchConfigurationIfNeeded()
+        uiTestLaunchCoordinator?.applyConfigurationIfNeeded()
         if hostWindow != nil, hasPendingFolderWatchOpenEvents {
             flushQueuedFolderWatchOpens()
         }
@@ -1010,90 +1011,6 @@ final class ReaderWindowCoordinator {
                 favoriteWorkspaceController?.updateLockedAppearance(appearanceController.lockedAppearance)
             }
         }
-    }
-
-    // MARK: - UI Test Flow
-
-    func applyUITestLaunchConfigurationIfNeeded() {
-        guard !hasAppliedUITestLaunchConfiguration else {
-            return
-        }
-
-        let action = resolvedUITestLaunchAction()
-        switch action {
-        case .none:
-            break
-        case .simulateGroupedSidebar:
-            startUITestGroupedSidebarFlow()
-        case .simulateAutoOpenWatchFlow:
-            startUITestAutoOpenWatchFlow()
-        case .presentWatchFolderSheet(let watchFolderURL):
-            applyScreenshotWindowSize()
-            var options = ReaderFolderWatchOptions.default
-            if ProcessInfo.processInfo.environment[
-                ReaderUITestLaunchConfiguration.screenshotWatchScopeEnvironmentKey
-            ] == "includeSubfolders" {
-                options.scope = .includeSubfolders
-            }
-            presentFolderWatchOptions(for: watchFolderURL, options: options)
-        case .startWatchingFolder(let watchFolderURL):
-            startWatchingFolder(folderURL: watchFolderURL, options: .default)
-        }
-        hasAppliedUITestLaunchConfiguration = true
-    }
-
-    private func resolvedUITestLaunchAction() -> ReaderWindowUITestLaunchAction {
-        ReaderWindowUITestFlowSupport.resolveLaunchAction(
-            configuration: ReaderUITestLaunchConfiguration.current,
-            hostWindowAvailable: hostWindow != nil
-        )
-    }
-
-    private func applyScreenshotWindowSize() {
-        guard let sizeStr = ProcessInfo.processInfo.environment[
-            ReaderUITestLaunchConfiguration.screenshotWindowSizeEnvironmentKey
-        ], !sizeStr.isEmpty else { return }
-
-        let parts = sizeStr.split(separator: "x").compactMap { Double($0) }
-        guard parts.count == 2 else { return }
-
-        if let window = hostWindow {
-            let frame = NSRect(
-                x: window.frame.origin.x,
-                y: window.frame.origin.y,
-                width: parts[0],
-                height: parts[1]
-            )
-            window.setFrame(frame, display: true, animate: false)
-        }
-    }
-
-    private func startUITestGroupedSidebarFlow() {
-        ReaderWindowUITestFlowSupport.startGroupedSidebarFlow { [self] fileURLs in
-            openFileRequest(FileOpenRequest(
-                fileURLs: fileURLs,
-                origin: .manual
-            ))
-        }
-    }
-
-    private func startUITestAutoOpenWatchFlow() {
-        ReaderWindowUITestFlowSupport.startAutoOpenWatchFlow(
-            startWatchingFolder: { [self] watchFolderURL in
-                startWatchingFolder(folderURL: watchFolderURL, options: .default)
-            },
-            cancelExistingTask: { [self] in
-                uiTestWatchFlowTask?.cancel()
-            },
-            waitForFolderWatchStartup: { [folderWatchFlowController] in
-                await ReaderWindowUITestFlowSupport.waitForFolderWatchStartup {
-                    folderWatchFlowController?.sharedFolderWatchSession != nil
-                }
-            },
-            assignTask: { [self] task in
-                uiTestWatchFlowTask = task
-            }
-        )
     }
 
     // MARK: - Appearance Reapplication

--- a/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/ReaderWindowCoordinator.swift
@@ -524,148 +524,14 @@ final class ReaderWindowCoordinator {
     }
 
     var isSharedFolderWatchAFavorite: Bool {
-        favoriteMatchingSharedFolderWatchSession() != nil
-    }
-
-    func saveSharedFolderWatchAsFavorite(name: String) {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession else {
-            return
-        }
-        guard let groupStateController else { return }
-        let groupSnapshot = groupStateController.persistenceSnapshot
-        var workspaceState = ReaderFavoriteWorkspaceState.from(
-            settings: settingsStore.currentSettings,
-            pinnedGroupIDs: groupSnapshot.pinnedGroupIDs,
-            collapsedGroupIDs: groupSnapshot.collapsedGroupIDs,
-            sidebarWidth: sidebarWidth
-        )
-        workspaceState.fileSortMode = groupSnapshot.fileSortMode
-        workspaceState.groupSortMode = groupSnapshot.sortMode
-        workspaceState.lockedAppearance = appearanceController?.lockedAppearance
-        workspaceState.manualGroupOrder = groupSnapshot.manualGroupOrder
-        settingsStore.addFavoriteWatchedFolder(
-            name: name,
-            folderURL: session.folderURL,
-            options: session.options,
-            openDocumentFileURLs: currentSidebarOpenDocumentFileURLs(),
-            workspaceState: workspaceState
-        )
-
-        if let created = favoriteMatchingSharedFolderWatchSession() {
-            favoriteWorkspaceController?.activate(id: created.id, workspaceState: created.workspaceState)
-        }
-    }
-
-    func removeSharedFolderWatchFromFavorites() {
-        guard let match = favoriteMatchingSharedFolderWatchSession() else {
-            return
-        }
-        settingsStore.removeFavoriteWatchedFolder(id: match.id)
-        favoriteWorkspaceController?.deactivate()
+        favoriteWorkspaceController?.isCurrentWatchAFavorite ?? false
     }
 
     func startFavoriteWatch(_ entry: ReaderFavoriteWatchedFolder) {
-        // Restore appearance FIRST so the controller is in the correct lock state
-        // before activeFavoriteWorkspaceState triggers onChange persistence.
-        if let lockedAppearance = entry.workspaceState.lockedAppearance {
-            appearanceController?.restore(from: lockedAppearance)
-        } else if appearanceController?.isLocked == true {
-            appearanceController?.unlock()
-        }
-
-        // Set active favorite and restore workspace state
-        favoriteWorkspaceController?.activate(id: entry.id, workspaceState: entry.workspaceState)
-        groupStateController?.applyWorkspaceState(entry.workspaceState)
-        sidebarWidth = entry.workspaceState.sidebarWidth
-
-        let resolvedURL = settingsStore.resolvedFavoriteWatchedFolderURL(for: entry)
-        startWatchingFolder(
-            folderURL: resolvedURL,
-            options: entry.options,
-            performInitialAutoOpen: false
-        )
-
-        let restoredFileURLs = entry.existingOpenDocumentFileURLs(relativeTo: resolvedURL)
-        if let session = folderWatchFlowController?.sharedFolderWatchSession,
-           !restoredFileURLs.isEmpty {
-            fileOpenCoordinator.open(FileOpenRequest(
-                fileURLs: restoredFileURLs,
-                origin: .folderWatchInitialBatchAutoOpen,
-                folderWatchSession: session,
-                slotStrategy: .reuseEmptySlotForFirst,
-                materializationStrategy: .deferThenMaterializeNewest(count: ReaderFolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)
-            ))
-            refreshWindowPresentation()
-        }
-
-        syncSharedFavoriteOpenDocumentsIfNeeded()
-
-        if entry.options.openMode == .openAllMarkdownFiles {
-            discoverNewFilesForFavorite(entry, resolvedFolderURL: resolvedURL)
-        }
-    }
-
-    private func discoverNewFilesForFavorite(
-        _ entry: ReaderFavoriteWatchedFolder,
-        resolvedFolderURL: URL
-    ) {
-        sidebarDocumentController.folderWatchCoordinator.scanCurrentMarkdownFiles { [weak self] scannedURLs in
-            guard let self,
-                  let session = folderWatchFlowController?.sharedFolderWatchSession else {
-                return
-            }
-
-            let newFileURLs = entry.newFileURLs(fromScanned: scannedURLs, relativeTo: resolvedFolderURL)
-            if !newFileURLs.isEmpty {
-                fileOpenCoordinator.open(FileOpenRequest(
-                    fileURLs: newFileURLs,
-                    origin: .folderWatchInitialBatchAutoOpen,
-                    folderWatchSession: session,
-                    slotStrategy: .alwaysAppend,
-                    materializationStrategy: .deferOnly
-                ))
-                sidebarDocumentController.selectDocumentWithNewestModificationDate()
-                refreshWindowPresentation()
-            }
-
-            settingsStore.updateFavoriteWatchedFolderKnownDocuments(
-                id: entry.id,
-                folderURL: resolvedFolderURL,
-                knownDocumentFileURLs: scannedURLs
-            )
-        }
-    }
-
-    func syncSharedFavoriteOpenDocumentsIfNeeded() {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession,
-              let favorite = favoriteMatchingSharedFolderWatchSession() else {
-            return
-        }
-
-        settingsStore.updateFavoriteWatchedFolderOpenDocuments(
-            id: favorite.id,
-            folderURL: session.folderURL,
-            openDocumentFileURLs: currentSidebarOpenDocumentFileURLs()
-        )
-    }
-
-    func favoriteMatchingSharedFolderWatchSession() -> ReaderFavoriteWatchedFolder? {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession else {
-            return nil
-        }
-        return favoriteWorkspaceController?.matchingFavorite(
-            folderURL: session.folderURL,
-            options: session.options,
-            in: settingsStore.currentSettings.favoriteWatchedFolders
-        )
-    }
-
-    func currentSidebarOpenDocumentFileURLs() -> [URL] {
-        sidebarDocumentController.documents.compactMap { $0.readerStore.document.fileURL }
-    }
-
-    func clearFavoriteWatchedFolders() {
-        settingsStore.clearFavoriteWatchedFolders()
+        guard let favoriteWorkspaceController else { return }
+        let restoredSidebarWidth = favoriteWorkspaceController.startFavoriteWatch(entry)
+        sidebarWidth = restoredSidebarWidth
+        refreshWindowPresentation()
     }
 
     func startWatchingFolder(
@@ -747,10 +613,6 @@ final class ReaderWindowCoordinator {
         return result
     }
 
-    func persistFinalWorkspaceStateIfNeeded() {
-        favoriteWorkspaceController?.persistFinalState(to: settingsStore)
-    }
-
     // MARK: - Warning Flow
 
     func confirmFolderWatch(_ options: ReaderFolderWatchOptions) {
@@ -796,15 +658,15 @@ final class ReaderWindowCoordinator {
         case .stopFolderWatch:
             stopFolderWatch()
         case .saveFolderWatchAsFavorite(let name):
-            saveSharedFolderWatchAsFavorite(name: name)
+            favoriteWorkspaceController?.saveAsFavorite(name: name, currentSidebarWidth: sidebarWidth)
         case .removeCurrentWatchFromFavorites:
-            removeSharedFolderWatchFromFavorites()
+            favoriteWorkspaceController?.removeFromFavorites()
         case .toggleAppearanceLock:
             toggleAppearanceLock()
         case .startFavoriteWatch(let fav):
             startFavoriteWatch(fav)
         case .clearFavoriteWatchedFolders:
-            clearFavoriteWatchedFolders()
+            favoriteWorkspaceController?.clearAll()
         case .renameFavoriteWatchedFolder(let id, let name):
             settingsStore.renameFavoriteWatchedFolder(id: id, newName: name)
         case .removeFavoriteWatchedFolder(let id):

--- a/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
+++ b/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
@@ -23,7 +23,7 @@ final class UITestLaunchCoordinator {
     }
 
     func applyConfigurationIfNeeded() {
-        guard !hasAppliedConfiguration else {
+        guard !hasAppliedConfiguration, actions != nil else {
             return
         }
 

--- a/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
+++ b/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class UITestLaunchCoordinator {
+    var hasAppliedConfiguration = false
+    var watchFlowTask: Task<Void, Never>?
+
+    struct Actions {
+        let hostWindow: () -> NSWindow?
+        let startWatchingFolder: (URL, ReaderFolderWatchOptions) -> Void
+        let presentFolderWatchOptions: (URL, ReaderFolderWatchOptions) -> Void
+        let openFileRequest: (FileOpenRequest) -> Void
+        let isSessionActive: () -> Bool
+    }
+
+    private var actions: Actions?
+
+    func configure(actions: Actions) {
+        self.actions = actions
+    }
+
+    func applyConfigurationIfNeeded() {
+        guard !hasAppliedConfiguration else {
+            return
+        }
+
+        let action = resolvedLaunchAction()
+        switch action {
+        case .none:
+            break
+        case .simulateGroupedSidebar:
+            startGroupedSidebarFlow()
+        case .simulateAutoOpenWatchFlow:
+            startAutoOpenWatchFlow()
+        case .presentWatchFolderSheet(let watchFolderURL):
+            applyScreenshotWindowSize()
+            var options = ReaderFolderWatchOptions.default
+            if ProcessInfo.processInfo.environment[
+                ReaderUITestLaunchConfiguration.screenshotWatchScopeEnvironmentKey
+            ] == "includeSubfolders" {
+                options.scope = .includeSubfolders
+            }
+            actions?.presentFolderWatchOptions(watchFolderURL, options)
+        case .startWatchingFolder(let watchFolderURL):
+            actions?.startWatchingFolder(watchFolderURL, .default)
+        }
+        hasAppliedConfiguration = true
+    }
+
+    // MARK: - Private
+
+    private func resolvedLaunchAction() -> ReaderWindowUITestLaunchAction {
+        ReaderWindowUITestFlowSupport.resolveLaunchAction(
+            configuration: ReaderUITestLaunchConfiguration.current,
+            hostWindowAvailable: actions?.hostWindow() != nil
+        )
+    }
+
+    private func applyScreenshotWindowSize() {
+        guard let sizeStr = ProcessInfo.processInfo.environment[
+            ReaderUITestLaunchConfiguration.screenshotWindowSizeEnvironmentKey
+        ], !sizeStr.isEmpty else { return }
+
+        let parts = sizeStr.split(separator: "x").compactMap { Double($0) }
+        guard parts.count == 2 else { return }
+
+        if let window = actions?.hostWindow() {
+            let frame = NSRect(
+                x: window.frame.origin.x,
+                y: window.frame.origin.y,
+                width: parts[0],
+                height: parts[1]
+            )
+            window.setFrame(frame, display: true, animate: false)
+        }
+    }
+
+    private func startGroupedSidebarFlow() {
+        ReaderWindowUITestFlowSupport.startGroupedSidebarFlow { [actions] fileURLs in
+            actions?.openFileRequest(FileOpenRequest(
+                fileURLs: fileURLs,
+                origin: .manual
+            ))
+        }
+    }
+
+    private func startAutoOpenWatchFlow() {
+        ReaderWindowUITestFlowSupport.startAutoOpenWatchFlow(
+            startWatchingFolder: { [actions] watchFolderURL in
+                actions?.startWatchingFolder(watchFolderURL, .default)
+            },
+            cancelExistingTask: { [weak self] in
+                self?.watchFlowTask?.cancel()
+            },
+            waitForFolderWatchStartup: { [actions] in
+                await ReaderWindowUITestFlowSupport.waitForFolderWatchStartup {
+                    actions?.isSessionActive() ?? false
+                }
+            },
+            assignTask: { [weak self] task in
+                self?.watchFlowTask = task
+            }
+        )
+    }
+}

--- a/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
+++ b/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
@@ -4,15 +4,20 @@ import Testing
 
 @Suite
 struct FavoriteWorkspaceControllerTests {
+    @MainActor private func makeController() -> FavoriteWorkspaceController {
+        let store = TestReaderSettingsStore(autoRefreshOnExternalChange: false)
+        return FavoriteWorkspaceController(settingsStore: store)
+    }
+
     @Test @MainActor func initialStateIsInactive() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         #expect(controller.activeFavoriteID == nil)
         #expect(controller.activeFavoriteWorkspaceState == nil)
         #expect(!controller.isActive)
     }
 
     @Test @MainActor func activateSetsIDAndWorkspaceState() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         let id = UUID()
         let state = ReaderFavoriteWorkspaceState.from(
             settings: .default, pinnedGroupIDs: ["pinned"], collapsedGroupIDs: [], sidebarWidth: 300
@@ -24,7 +29,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func deactivateClearsBothProperties() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.activate(
             id: UUID(),
             workspaceState: .from(settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [], sidebarWidth: 250)
@@ -36,7 +41,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func updateSidebarWidthWhenActive() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.activate(
             id: UUID(),
             workspaceState: .from(settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [], sidebarWidth: 250)
@@ -46,13 +51,13 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func updateSidebarWidthWhenInactiveIsNoOp() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.updateSidebarWidth(320)
         #expect(controller.activeFavoriteWorkspaceState == nil)
     }
 
     @Test @MainActor func updateLockedAppearanceMutatesState() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.activate(
             id: UUID(),
             workspaceState: .from(settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [], sidebarWidth: 250)
@@ -63,7 +68,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func updateSidebarPositionMutatesState() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.activate(
             id: UUID(),
             workspaceState: .from(settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [], sidebarWidth: 250)
@@ -73,7 +78,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func updateGroupStateMutatesRelevantFields() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         controller.activate(
             id: UUID(),
             workspaceState: .from(settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [], sidebarWidth: 250)
@@ -92,7 +97,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func matchingFavoriteFindsMatchByFolderPathAndOptions() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         let folderURL = URL(fileURLWithPath: "/tmp/test-folder")
         let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
         let options = ReaderFolderWatchOptions(
@@ -106,7 +111,7 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func matchingFavoriteReturnsNilWhenNoMatch() {
-        let controller = FavoriteWorkspaceController()
+        let controller = makeController()
         let result = controller.matchingFavorite(
             folderURL: URL(fileURLWithPath: "/tmp/no-match"), options: .default, in: []
         )
@@ -114,8 +119,8 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func persistFinalStateWritesToSettingsStore() {
-        let controller = FavoriteWorkspaceController()
         let store = TestReaderSettingsStore(autoRefreshOnExternalChange: false)
+        let controller = FavoriteWorkspaceController(settingsStore: store)
         store.addFavoriteWatchedFolder(name: "Persist", folderURL: URL(fileURLWithPath: "/tmp/persist"), options: .default)
         let favoriteID = store.currentSettings.favoriteWatchedFolders.first!.id
         var workspaceState = ReaderFavoriteWorkspaceState.from(
@@ -131,8 +136,8 @@ struct FavoriteWorkspaceControllerTests {
     }
 
     @Test @MainActor func persistFinalStateIsNoOpWhenInactive() {
-        let controller = FavoriteWorkspaceController()
         let store = TestReaderSettingsStore(autoRefreshOnExternalChange: false)
+        let controller = FavoriteWorkspaceController(settingsStore: store)
         store.addFavoriteWatchedFolder(name: "NoOp", folderURL: URL(fileURLWithPath: "/tmp/no-persist"), options: .default)
         controller.persistFinalState(to: store)
         let persisted = store.currentSettings.favoriteWatchedFolders.first!


### PR DESCRIPTION
## Summary

- Extract `UITestLaunchCoordinator` (new, 108 lines) — owns UI test launch configuration and simulated flows
- Enrich `FolderWatchFlowController` (179→324 lines) — absorbs `startWatchingFolder`, `stopFolderWatch`, `confirmFolderWatch`, `updateFolderWatchExclusions`, and warning flow delegation
- Extract `RecentHistoryCoordinator` (new, 71 lines) — owns recent file/folder history operations and notification handling
- Enrich `FavoriteWorkspaceController` (62→244 lines) — absorbs `startFavoriteWatch`, `saveAsFavorite`, `removeFromFavorites`, document sync, and new-file discovery
- `ReaderWindowCoordinator` shrinks from 1130→762 lines (-33%), retaining window lifecycle, sidebar mutations, appearance, and thin forwarders for `sidebarWidth`-dependent operations

Purely structural refactoring — no behavior changes. All 926 unit tests pass.

Closes #322

## Test plan

- [x] All 926 unit tests pass (verified after each extraction)
- [x] `FavoriteWorkspaceControllerTests` updated for new init signature
- [ ] Manual smoke test: open file, start folder watch, save/restore favorite, verify all flows
- [ ] Run UI tests (`minimarkUITests`) to verify end-to-end flows