### PR TITLE
Remove pass-through wrappers from ReaderStore (#327)

### DIFF
--- a/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
@@ -17,7 +17,7 @@ extension ReaderStore {
             let normalizedURL = Self.normalizedFileURL(accessibleURL)
             securityScopeResolver.activateFileSecurityScope(for: accessibleURL, reason: "open")
             if let folderWatchSession {
-                setActiveFolderWatchSession(securityScopeResolver.normalizedFolderWatchSession(folderWatchSession))
+                folderWatchDispatcher.setSession(securityScopeResolver.normalizedFolderWatchSession(folderWatchSession))
             }
             let readURL = securityScopeResolver.effectiveAccessibleFileURL(
                 for: normalizedURL, reason: "open", folderWatchSession: folderWatchDispatcher.activeFolderWatchSession

--- a/minimark/Stores/Coordination/ReaderStore+Persistence.swift
+++ b/minimark/Stores/Coordination/ReaderStore+Persistence.swift
@@ -46,7 +46,7 @@ extension ReaderStore {
                 throw error
             }
             if let updatedSession = result.updatedSession {
-                setActiveFolderWatchSession(updatedSession)
+                folderWatchDispatcher.setSession(updatedSession)
             }
 
             logSaveInfo(

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -234,14 +234,14 @@ final class ReaderSidebarDocumentController {
     // MARK: - Document actions
 
     func openDocumentsInApplication(_ application: ReaderExternalApplication?, documentIDs: Set<UUID>) {
-        for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.document.fileURL != nil {
-            document.readerStore.document.openInApplication(application)
+        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.readerStore.document.fileURL != nil {
+            tab.readerStore.document.openInApplication(application)
         }
     }
 
     func revealDocumentsInFinder(_ documentIDs: Set<UUID>) {
-        for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.document.fileURL != nil {
-            document.readerStore.document.revealInFinder()
+        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.readerStore.document.fileURL != nil {
+            tab.readerStore.document.revealInFinder()
         }
     }
 

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -235,13 +235,13 @@ final class ReaderSidebarDocumentController {
 
     func openDocumentsInApplication(_ application: ReaderExternalApplication?, documentIDs: Set<UUID>) {
         for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.document.fileURL != nil {
-            document.readerStore.openCurrentFileInApplication(application)
+            document.readerStore.document.openInApplication(application)
         }
     }
 
     func revealDocumentsInFinder(_ documentIDs: Set<UUID>) {
         for document in documentList.orderedDocuments(matching: documentIDs) where document.readerStore.document.fileURL != nil {
-            document.readerStore.revealCurrentFileInFinder()
+            document.readerStore.document.revealInFinder()
         }
     }
 

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -126,10 +126,6 @@ final class ReaderStore {
         )
     }
 
-    var currentSettings: ReaderSettings {
-        settingsStore.currentSettings
-    }
-
     func setOpenAdditionalDocumentForFolderWatchEventHandler(
         _ handler: @escaping (ReaderFolderWatchChangeEvent, ReaderFolderWatchSession?, ReaderOpenOrigin) -> Void
     ) {
@@ -153,14 +149,6 @@ final class ReaderStore {
 
     func setActiveFolderWatchSession(_ session: ReaderFolderWatchSession?) {
         folderWatchDispatcher.setSession(session)
-    }
-
-    func setLastWatchedFolderEventAt(_ date: Date?) {
-        folderWatchDispatcher.lastWatchedFolderEventAt = date
-    }
-
-    func setFolderWatchAutoOpenWarning(_ warning: ReaderFolderWatchAutoOpenWarning?) {
-        folderWatchDispatcher.autoOpenWarning = warning
     }
 
     func noteObservedExternalChange(kind: ReaderExternalChangeKind = .modified) {

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -132,14 +132,6 @@ final class ReaderStore {
         folderWatchDispatcher.setAdditionalOpenHandler(handler)
     }
 
-    func setDocumentViewMode(_ mode: ReaderDocumentViewMode) {
-        sourceEditingController.setViewMode(mode, hasOpenDocument: document.hasOpenDocument)
-    }
-
-    func toggleDocumentViewMode() {
-        sourceEditingController.toggleViewMode()
-    }
-
     func setFolderWatchStateCallbacks(
         onStarted: ((ReaderFolderWatchSession) -> Void)?,
         onStopped: (() -> Void)?

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -194,14 +194,6 @@ final class ReaderStore {
         document.refreshOpenInApplications()
     }
 
-    func openCurrentFileInApplication(_ application: ReaderExternalApplication?) {
-        document.openInApplication(application)
-    }
-
-    func revealCurrentFileInFinder() {
-        document.revealInFinder()
-    }
-
     func presentError(_ error: Error) {
         handle(error)
     }

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -147,10 +147,6 @@ final class ReaderStore {
         folderWatchDispatcher.setStateCallbacks(onStarted: onStarted, onStopped: onStopped)
     }
 
-    func setActiveFolderWatchSession(_ session: ReaderFolderWatchSession?) {
-        folderWatchDispatcher.setSession(session)
-    }
-
     func noteObservedExternalChange(kind: ReaderExternalChangeKind = .modified) {
         externalChange.noteObservedExternalChange(kind: kind)
     }

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -181,7 +181,7 @@ struct ReaderStoreExternalChangeTests {
 
         #expect(fixture.store.sourceEditingController.documentViewMode == .preview)
 
-        fixture.store.setDocumentViewMode(.split)
+        fixture.store.sourceEditingController.setViewMode(.split, hasOpenDocument: fixture.store.document.hasOpenDocument)
 
         #expect(fixture.store.sourceEditingController.documentViewMode == .preview)
     }
@@ -191,7 +191,7 @@ struct ReaderStoreExternalChangeTests {
         defer { fixture.cleanup() }
 
         fixture.store.openFile(at: fixture.primaryFileURL)
-        fixture.store.setDocumentViewMode(.source)
+        fixture.store.sourceEditingController.setViewMode(.source, hasOpenDocument: fixture.store.document.hasOpenDocument)
 
         #expect(fixture.store.sourceEditingController.documentViewMode == .source)
 
@@ -205,7 +205,7 @@ struct ReaderStoreExternalChangeTests {
         defer { fixture.cleanup() }
 
         fixture.store.openFile(at: fixture.primaryFileURL)
-        fixture.store.setDocumentViewMode(.split)
+        fixture.store.sourceEditingController.setViewMode(.split, hasOpenDocument: fixture.store.document.hasOpenDocument)
 
         #expect(fixture.store.sourceEditingController.documentViewMode == .split)
 
@@ -222,13 +222,13 @@ struct ReaderStoreExternalChangeTests {
 
         #expect(fixture.store.sourceEditingController.documentViewMode == .preview)
 
-        fixture.store.toggleDocumentViewMode()
+        fixture.store.sourceEditingController.toggleViewMode()
         #expect(fixture.store.sourceEditingController.documentViewMode == .split)
 
-        fixture.store.toggleDocumentViewMode()
+        fixture.store.sourceEditingController.toggleViewMode()
         #expect(fixture.store.sourceEditingController.documentViewMode == .source)
 
-        fixture.store.toggleDocumentViewMode()
+        fixture.store.sourceEditingController.toggleViewMode()
         #expect(fixture.store.sourceEditingController.documentViewMode == .preview)
     }
 

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -78,7 +78,7 @@ struct ReaderStoreExternalChangeTests {
         let folderURL = fixture.temporaryDirectoryURL
         let options = ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         fixture.store.openFile(at: fixture.primaryFileURL, origin: .folderWatchAutoOpen)
 
@@ -98,7 +98,7 @@ struct ReaderStoreExternalChangeTests {
         let folderURL = fixture.temporaryDirectoryURL
         let options = ReaderFolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly)
         let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         fixture.store.openFile(
             at: fixture.primaryFileURL,
@@ -122,7 +122,7 @@ struct ReaderStoreExternalChangeTests {
         let folderURL = fixture.temporaryDirectoryURL
         let options = ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly)
         let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         fixture.store.openFile(at: fixture.primaryFileURL)
         fixture.store.handleObservedFileChange()
@@ -632,7 +632,7 @@ struct ReaderStoreExternalChangeTests {
             options: .default,
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         fixture.store.openFile(
             at: fixture.primaryFileURL,
@@ -653,7 +653,7 @@ struct ReaderStoreExternalChangeTests {
             options: .default,
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
         fixture.store.openFile(
             at: fixture.primaryFileURL,
             origin: .manual,
@@ -682,7 +682,7 @@ struct ReaderStoreExternalChangeTests {
             options: .default,
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
         fixture.store.openFile(
             at: fixture.primaryFileURL,
             origin: .manual,
@@ -706,7 +706,7 @@ struct ReaderStoreExternalChangeTests {
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         let fourthFileURL = fixture.temporaryDirectoryURL.appendingPathComponent("fourth.md")
         fixture.write(content: "# Fourth", to: fourthFileURL)
@@ -741,7 +741,7 @@ struct ReaderStoreExternalChangeTests {
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         let createdFileURL = fixture.temporaryDirectoryURL.appendingPathComponent("created.md")
         fixture.write(content: "", to: createdFileURL)
@@ -771,7 +771,7 @@ struct ReaderStoreExternalChangeTests {
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         let changedFileURL = fixture.secondaryFileURL
         var capturedEvent: ReaderFolderWatchChangeEvent?
@@ -802,7 +802,7 @@ struct ReaderStoreExternalChangeTests {
             options: ReaderFolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         let autoOpenLimit = ReaderFolderWatchAutoOpenPolicy.maximumLiveAutoOpenFileCount
         let fileURLs = (0..<(autoOpenLimit + 2)).map { index in

--- a/minimarkTests/ReaderStore/ReaderStoreSecurityScopeFlowTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreSecurityScopeFlowTests.swift
@@ -47,7 +47,7 @@ struct ReaderStoreSecurityScopeFlowTests {
         let session = ReaderFolderWatchSession(folderURL: folderURL, options: options, startedAt: Date())
 
         fixture.settings.addRecentWatchedFolder(folderURL, options: options)
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         resolver.context.folderToken = fixture.securityScope.beginAccess(to: folderURL)
         resolver.context.fileToken = nil

--- a/minimarkTests/ReaderStore/ReaderStoreSourceEditingTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreSourceEditingTests.swift
@@ -128,7 +128,7 @@ struct ReaderStoreSourceEditingTests {
             options: options,
             startedAt: .now
         )
-        fixture.store.setActiveFolderWatchSession(session)
+        fixture.store.folderWatchDispatcher.setSession(session)
 
         let permissionDeniedError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError)
         let result = fixture.store.securityScopeResolver.tryReauthorizeWatchedFolder(
@@ -137,7 +137,7 @@ struct ReaderStoreSourceEditingTests {
             folderWatchSession: fixture.store.folderWatchDispatcher.activeFolderWatchSession
         )
         if let updatedSession = result.updatedSession {
-            fixture.store.setActiveFolderWatchSession(updatedSession)
+            fixture.store.folderWatchDispatcher.setSession(updatedSession)
         }
 
         #expect(result.succeeded)


### PR DESCRIPTION
## Summary

Deletes 8 pass-through wrapper methods from `ReaderStore` that forwarded a single call to an owned controller with no added value, and rewrites callers to depend on the underlying controller directly (`folderWatchDispatcher`, `sourceEditingController`, `document`). Takes `ReaderStore` one step further toward a pure-container role — see #327 for context.

Four mechanical commits, each independently reviewable:

- \`e49e2a2\` delete 3 unused wrappers (zero callsites): \`currentSettings\`, \`setLastWatchedFolderEventAt\`, \`setFolderWatchAutoOpenWarning\`
- \`d20b7ef\` inline \`setActiveFolderWatchSession\` → \`folderWatchDispatcher.setSession\` (2 prod + 19 test callsites)
- \`771a766\` inline \`setDocumentViewMode\` / \`toggleDocumentViewMode\` → \`sourceEditingController.*\` (6 test-only callsites)
- \`e5502b0\` inline \`openCurrentFileInApplication\` / \`revealCurrentFileInFinder\` → \`document.*\` (2 sidebar callsites)

Diff: 7 files, +23/-55.

## Scope

HIGH-severity pass-throughs only. Intentionally **not** touched:

- \`handle(_:)\` — kept as an error-handling facade; may gain logging/analytics logic.
- \`clearOpenDocument()\` — real coordination of five sub-objects, not a pass-through.

Follow-up issues filed: #328 (remove the ~11 remaining MEDIUM/LOW pass-throughs), #329 (test helper for \`folderWatchDispatcher.setSession\`), #330 (shorten the \`document.readerStore.document\` chain in \`ReaderSidebarDocumentController\`).

## Test plan

- [x] \`xcodebuild build\` clean
- [x] \`xcodebuild test -only-testing:minimarkTests\` — all tests pass
- [x] Full clean build + test run after last commit (no incremental build artifacts)
- [x] Repo-wide grep for every deleted symbol — zero matches
- [ ] Manual smoke test from sidebar context menu (only Task 4 has user-visible surface):
  - [ ] "Reveal in Finder" opens Finder to the correct file
  - [ ] "Open in …" opens the file in the selected external editor

Closes #327.