### PR TITLE
Remove remaining pass-through wrappers from ReaderStore (#328)

### DIFF
--- a/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
@@ -75,7 +75,7 @@ extension ReaderStore {
         clearLoadingState()
 
         if initialDiffBaselineMarkdown != nil {
-            noteObservedExternalChange(kind: .modified)
+            externalChange.noteObservedExternalChange(kind: .modified)
         }
     }
 }

--- a/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentOpenFlow.swift
@@ -61,7 +61,7 @@ extension ReaderStore {
         }
 
         if document.documentLoadState == .deferred {
-            transitionToLoading()
+            document.transitionToLoading()
         }
 
         openFile(
@@ -72,7 +72,7 @@ extension ReaderStore {
         )
 
         // Safety: if openFile failed internally, clear the loading state
-        clearLoadingState()
+        document.clearLoadingState()
 
         if initialDiffBaselineMarkdown != nil {
             externalChange.noteObservedExternalChange(kind: .modified)

--- a/minimark/Stores/Coordination/ReaderStore+DocumentPresentation.swift
+++ b/minimark/Stores/Coordination/ReaderStore+DocumentPresentation.swift
@@ -141,7 +141,7 @@ extension ReaderStore {
                 at: now
             )
         }
-        refreshOpenInApplications()
+        document.refreshOpenInApplications()
         recordRecentManualOpenIfNeeded(accessibleURL, origin: origin)
         notifyAutoLoadedFileIfNeeded(
             normalizedURL,

--- a/minimark/Stores/Coordination/ReaderStore+ExternalChangeFlow.swift
+++ b/minimark/Stores/Coordination/ReaderStore+ExternalChangeFlow.swift
@@ -28,7 +28,7 @@ extension ReaderStore {
             return
         }
 
-        noteObservedExternalChange(kind: .modified)
+        externalChange.noteObservedExternalChange(kind: .modified)
         if let fileURL = document.fileURL,
            settingsStore.currentSettings.notificationsEnabled {
             folderWatch.systemNotifier.notifyFileChanged(

--- a/minimark/Stores/Coordination/ReaderStore+SourceEditing.swift
+++ b/minimark/Stores/Coordination/ReaderStore+SourceEditing.swift
@@ -10,7 +10,7 @@ extension ReaderStore {
         )
         if !wasEditing && sourceEditingController.isSourceEditing {
             document.sourceMarkdown = document.savedMarkdown
-            clearLastError()
+            document.clearLastError()
         }
     }
 
@@ -74,7 +74,7 @@ extension ReaderStore {
 
         do {
             try renderCurrentMarkdownImmediately()
-            clearLastError()
+            document.clearLastError()
         } catch {
             handle(error)
         }

--- a/minimark/Stores/FileOpenPlanExecutor.swift
+++ b/minimark/Stores/FileOpenPlanExecutor.swift
@@ -194,11 +194,11 @@ final class FileOpenPlanExecutor {
     }
 
     private func scheduleLoadWithOverlay(on store: ReaderStore, load: @escaping @MainActor () -> Void) {
-        store.transitionToLoading()
+        store.document.transitionToLoading()
         Task { @MainActor in
             await Task.yield()
             load()
-            store.holdLoadingOverlayBriefly()
+            store.document.holdLoadingOverlayBriefly()
         }
     }
 

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -252,11 +252,11 @@ final class ReaderSidebarDocumentController {
     }
 
     private func scheduleLoadWithOverlay(on store: ReaderStore, load: @escaping @MainActor () -> Void) {
-        store.transitionToLoading()
+        store.document.transitionToLoading()
         Task { @MainActor in
             await Task.yield()
             load()
-            store.holdLoadingOverlayBriefly()
+            store.document.holdLoadingOverlayBriefly()
         }
     }
 

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -139,19 +139,11 @@ final class ReaderStore {
         folderWatchDispatcher.setStateCallbacks(onStarted: onStarted, onStopped: onStopped)
     }
 
-    func noteObservedExternalChange(kind: ReaderExternalChangeKind = .modified) {
-        externalChange.noteObservedExternalChange(kind: kind)
-    }
-
     /// Marks this document as live-auto-opened: sets the external change
     /// indicator and clears the settler so subsequent edits are not absorbed.
     func markAsLiveAutoOpened() {
-        noteObservedExternalChange(kind: .added)
+        externalChange.noteObservedExternalChange(kind: .added)
         folderWatch.settler.clearSettling()
-    }
-
-    func clearExternalChangeIndicator() {
-        externalChange.clear()
     }
 
     func deferFile(at url: URL, origin: ReaderOpenOrigin = .folderWatchInitialBatchAutoOpen, folderWatchSession: ReaderFolderWatchSession?) {

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -153,18 +153,6 @@ final class ReaderStore {
         }
     }
 
-    func transitionToLoading() {
-        document.transitionToLoading()
-    }
-
-    func clearLoadingState() {
-        document.clearLoadingState()
-    }
-
-    func holdLoadingOverlayBriefly() {
-        document.holdLoadingOverlayBriefly()
-    }
-
     func clearOpenDocument() {
         // Note: diffBaselineTracker is intentionally NOT reset here.
         // Per-file-URL history is preserved across open/close cycles
@@ -180,10 +168,6 @@ final class ReaderStore {
 
     func dismissFolderWatchAutoOpenWarning() {
         folderWatchDispatcher.dismissAutoOpenWarning()
-    }
-
-    func refreshOpenInApplications() {
-        document.refreshOpenInApplications()
     }
 
     func presentError(_ error: Error) {
@@ -210,10 +194,6 @@ final class ReaderStore {
 
     func handle(_ error: Error) {
         document.handle(error)
-    }
-
-    func clearLastError() {
-        document.clearLastError()
     }
 
     static func normalizedFileURL(_ url: URL) -> URL {

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -47,7 +47,7 @@ final class ReaderStore {
     //
     // - diffBaselineTracker: read-only (`let`) — used by ExternalChangeFlow
     // - onFolderWatchStarted/Stopped: read-only from extensions (called, never reassigned);
-    //   set exclusively through setFolderWatchStateCallbacks(_:onStopped:)
+    //   set exclusively through folderWatchDispatcher.setStateCallbacks(onStarted:onStopped:)
     let diffBaselineTracker: DiffBaselineTracking
 
     var onFolderWatchStarted: ((ReaderFolderWatchSession) -> Void)? { folderWatchDispatcher.onFolderWatchStarted }
@@ -126,19 +126,6 @@ final class ReaderStore {
         )
     }
 
-    func setOpenAdditionalDocumentForFolderWatchEventHandler(
-        _ handler: @escaping (ReaderFolderWatchChangeEvent, ReaderFolderWatchSession?, ReaderOpenOrigin) -> Void
-    ) {
-        folderWatchDispatcher.setAdditionalOpenHandler(handler)
-    }
-
-    func setFolderWatchStateCallbacks(
-        onStarted: ((ReaderFolderWatchSession) -> Void)?,
-        onStopped: (() -> Void)?
-    ) {
-        folderWatchDispatcher.setStateCallbacks(onStarted: onStarted, onStopped: onStopped)
-    }
-
     /// Marks this document as live-auto-opened: sets the external change
     /// indicator and clears the settler so subsequent edits are not absorbed.
     func markAsLiveAutoOpened() {
@@ -164,10 +151,6 @@ final class ReaderStore {
         sourceEditingController.reset()
         externalChange.clear()
         toc.clear()
-    }
-
-    func dismissFolderWatchAutoOpenWarning() {
-        folderWatchDispatcher.dismissAutoOpenWarning()
     }
 
     func presentError(_ error: Error) {

--- a/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
+++ b/minimarkTests/ReaderStore/ReaderStoreExternalChangeTests.swift
@@ -715,7 +715,7 @@ struct ReaderStoreExternalChangeTests {
 
         var openedAdditionalDocuments: [URL] = []
         var openedEvents: [ReaderFolderWatchChangeEvent] = []
-        fixture.store.setOpenAdditionalDocumentForFolderWatchEventHandler { event, _, _ in
+        fixture.store.folderWatchDispatcher.setAdditionalOpenHandler { event, _, _ in
             openedAdditionalDocuments.append(ReaderFileRouting.normalizedFileURL(event.fileURL))
             openedEvents.append(event)
         }
@@ -747,7 +747,7 @@ struct ReaderStoreExternalChangeTests {
         fixture.write(content: "", to: createdFileURL)
 
         var openedEvents: [ReaderFolderWatchChangeEvent] = []
-        fixture.store.setOpenAdditionalDocumentForFolderWatchEventHandler { event, _, _ in
+        fixture.store.folderWatchDispatcher.setAdditionalOpenHandler { event, _, _ in
             openedEvents.append(event)
         }
 
@@ -775,7 +775,7 @@ struct ReaderStoreExternalChangeTests {
 
         let changedFileURL = fixture.secondaryFileURL
         var capturedEvent: ReaderFolderWatchChangeEvent?
-        fixture.store.setOpenAdditionalDocumentForFolderWatchEventHandler { event, _, _ in
+        fixture.store.folderWatchDispatcher.setAdditionalOpenHandler { event, _, _ in
             capturedEvent = event
         }
 
@@ -812,7 +812,7 @@ struct ReaderStoreExternalChangeTests {
         }
 
         var openedAdditionalDocuments: [URL] = []
-        fixture.store.setOpenAdditionalDocumentForFolderWatchEventHandler { event, _, _ in
+        fixture.store.folderWatchDispatcher.setAdditionalOpenHandler { event, _, _ in
             openedAdditionalDocuments.append(ReaderFileRouting.normalizedFileURL(event.fileURL))
         }
 

--- a/minimarkTests/Sidebar/ReaderSidebarDeferredLoadingTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDeferredLoadingTests.swift
@@ -388,7 +388,7 @@ struct ReaderSidebarDeferredLoadingTests {
         )
 
         store.deferFile(at: harness.primaryFileURL, folderWatchSession: session)
-        store.transitionToLoading()
+        store.document.transitionToLoading()
         #expect(store.document.documentLoadState == .loading)
 
         store.materializeDeferredDocument()
@@ -449,7 +449,7 @@ struct ReaderSidebarDeferredLoadingTests {
         store.deferFile(at: harness.primaryFileURL, folderWatchSession: session)
         #expect(store.document.documentLoadState == .deferred)
 
-        store.transitionToLoading()
+        store.document.transitionToLoading()
 
         #expect(store.document.documentLoadState == .loading)
     }

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -99,7 +99,7 @@ struct SidebarRowStateComputerTests {
         #expect(computer.rowStates[doc.id]?.indicatorPulseToken == 0)
 
         // Simulate external change -> indicator becomes active
-        doc.readerStore.noteObservedExternalChange()
+        doc.readerStore.externalChange.noteObservedExternalChange()
 
         // Second rebuild — indicator transitioned to active, pulse increments
         computer.rebuildAllRowStates(from: [doc])
@@ -188,7 +188,7 @@ struct SidebarRowStateComputerTests {
         computer.onRowStatesChanged = { _ in callbackFired = true }
         computer.onDockTileRowStatesChanged = { _ in dockTileCallbackFired = true }
 
-        doc.readerStore.noteObservedExternalChange()
+        doc.readerStore.externalChange.noteObservedExternalChange()
         computer.updateRowStateIfNeeded(for: doc.id, in: [doc])
 
         #expect(callbackFired)

--- a/minimarkTests/Sidebar/SidebarRowStateTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateTests.swift
@@ -99,7 +99,7 @@ struct SidebarRowStateDerivationTests {
         await Task.yield()
 
         // Simulate an external change notification on the store
-        store.noteObservedExternalChange()
+        store.externalChange.noteObservedExternalChange()
 
         // Allow the observation tracking task to process and update rowStates
         try await Task.sleep(for: .milliseconds(50))
@@ -126,14 +126,14 @@ struct SidebarRowStateDerivationTests {
         await Task.yield()
 
         // Simulate file-created indicator (green badge)
-        store.noteObservedExternalChange(kind: .added)
+        store.externalChange.noteObservedExternalChange(kind: .added)
         try await Task.sleep(for: .milliseconds(50))
 
         let addedState = harness.controller.rowStates[docID]
         #expect(addedState?.indicatorState == .addedExternalChange)
 
         // Simulate file-modified indicator (yellow badge) — should replace green
-        store.noteObservedExternalChange(kind: .modified)
+        store.externalChange.noteObservedExternalChange(kind: .modified)
         try await Task.sleep(for: .milliseconds(50))
 
         let modifiedState = harness.controller.rowStates[docID]


### PR DESCRIPTION
## Summary

Deletes the ~10 remaining MEDIUM/LOW pass-through wrappers that #327 / #331 intentionally left out of scope. Each wrapper forwarded a single call to an owned controller with no added logic; every callsite now talks to the controller directly. Takes `ReaderStore` one step further toward a pure-container role. Closes #328.

Three mechanical commits, each independently reviewable (build + tests green after each):

- `56ce160` — inline `externalChange` wrappers: delete `noteObservedExternalChange`, `clearExternalChangeIndicator` (the latter had zero callers).
- `28e873d` — inline `document` wrappers: delete `transitionToLoading`, `clearLoadingState`, `holdLoadingOverlayBriefly`, `refreshOpenInApplications`, `clearLastError`.
- `992d256` — inline `folderWatchDispatcher` wrappers: delete `setOpenAdditionalDocumentForFolderWatchEventHandler`, `setFolderWatchStateCallbacks`, `dismissFolderWatchAutoOpenWarning`. The last two had zero callers.

Diff: 11 files, +24/−69. `ReaderStore.swift` drops another 45 lines.

## Scope

Intentionally **not** touched, per the issue's scope gate:

- `handle(_:)` and `presentError(_:)` — kept as the explicit deferred decision from #327 (original author set a 3–6-month clock; #331 merged only days ago, well inside that window). Worth a separate, conscious call.

## Incidental finding (not in this PR)

`ReaderStore.onFolderWatchStarted` / `onFolderWatchStopped` (lines 51–52) are computed properties that forward to `folderWatchDispatcher` but have zero callers anywhere — surfaced while updating the adjacent comment. Out of scope for #328; can file a separate issue if worth cleaning up.

## Test plan

- [x] `xcodebuild build` clean after each commit
- [x] `xcodebuild test -only-testing:minimarkTests` — all tests pass after each commit
- [x] Repo-wide grep for every deleted symbol — zero lookup-through-`store` matches remain