### PR TITLE
Refactor: break up ContentView (#335)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -581,39 +581,6 @@ struct DocumentSurfaceHost: View {
     }
 }
 
-private struct FolderDropBlockedOverlayView: View {
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color.black.opacity(0.24))
-
-            VStack(spacing: 6) {
-                Image(systemName: "folder.badge.minus")
-                    .font(.system(size: 22, weight: .semibold))
-
-                Text("Already Watching a Folder")
-                    .font(.headline)
-
-                Text("Stop the current folder watch before dropping another folder.")
-                    .font(.subheadline)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
-            }
-            .foregroundStyle(Color.black)
-            .padding(20)
-            .frame(maxWidth: 460)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color(nsColor: .systemYellow))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .strokeBorder(Color.orange, lineWidth: 2)
-            )
-        }
-    }
-}
-
 private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: View {
     let documentViewMode: ReaderDocumentViewMode
     let hasOpenDocument: Bool

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
         .overlay(alignment: .bottomLeading) {
             ContentViewUITestAccessibilityLabel(
                 isEnabled: viewModel.isUITestModeEnabled,
-                value: viewModel.previewAccessibilityValue
+                makeValue: { viewModel.previewAccessibilityValue }
             )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -1,27 +1,10 @@
 import AppKit
 import Foundation
-import OSLog
 import SwiftUI
 
 struct ContentView: View {
-    private enum Metrics {
-        static let splitPaneMinimumWidth: CGFloat = 320
-    }
+    let viewModel: ContentAreaViewModel
 
-    static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
-        category: "ContentView"
-    )
-
-    let document: ReaderDocumentController
-    let rendering: ReaderRenderingController
-    let sourceEditing: ReaderSourceEditingController
-    let externalChange: ReaderExternalChangeController
-    let toc: ReaderTOCController
-    let settingsStore: ReaderSettingsStore
-    let folderWatchState: ContentViewFolderWatchState
-    let surfaceViewModel: DocumentSurfaceViewModel
-    let onAction: (ContentViewAction) -> Void
     @Binding var isFolderWatchOptionsPresented: Bool
     @Binding var pendingFolderWatchOpenMode: ReaderFolderWatchOpenMode
     @Binding var pendingFolderWatchScope: ReaderFolderWatchScope
@@ -29,16 +12,13 @@ struct ContentView: View {
 
     var body: some View {
         baseBody.modifier(ContentViewFocusedValues(
-            document: document,
-            sourceEditing: sourceEditing,
-            toc: toc,
-            folderWatchState: folderWatchState,
-            onAction: onAction,
-            canNavigateChangedRegions: canNavigateChangedRegions,
-            onNavigateChangedRegion: { direction in
-                surfaceViewModel.changeNavigation.requestNavigation(direction)
-                surfaceViewModel.splitScrollCoordinator.suppressPreviewBounceBack()
-            },
+            document: viewModel.document,
+            sourceEditing: viewModel.sourceEditing,
+            toc: viewModel.toc,
+            folderWatchState: viewModel.folderWatchState,
+            onAction: viewModel.onAction,
+            canNavigateChangedRegions: viewModel.canNavigateChangedRegions,
+            onNavigateChangedRegion: viewModel.requestChangeNavigation,
             isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
             pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
             pendingFolderWatchScope: $pendingFolderWatchScope,
@@ -46,584 +26,145 @@ struct ContentView: View {
         ))
     }
 
-    private var canNavigateChangedRegions: Bool {
-        surfaceViewModel.canNavigateChangedRegions(
-            documentViewMode: sourceEditing.documentViewMode,
-            changedRegions: document.changedRegions
-        )
-    }
-
-    private var statusBarTimestamp: ReaderStatusBarTimestamp? {
-        if let date = externalChange.lastExternalChangeAt { return .updated(date) }
-        if let date = document.fileLastModifiedAt { return .lastModified(date) }
-        if let date = rendering.lastRefreshAt { return .updated(date) }
-        return nil
-    }
-
     private var baseBody: some View {
         ZStack(alignment: .top) {
-            VStack(spacing: 0) {
-                if document.isCurrentFileMissing {
-                    DeletedFileWarningBar(
-                        fileName: document.fileDisplayName,
-                        message: document.lastError?.message
-                    )
-                    .padding(.top, ReaderOverlayInsetCalculator.statusBannerTopPadding(topBarInset: overlayTopInset))
-                } else if rendering.needsImageDirectoryAccess {
-                    ImageAccessWarningBar {
-                        promptForImageDirectoryAccess()
-                    }
-                    .padding(.top, ReaderOverlayInsetCalculator.statusBannerTopPadding(topBarInset: overlayTopInset))
-                }
-
-                documentSurfaceWithOverlays
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay {
-                if surfaceViewModel.dropTargeting.isBlockedFolderDropTargeted {
-                    FolderDropBlockedOverlayView()
-                        .padding(10)
-                        .allowsHitTesting(false)
-                } else if surfaceViewModel.dropTargeting.isDragTargeted {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .strokeBorder(Color.accentColor.opacity(0.65), lineWidth: 2)
-                        .padding(10)
-                        .allowsHitTesting(false)
-                }
-            }
-            .onChange(of: document.fileURL?.standardizedFileURL.path) { _, _ in
-                surfaceViewModel.handleFileIdentityChange()
-            }
-            .onChange(of: document.changedRegions) { _, _ in
-                surfaceViewModel.changeNavigation.resetForNewRegions()
-            }
-            .onChange(of: surfaceViewModel.previewMode) { _, newValue in
-                surfaceViewModel.handlePreviewModeChange(newValue)
-            }
-            .onChange(of: surfaceViewModel.sourceMode) { _, newValue in
-                surfaceViewModel.handleSourceModeChange(newValue)
-            }
-            .onChange(of: sourceEditing.documentViewMode) { _, newValue in
-                surfaceViewModel.handleDocumentViewModeChange(newValue)
-            }
-            .onChange(of: sourceEditing.sourceEditorSeedMarkdown) { _, _ in
-                refreshSourceHTMLFromControllers()
-            }
-            .onChange(of: settingsStore.currentSettings) { _, _ in
-                refreshSourceHTMLFromControllers()
-            }
-            .onChange(of: sourceEditing.isSourceEditing) { _, _ in
-                refreshSourceHTMLFromControllers()
-            }
-            .onChange(of: folderWatchState.activeFolderWatch?.folderURL.standardizedFileURL.path) { _, _ in
-                surfaceViewModel.dropTargeting.clearAll()
-            }
-            .onAppear {
-                refreshSourceHTMLFromControllers()
-                surfaceViewModel.handleSurfaceAppear(
-                    renderedHTMLDocument: rendering.renderedHTMLDocument,
-                    sourceMarkdown: document.sourceMarkdown
-                )
-            }
-
-            ReaderTopBar(
-                document: document,
-                sourceEditing: sourceEditing,
-                statusBarTimestamp: statusBarTimestamp,
-                canStopFolderWatch: folderWatchState.canStopFolderWatch,
-                apps: document.openInApplications,
-                favoriteWatchedFolders: folderWatchState.favoriteWatchedFolders,
-                recentWatchedFolders: folderWatchState.recentWatchedFolders,
-                recentManuallyOpenedFiles: folderWatchState.recentManuallyOpenedFiles,
-                iconProvider: appIconImage(for:),
-                onAction: { action in
-                    switch action {
-                    case .openFiles(let urls):
-                        handlePickedFileURLs(urls)
-                    case .openInApp(let app):
-                        onAction(.openInApplication(app))
-                    case .revealInFinder:
-                        onAction(.revealInFinder)
-                    case .saveSourceDraft:
-                        onAction(.saveSourceDraft)
-                    case .discardSourceDraft:
-                        onAction(.discardSourceDraft)
-                    case .requestFolderWatch(let url):
-                        onAction(.requestFolderWatch(url))
-                    case .stopFolderWatch:
-                        onAction(.stopFolderWatch)
-                    case .startFavoriteWatch(let fav):
-                        onAction(.startFavoriteWatch(fav))
-                    case .clearFavoriteWatchedFolders:
-                        onAction(.clearFavoriteWatchedFolders)
-                    case .renameFavoriteWatchedFolder(let id, let name):
-                        onAction(.renameFavoriteWatchedFolder(id: id, name: name))
-                    case .removeFavoriteWatchedFolder(let id):
-                        onAction(.removeFavoriteWatchedFolder(id))
-                    case .reorderFavoriteWatchedFolders(let ids):
-                        onAction(.reorderFavoriteWatchedFolders(ids))
-                    case .startRecentManuallyOpenedFile(let entry):
-                        onAction(.startRecentManuallyOpenedFile(entry))
-                    case .startRecentFolderWatch(let entry):
-                        onAction(.startRecentFolderWatch(entry))
-                    case .clearRecentWatchedFolders:
-                        onAction(.clearRecentWatchedFolders)
-                    case .clearRecentManuallyOpenedFiles:
-                        onAction(.clearRecentManuallyOpenedFiles)
-                    }
-                }
-            )
-            .environment(\.colorScheme, overlayColorScheme)
+            mainStack
+            topBar
         }
         .overlay(alignment: .bottomLeading) {
-            if isUITestModeEnabled {
-                Text(previewAccessibilityValue)
-                    .font(.system(size: 8, weight: .regular, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 4)
-                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    .padding(6)
-                    .allowsHitTesting(false)
-                    .accessibilityIdentifier("reader-preview-summary")
-                    .accessibilityLabel("Reader preview summary")
-                    .accessibilityValue(previewAccessibilityValue)
-            }
+            ContentViewUITestAccessibilityLabel(
+                isEnabled: viewModel.isUITestModeEnabled,
+                value: viewModel.previewAccessibilityValue
+            )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
     }
 
-    private func promptForImageDirectoryAccess() {
-        guard let directoryURL = document.fileURL?.deletingLastPathComponent() else {
-            return
+    private var mainStack: some View {
+        VStack(spacing: 0) {
+            ContentStatusBanner(
+                isCurrentFileMissing: viewModel.document.isCurrentFileMissing,
+                fileDisplayName: viewModel.document.fileDisplayName,
+                errorMessage: viewModel.document.lastError?.message,
+                needsImageDirectoryAccess: viewModel.rendering.needsImageDirectoryAccess,
+                topPadding: viewModel.overlayLayout.statusBannerTopPadding,
+                onGrantImageAccess: viewModel.promptForImageDirectoryAccess
+            )
+            documentSurfaceWithOverlays
         }
-
-        let panel = NSOpenPanel()
-        panel.title = "Grant Image Access"
-        panel.message = "Select the folder containing your images to display them in the preview."
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        panel.prompt = "Grant Access"
-        panel.directoryURL = directoryURL
-
-        guard panel.runModal() == .OK, let selectedURL = panel.url else {
-            return
-        }
-
-        onAction(.grantImageDirectoryAccess(selectedURL))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .modifier(ContentDropModifier(
+            isBlockedFolderDropTargeted: viewModel.surfaceViewModel.dropTargeting.isBlockedFolderDropTargeted,
+            isDragTargeted: viewModel.surfaceViewModel.dropTargeting.isDragTargeted
+        ))
+        .modifier(ContentViewObservers(viewModel: viewModel))
+        .onAppear { viewModel.handleAppear() }
     }
 
-    var previewAccessibilityValue: String {
-        let fileName = document.fileURL?.lastPathComponent ?? "none"
-        return "file=\(fileName)|regions=\(document.changedRegions.count)|mode=\(sourceEditing.documentViewMode.rawValue)|surface=preview"
+    private var topBar: some View {
+        ReaderTopBar(
+            document: viewModel.document,
+            sourceEditing: viewModel.sourceEditing,
+            statusBarTimestamp: viewModel.statusBarTimestamp,
+            canStopFolderWatch: viewModel.folderWatchState.canStopFolderWatch,
+            apps: viewModel.document.openInApplications,
+            favoriteWatchedFolders: viewModel.folderWatchState.favoriteWatchedFolders,
+            recentWatchedFolders: viewModel.folderWatchState.recentWatchedFolders,
+            recentManuallyOpenedFiles: viewModel.folderWatchState.recentManuallyOpenedFiles,
+            iconProvider: appIconImage(for:),
+            onAction: viewModel.dispatchTopBarAction
+        )
+        .environment(\.colorScheme, viewModel.overlayColorScheme)
+    }
+
+    private var documentSurfaceWithOverlays: some View {
+        documentSurfaceLayout
+            .overlay(alignment: .topTrailing) { utilityRail }
+            .overlayPreferenceValue(TOCButtonAnchorKey.self) { anchor in
+                if viewModel.toc.isVisible, let anchor {
+                    TOCOverlayView(
+                        headings: viewModel.toc.headings,
+                        buttonAnchor: anchor,
+                        colorScheme: viewModel.overlayColorScheme,
+                        onDismiss: { viewModel.toc.isVisible = false },
+                        onSelectHeading: { viewModel.toc.scrollTo($0) }
+                    )
+                }
+            }
+            .overlay(alignment: .topLeading) { changeNavigationOverlay }
+            .animation(.easeOut(duration: 0.25), value: viewModel.canNavigateChangedRegions)
+            .overlay(alignment: .top) { watchPillOverlay }
+            .animation(.easeOut(duration: 0.25), value: viewModel.folderWatchState.activeFolderWatch != nil)
+    }
+
+    private var utilityRail: some View {
+        ContentUtilityRailView(
+            hasFile: viewModel.document.fileURL != nil,
+            documentViewMode: viewModel.sourceEditing.documentViewMode,
+            showEditButton: viewModel.showSourceEditingControls && !viewModel.sourceEditing.isSourceEditing,
+            canStartSourceEditing: viewModel.document.hasOpenDocument
+                && !viewModel.document.isCurrentFileMissing
+                && !viewModel.sourceEditing.isSourceEditing,
+            hasTOCHeadings: !viewModel.toc.headings.isEmpty,
+            isTOCVisible: Binding(
+                get: { viewModel.toc.isVisible },
+                set: { viewModel.toc.isVisible = $0 }
+            ),
+            onSetDocumentViewMode: { mode in
+                viewModel.sourceEditing.setViewMode(mode, hasOpenDocument: viewModel.document.hasOpenDocument)
+            },
+            onStartSourceEditing: { viewModel.onAction(.startSourceEditing) }
+        )
+        .padding(.top, viewModel.overlayLayout.insets.railTopPadding)
+        .environment(\.colorScheme, viewModel.overlayColorScheme)
+    }
+
+    private var changeNavigationOverlay: some View {
+        ChangeNavigationOverlayView(
+            canNavigate: viewModel.canNavigateChangedRegions,
+            currentIndex: viewModel.surfaceViewModel.changeNavigation.currentIndex,
+            totalCount: viewModel.document.changedRegions.count,
+            topPadding: viewModel.overlayLayout.insets.leadingOverlayTopPadding,
+            colorScheme: viewModel.overlayColorScheme,
+            settingsStore: viewModel.settingsStore,
+            onNavigate: viewModel.requestChangeNavigation
+        )
+    }
+
+    private var watchPillOverlay: some View {
+        WatchPillOverlayView(
+            activeFolderWatch: viewModel.folderWatchState.activeFolderWatch,
+            isCurrentWatchAFavorite: viewModel.folderWatchState.isCurrentWatchAFavorite,
+            canStop: viewModel.folderWatchState.canStopFolderWatch,
+            isAppearanceLocked: viewModel.folderWatchState.isAppearanceLocked,
+            topPadding: viewModel.overlayLayout.insets.leadingOverlayTopPadding,
+            leadingPadding: viewModel.canNavigateChangedRegions ? 150 : 60,
+            trailingPadding: 70,
+            colorScheme: viewModel.overlayColorScheme,
+            onAction: viewModel.dispatchWatchPillAction
+        )
     }
 
     private var documentSurfaceLayout: some View {
         DocumentSurfaceLayoutView(
-            documentViewMode: sourceEditing.documentViewMode,
-            hasOpenDocument: document.hasOpenDocument,
-            showsLoadingOverlay: shouldShowDocumentLoadingOverlay,
-            loadingOverlayHeadline: loadingOverlayHeadline,
-            loadingOverlaySubtitle: loadingOverlaySubtitle,
-            emptyStateVariant: emptyStateVariant,
-            currentReaderTheme: currentReaderTheme,
-            onDroppedFileURLs: handleDroppedFileURLs,
-            previewSurface: surfaceHost(for: .preview),
-            sourceSurface: surfaceHost(for: .source)
-        )
-    }
-
-    private func surfaceHost(for surface: DocumentSurfaceRole) -> DocumentSurfaceHost {
-        DocumentSurfaceHost(
-            configuration: surfaceViewModel.documentSurfaceConfiguration(
-                for: surface,
-                fileURL: document.fileURL,
-                renderedHTMLDocument: rendering.renderedHTMLDocument,
-                documentViewMode: sourceEditing.documentViewMode,
-                changedRegions: document.changedRegions,
-                isSourceEditing: sourceEditing.isSourceEditing,
-                overlayTopInset: overlayInsets.scrollTargetTopInset,
-                minimumSurfaceWidth: minimumSurfaceWidth,
-                tocScrollRequest: toc.scrollRequest,
-                canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-                onSharedAction: { action, role in
-                    surfaceViewModel.handleSharedAction(
-                        action,
-                        for: role,
-                        documentViewMode: sourceEditing.documentViewMode,
-                        onDroppedFileURLs: handleDroppedFileURLs,
-                        onAction: onAction
-                    )
-                },
-                onAction: onAction
+            documentViewMode: viewModel.sourceEditing.documentViewMode,
+            hasOpenDocument: viewModel.document.hasOpenDocument,
+            showsLoadingOverlay: viewModel.shouldShowDocumentLoadingOverlay,
+            loadingOverlayHeadline: viewModel.loadingOverlayHeadline,
+            loadingOverlaySubtitle: viewModel.loadingOverlaySubtitle,
+            emptyStateVariant: viewModel.emptyStateVariant,
+            currentReaderTheme: viewModel.currentReaderTheme,
+            onDroppedFileURLs: viewModel.handleDroppedFileURLs,
+            previewSurface: DocumentSurfaceHost(
+                configuration: viewModel.makeSurfaceConfiguration(for: .preview),
+                fallbackMarkdown: viewModel.document.sourceMarkdown
             ),
-            fallbackMarkdown: document.sourceMarkdown
-        )
-    }
-
-    private var overlayColorScheme: ColorScheme {
-        currentReaderTheme.kind.isDark ? .dark : .light
-    }
-
-    private var overlayTopInset: CGFloat {
-        var height = ReaderTopBarMetrics.mainBarHeight
-        if sourceEditing.isSourceEditing {
-            height += ReaderTopBarMetrics.sourceEditingBarHeight
-        }
-        return height
-    }
-
-    private var isStatusBannerVisible: Bool {
-        document.isCurrentFileMissing || rendering.needsImageDirectoryAccess
-    }
-
-    var overlayInsets: ReaderOverlayInsetValues {
-        ReaderOverlayInsetCalculator.compute(
-            topBarInset: overlayTopInset,
-            hasStatusBanner: isStatusBannerVisible
-        )
-    }
-
-    @ViewBuilder
-    private var documentSurfaceWithOverlays: some View {
-        documentSurfaceLayout
-            .overlay(alignment: .topTrailing) {
-                contentUtilityRail
-                    .padding(.top, overlayInsets.railTopPadding)
-                    .environment(\.colorScheme, overlayColorScheme)
-            }
-            .overlayPreferenceValue(TOCButtonAnchorKey.self) { anchor in
-                if toc.isVisible, let anchor {
-                    tocOverlay(buttonAnchor: anchor)
-                }
-            }
-            .overlay(alignment: .topLeading) { changeNavigationOverlay }
-            .animation(.easeOut(duration: 0.25), value: canNavigateChangedRegions)
-            .overlay(alignment: .top) { watchPillOverlay }
-            .animation(.easeOut(duration: 0.25), value: folderWatchState.activeFolderWatch != nil)
-    }
-
-    @ViewBuilder
-    private var changeNavigationOverlay: some View {
-        if canNavigateChangedRegions {
-            ChangeNavigationPill(
-                currentIndex: surfaceViewModel.changeNavigation.currentIndex,
-                totalCount: document.changedRegions.count,
-                onNavigate: { direction in
-                    surfaceViewModel.changeNavigation.requestNavigation(direction)
-                    surfaceViewModel.splitScrollCoordinator.suppressPreviewBounceBack()
-                }
-            )
-            .firstUseHint(.changeNavigation, message: "Use the arrows to step through changes", settingsStore: settingsStore)
-            .padding(.top, overlayInsets.leadingOverlayTopPadding)
-            .padding(.leading, 8)
-            .environment(\.colorScheme, overlayColorScheme)
-            .transition(.asymmetric(
-                insertion: .opacity.combined(with: .move(edge: .top)),
-                removal: .opacity
-            ))
-        }
-    }
-
-    @ViewBuilder
-    private var watchPillOverlay: some View {
-        if let activeWatch = folderWatchState.activeFolderWatch {
-            WatchPill(
-                activeFolderWatch: activeWatch,
-                isCurrentWatchAFavorite: folderWatchState.isCurrentWatchAFavorite,
-                canStop: folderWatchState.canStopFolderWatch,
-                isAppearanceLocked: folderWatchState.isAppearanceLocked,
-                onAction: { action in
-                    switch action {
-                    case .stop:
-                        onAction(.stopFolderWatch)
-                    case .saveFavorite(let name):
-                        onAction(.saveFolderWatchAsFavorite(name))
-                    case .removeFavorite:
-                        onAction(.removeCurrentWatchFromFavorites)
-                    case .revealInFinder:
-                        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: activeWatch.folderURL.path)
-                    case .toggleAppearanceLock:
-                        onAction(.toggleAppearanceLock)
-                    case .editSubfolders:
-                        onAction(.editSubfolders)
-                    }
-                }
-            )
-            .padding(.top, overlayInsets.leadingOverlayTopPadding)
-            .padding(.leading, canNavigateChangedRegions ? 150 : 60)
-            .padding(.trailing, 70)
-            .environment(\.colorScheme, overlayColorScheme)
-            .transition(.asymmetric(
-                insertion: .opacity.combined(with: .move(edge: .top)),
-                removal: .opacity
-            ))
-        }
-    }
-
-    private var contentUtilityRail: some View {
-        ContentUtilityRail(
-            hasFile: document.fileURL != nil,
-            documentViewMode: sourceEditing.documentViewMode,
-            showEditButton: showSourceEditingControls && !sourceEditing.isSourceEditing,
-            canStartSourceEditing: (document.hasOpenDocument && !document.isCurrentFileMissing && !sourceEditing.isSourceEditing),
-            onSetDocumentViewMode: { mode in
-                sourceEditing.setViewMode(mode, hasOpenDocument: document.hasOpenDocument)
-            },
-            onStartSourceEditing: {
-                onAction(.startSourceEditing)
-            },
-            hasTOCHeadings: !toc.headings.isEmpty,
-            isTOCVisible: Binding(
-                get: { toc.isVisible },
-                set: { toc.isVisible = $0 }
+            sourceSurface: DocumentSurfaceHost(
+                configuration: viewModel.makeSurfaceConfiguration(for: .source),
+                fallbackMarkdown: viewModel.document.sourceMarkdown
             )
         )
-    }
-
-    @ViewBuilder
-    private func tocOverlay(buttonAnchor: Anchor<CGRect>) -> some View {
-        let gap: CGFloat = 8
-        let tocColorScheme: ColorScheme = currentReaderTheme.kind.isDark ? .dark : .light
-
-        GeometryReader { proxy in
-            let buttonFrame = proxy[buttonAnchor]
-            let panelTrailing = buttonFrame.minX - gap
-
-            ZStack(alignment: .topLeading) {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture { toc.isVisible = false }
-
-                TOCPopoverView(
-                    headings: toc.headings,
-                    onSelect: { heading in
-                        toc.scrollTo(heading)
-                    }
-                )
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
-                }
-                .shadow(color: .black.opacity(0.25), radius: 16, y: 4)
-                .colorScheme(tocColorScheme)
-                .frame(maxWidth: panelTrailing, alignment: .trailing)
-                .offset(y: buttonFrame.minY)
-            }
-        }
-    }
-
-    private var showSourceEditingControls: Bool {
-        document.hasOpenDocument &&
-            (sourceEditing.documentViewMode != .preview || sourceEditing.isSourceEditing)
-    }
-
-    private var currentReaderTheme: ReaderTheme {
-        ReaderTheme.theme(for: folderWatchState.effectiveReaderTheme)
-    }
-
-    private var emptyStateVariant: ContentEmptyStateView.Variant {
-        if let activeWatch = folderWatchState.activeFolderWatch {
-            return .folderWatchEmpty(folderName: activeWatch.detailSummaryTitle)
-        }
-        return .noDocument
-    }
-
-    private var shouldShowDocumentLoadingOverlay: Bool {
-        document.documentLoadState == .loading || document.documentLoadState == .settlingAutoOpen
-    }
-
-    private var loadingOverlayHeadline: String {
-        switch document.documentLoadState {
-        case .settlingAutoOpen:
-            return "Waiting for file contents\u{2026}"
-        case .ready, .loading, .deferred:
-            return "Loading document\u{2026}"
-        }
-    }
-
-    private var loadingOverlaySubtitle: String? {
-        switch document.documentLoadState {
-        case .settlingAutoOpen:
-            return "The new watched document will appear as soon as writing finishes."
-        case .ready, .loading, .deferred:
-            return nil
-        }
-    }
-
-    var minimumSurfaceWidth: CGFloat? {
-        sourceEditing.documentViewMode == .split ? Metrics.splitPaneMinimumWidth : nil
-    }
-
-    private var isUITestModeEnabled: Bool {
-        ReaderUITestLaunchConfiguration.current.isUITestModeEnabled
-    }
-
-    private func refreshSourceHTMLFromControllers() {
-        surfaceViewModel.refreshSourceHTML(
-            markdown: sourceEditing.sourceEditorSeedMarkdown,
-            settings: settingsStore.currentSettings,
-            isEditable: sourceEditing.isSourceEditing
-        )
-    }
-
-    private func handleDroppedFileURLs(_ fileURLs: [URL]) {
-        if let droppedFolderURL = ReaderFileRouting.firstDroppedDirectoryURL(from: fileURLs) {
-            guard folderWatchState.activeFolderWatch == nil else {
-                return
-            }
-
-            onAction(.requestFolderWatch(droppedFolderURL))
-            return
-        }
-
-        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
-        guard !markdownURLs.isEmpty else {
-            return
-        }
-
-        let slotStrategy: FileOpenRequest.SlotStrategy =
-            document.fileURL == nil ? .reuseEmptySlotForFirst : .alwaysAppend
-        onAction(.requestFileOpen(FileOpenRequest(
-            fileURLs: markdownURLs,
-            origin: .manual,
-            slotStrategy: slotStrategy
-        )))
-    }
-
-    private func handlePickedFileURLs(_ fileURLs: [URL]) {
-        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
-        guard !markdownURLs.isEmpty else {
-            return
-        }
-
-        let normalizedIncomingURL = ReaderFileRouting.normalizedFileURL(markdownURLs[0])
-        let currentURL = document.fileURL.map(ReaderFileRouting.normalizedFileURL)
-        if sourceEditing.hasUnsavedDraftChanges,
-           currentURL != normalizedIncomingURL {
-            onAction(.presentError(ReaderError.unsavedDraftRequiresResolution))
-            return
-        }
-
-        onAction(.requestFileOpen(FileOpenRequest(
-            fileURLs: [markdownURLs[0]],
-            origin: .manual,
-            slotStrategy: .replaceSelectedSlot
-        )))
-
-        let additionalMarkdownURLs = Array(markdownURLs.dropFirst())
-        guard !additionalMarkdownURLs.isEmpty else {
-            return
-        }
-
-        onAction(.requestFileOpen(FileOpenRequest(
-            fileURLs: additionalMarkdownURLs,
-            origin: .manual,
-            slotStrategy: .alwaysAppend
-        )))
-    }
-
-    private func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {
-        !ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs) || folderWatchState.activeFolderWatch == nil
-    }
-}
-
-struct DocumentSurfaceHost: View {
-    let configuration: DocumentSurfaceConfiguration
-    let fallbackMarkdown: String
-
-    var body: some View {
-        Group {
-            if configuration.usesWebSurface {
-                MarkdownWebView(
-                    htmlDocument: configuration.htmlDocument,
-                    documentIdentity: configuration.documentIdentity,
-                    accessibilityIdentifier: configuration.accessibilityIdentifier,
-                    accessibilityValue: configuration.accessibilityValue,
-                    reloadToken: configuration.reloadToken,
-                    diagnosticName: configuration.diagnosticName,
-                    postLoadStatusScript: configuration.postLoadStatusScript,
-                    changedRegionNavigationRequest: configuration.changedRegionNavigationRequest,
-                    scrollSyncRequest: configuration.scrollSyncRequest,
-                    tocScrollRequest: configuration.tocScrollRequest,
-                    supportsInPlaceContentUpdates: configuration.supportsInPlaceContentUpdates,
-                    overlayTopInset: configuration.overlayTopInset,
-                    reloadAnchorProgress: configuration.reloadAnchorProgress,
-                    canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs,
-                    onAction: configuration.onAction
-                )
-            } else {
-                fallbackSurface
-            }
-        }
-        .frame(minWidth: configuration.minimumWidth)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    @ViewBuilder
-    private var fallbackSurface: some View {
-        switch configuration.role {
-        case .preview:
-            NativeMarkdownFallbackView(
-                markdown: fallbackMarkdown,
-                onRetryPreview: { configuration.onAction(.retryFallback) }
-            )
-        case .source:
-            MarkdownSourceFallbackView(
-                markdown: fallbackMarkdown,
-                onRetryHighlighting: { configuration.onAction(.retryFallback) }
-            )
-        }
-    }
-}
-
-private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: View {
-    let documentViewMode: ReaderDocumentViewMode
-    let hasOpenDocument: Bool
-    let showsLoadingOverlay: Bool
-    let loadingOverlayHeadline: String
-    let loadingOverlaySubtitle: String?
-    let emptyStateVariant: ContentEmptyStateView.Variant
-    let currentReaderTheme: ReaderTheme
-    let onDroppedFileURLs: ([URL]) -> Void
-    let previewSurface: PreviewSurface
-    let sourceSurface: SourceSurface
-
-    var body: some View {
-        if showsLoadingOverlay {
-            DocumentLoadingOverlay(
-                theme: currentReaderTheme,
-                headline: loadingOverlayHeadline,
-                subtitle: loadingOverlaySubtitle
-            )
-        } else if !hasOpenDocument {
-            ContentEmptyStateView(
-                variant: emptyStateVariant,
-                theme: currentReaderTheme
-            )
-            .dropDestination(for: URL.self) { urls, _ in
-                let fileURLs = urls.filter { $0.isFileURL }
-                guard !fileURLs.isEmpty else { return false }
-                onDroppedFileURLs(fileURLs)
-                return true
-            }
-        } else {
-            switch documentViewMode {
-            case .preview:
-                previewSurface
-            case .split:
-                HSplitView {
-                    previewSurface
-                    sourceSurface
-                }
-            case .source:
-                sourceSurface
-            }
-        }
     }
 }
 
@@ -657,7 +198,8 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
     let sourceEditing = ReaderSourceEditingController()
     let externalChange = ReaderExternalChangeController()
     let toc = ReaderTOCController()
-    return ContentView(
+
+    let viewModel = ContentAreaViewModel(
         document: document,
         rendering: rendering,
         sourceEditing: sourceEditing,
@@ -678,7 +220,11 @@ private struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: Vi
             effectiveReaderTheme: .blackOnWhite
         ),
         surfaceViewModel: DocumentSurfaceViewModel(),
-        onAction: { _ in },
+        onAction: { _ in }
+    )
+
+    return ContentView(
+        viewModel: viewModel,
         isFolderWatchOptionsPresented: .constant(false),
         pendingFolderWatchOpenMode: .constant(.watchChangesOnly),
         pendingFolderWatchScope: .constant(.selectedFolderOnly),

--- a/minimark/Views/Content/ChangeNavigationOverlayView.swift
+++ b/minimark/Views/Content/ChangeNavigationOverlayView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ChangeNavigationOverlayView: View {
+    let canNavigate: Bool
+    let currentIndex: Int?
+    let totalCount: Int
+    let topPadding: CGFloat
+    let colorScheme: ColorScheme
+    let settingsStore: ReaderSettingsStore
+    let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
+
+    var body: some View {
+        if canNavigate {
+            ChangeNavigationPill(
+                currentIndex: currentIndex,
+                totalCount: totalCount,
+                onNavigate: onNavigate
+            )
+            .firstUseHint(.changeNavigation,
+                          message: "Use the arrows to step through changes",
+                          settingsStore: settingsStore)
+            .padding(.top, topPadding)
+            .padding(.leading, 8)
+            .environment(\.colorScheme, colorScheme)
+            .transition(.asymmetric(
+                insertion: .opacity.combined(with: .move(edge: .top)),
+                removal: .opacity
+            ))
+        }
+    }
+}

--- a/minimark/Views/Content/ChangeNavigationOverlayView.swift
+++ b/minimark/Views/Content/ChangeNavigationOverlayView.swift
@@ -22,10 +22,7 @@ struct ChangeNavigationOverlayView: View {
             .padding(.top, topPadding)
             .padding(.leading, 8)
             .environment(\.colorScheme, colorScheme)
-            .transition(.asymmetric(
-                insertion: .opacity.combined(with: .move(edge: .top)),
-                removal: .opacity
-            ))
+            .transition(.overlayPill)
         }
     }
 }

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -45,8 +45,6 @@ final class ContentAreaViewModel {
         self.onAction = onAction
     }
 
-    // MARK: - Derivations
-
     var statusBarTimestamp: ReaderStatusBarTimestamp? {
         if let date = externalChange.lastExternalChangeAt { return .updated(date) }
         if let date = document.fileLastModifiedAt { return .lastModified(date) }
@@ -128,8 +126,6 @@ final class ContentAreaViewModel {
         ReaderUITestLaunchConfiguration.current.isUITestModeEnabled
     }
 
-    // MARK: - Actions
-
     func handleAppear() {
         refreshSourceHTMLFromControllers()
         surfaceViewModel.handleSurfaceAppear(
@@ -199,18 +195,12 @@ final class ContentAreaViewModel {
 
     func promptForImageDirectoryAccess() {
         guard let directoryURL = document.fileURL?.deletingLastPathComponent() else { return }
-
-        let panel = NSOpenPanel()
-        panel.title = "Grant Image Access"
-        panel.message = "Select the folder containing your images to display them in the preview."
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        panel.prompt = "Grant Access"
-        panel.directoryURL = directoryURL
-
-        guard panel.runModal() == .OK, let selectedURL = panel.url else { return }
+        guard let selectedURL = MarkdownOpenPanel.pickFolder(
+            directoryURL: directoryURL,
+            title: "Grant Image Access",
+            message: "Select the folder containing your images to display them in the preview.",
+            prompt: "Grant Access"
+        ) else { return }
         onAction(.grantImageDirectoryAccess(selectedURL))
     }
 

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Foundation
+import OSLog
+import SwiftUI
+
+@MainActor
+@Observable
+final class ContentAreaViewModel {
+    static let splitPaneMinimumWidth: CGFloat = 320
+
+    static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
+        category: "ContentAreaViewModel"
+    )
+
+    let document: ReaderDocumentController
+    let rendering: ReaderRenderingController
+    let sourceEditing: ReaderSourceEditingController
+    let externalChange: ReaderExternalChangeController
+    let toc: ReaderTOCController
+    let settingsStore: ReaderSettingsStore
+    let folderWatchState: ContentViewFolderWatchState
+    let surfaceViewModel: DocumentSurfaceViewModel
+    let onAction: (ContentViewAction) -> Void
+
+    init(
+        document: ReaderDocumentController,
+        rendering: ReaderRenderingController,
+        sourceEditing: ReaderSourceEditingController,
+        externalChange: ReaderExternalChangeController,
+        toc: ReaderTOCController,
+        settingsStore: ReaderSettingsStore,
+        folderWatchState: ContentViewFolderWatchState,
+        surfaceViewModel: DocumentSurfaceViewModel,
+        onAction: @escaping (ContentViewAction) -> Void
+    ) {
+        self.document = document
+        self.rendering = rendering
+        self.sourceEditing = sourceEditing
+        self.externalChange = externalChange
+        self.toc = toc
+        self.settingsStore = settingsStore
+        self.folderWatchState = folderWatchState
+        self.surfaceViewModel = surfaceViewModel
+        self.onAction = onAction
+    }
+
+    // MARK: - Derivations
+
+    var statusBarTimestamp: ReaderStatusBarTimestamp? {
+        if let date = externalChange.lastExternalChangeAt { return .updated(date) }
+        if let date = document.fileLastModifiedAt { return .lastModified(date) }
+        if let date = rendering.lastRefreshAt { return .updated(date) }
+        return nil
+    }
+
+    var currentReaderTheme: ReaderTheme {
+        ReaderTheme.theme(for: folderWatchState.effectiveReaderTheme)
+    }
+
+    var overlayColorScheme: ColorScheme {
+        currentReaderTheme.kind.isDark ? .dark : .light
+    }
+
+    var isStatusBannerVisible: Bool {
+        document.isCurrentFileMissing || rendering.needsImageDirectoryAccess
+    }
+
+    var overlayLayout: OverlayLayoutModel {
+        OverlayLayoutModel(
+            isSourceEditing: sourceEditing.isSourceEditing,
+            isStatusBannerVisible: isStatusBannerVisible
+        )
+    }
+
+    var emptyStateVariant: ContentEmptyStateView.Variant {
+        if let activeWatch = folderWatchState.activeFolderWatch {
+            return .folderWatchEmpty(folderName: activeWatch.detailSummaryTitle)
+        }
+        return .noDocument
+    }
+
+    var shouldShowDocumentLoadingOverlay: Bool {
+        document.documentLoadState == .loading
+            || document.documentLoadState == .settlingAutoOpen
+    }
+
+    var loadingOverlayHeadline: String {
+        switch document.documentLoadState {
+        case .settlingAutoOpen:
+            return "Waiting for file contents\u{2026}"
+        case .ready, .loading, .deferred:
+            return "Loading document\u{2026}"
+        }
+    }
+
+    var loadingOverlaySubtitle: String? {
+        switch document.documentLoadState {
+        case .settlingAutoOpen:
+            return "The new watched document will appear as soon as writing finishes."
+        case .ready, .loading, .deferred:
+            return nil
+        }
+    }
+
+    var minimumSurfaceWidth: CGFloat? {
+        sourceEditing.documentViewMode == .split ? Self.splitPaneMinimumWidth : nil
+    }
+
+    var canNavigateChangedRegions: Bool {
+        surfaceViewModel.canNavigateChangedRegions(
+            documentViewMode: sourceEditing.documentViewMode,
+            changedRegions: document.changedRegions
+        )
+    }
+
+    var showSourceEditingControls: Bool {
+        document.hasOpenDocument
+            && (sourceEditing.documentViewMode != .preview || sourceEditing.isSourceEditing)
+    }
+
+    var previewAccessibilityValue: String {
+        let fileName = document.fileURL?.lastPathComponent ?? "none"
+        return "file=\(fileName)|regions=\(document.changedRegions.count)|mode=\(sourceEditing.documentViewMode.rawValue)|surface=preview"
+    }
+
+    var isUITestModeEnabled: Bool {
+        ReaderUITestLaunchConfiguration.current.isUITestModeEnabled
+    }
+
+    // Actions will be added in Task 3.
+}

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -219,6 +219,51 @@ final class ContentAreaViewModel {
         surfaceViewModel.splitScrollCoordinator.suppressPreviewBounceBack()
     }
 
+    func dispatchWatchPillAction(_ action: WatchPillAction) {
+        switch action {
+        case .stop:
+            onAction(.stopFolderWatch)
+        case .saveFavorite(let name):
+            onAction(.saveFolderWatchAsFavorite(name))
+        case .removeFavorite:
+            onAction(.removeCurrentWatchFromFavorites)
+        case .revealInFinder:
+            if let url = folderWatchState.activeFolderWatch?.folderURL {
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
+            }
+        case .toggleAppearanceLock:
+            onAction(.toggleAppearanceLock)
+        case .editSubfolders:
+            onAction(.editSubfolders)
+        }
+    }
+
+    func makeSurfaceConfiguration(for surface: DocumentSurfaceRole) -> DocumentSurfaceConfiguration {
+        surfaceViewModel.documentSurfaceConfiguration(
+            for: surface,
+            fileURL: document.fileURL,
+            renderedHTMLDocument: rendering.renderedHTMLDocument,
+            documentViewMode: sourceEditing.documentViewMode,
+            changedRegions: document.changedRegions,
+            isSourceEditing: sourceEditing.isSourceEditing,
+            overlayTopInset: overlayLayout.insets.scrollTargetTopInset,
+            minimumSurfaceWidth: minimumSurfaceWidth,
+            tocScrollRequest: toc.scrollRequest,
+            canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
+            onSharedAction: { [weak self] action, role in
+                guard let self else { return false }
+                return self.surfaceViewModel.handleSharedAction(
+                    action,
+                    for: role,
+                    documentViewMode: self.sourceEditing.documentViewMode,
+                    onDroppedFileURLs: self.handleDroppedFileURLs,
+                    onAction: self.onAction
+                )
+            },
+            onAction: onAction
+        )
+    }
+
     func dispatchTopBarAction(_ action: ReaderTopBarAction) {
         switch action {
         case .openFiles(let urls):

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -240,9 +240,8 @@ final class ContentAreaViewModel {
             minimumSurfaceWidth: minimumSurfaceWidth,
             tocScrollRequest: toc.scrollRequest,
             canAcceptDroppedFileURLs: canAcceptDroppedFileURLs,
-            onSharedAction: { [weak self] action, role in
-                guard let self else { return false }
-                return self.surfaceViewModel.handleSharedAction(
+            onSharedAction: { action, role in
+                self.surfaceViewModel.handleSharedAction(
                     action,
                     for: role,
                     documentViewMode: self.sourceEditing.documentViewMode,

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -128,5 +128,131 @@ final class ContentAreaViewModel {
         ReaderUITestLaunchConfiguration.current.isUITestModeEnabled
     }
 
-    // Actions will be added in Task 3.
+    // MARK: - Actions
+
+    func handleAppear() {
+        refreshSourceHTMLFromControllers()
+        surfaceViewModel.handleSurfaceAppear(
+            renderedHTMLDocument: rendering.renderedHTMLDocument,
+            sourceMarkdown: document.sourceMarkdown
+        )
+    }
+
+    func refreshSourceHTMLFromControllers() {
+        surfaceViewModel.refreshSourceHTML(
+            markdown: sourceEditing.sourceEditorSeedMarkdown,
+            settings: settingsStore.currentSettings,
+            isEditable: sourceEditing.isSourceEditing
+        )
+    }
+
+    func canAcceptDroppedFileURLs(_ fileURLs: [URL]) -> Bool {
+        !ReaderFileRouting.containsLikelyDirectoryPath(in: fileURLs)
+            || folderWatchState.activeFolderWatch == nil
+    }
+
+    func handleDroppedFileURLs(_ fileURLs: [URL]) {
+        if let droppedFolderURL = ReaderFileRouting.firstDroppedDirectoryURL(from: fileURLs) {
+            guard folderWatchState.activeFolderWatch == nil else { return }
+            onAction(.requestFolderWatch(droppedFolderURL))
+            return
+        }
+
+        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
+        guard !markdownURLs.isEmpty else { return }
+
+        let slotStrategy: FileOpenRequest.SlotStrategy =
+            document.fileURL == nil ? .reuseEmptySlotForFirst : .alwaysAppend
+        onAction(.requestFileOpen(FileOpenRequest(
+            fileURLs: markdownURLs,
+            origin: .manual,
+            slotStrategy: slotStrategy
+        )))
+    }
+
+    func handlePickedFileURLs(_ fileURLs: [URL]) {
+        let markdownURLs = ReaderFileRouting.supportedMarkdownFiles(from: fileURLs)
+        guard !markdownURLs.isEmpty else { return }
+
+        let normalizedIncomingURL = ReaderFileRouting.normalizedFileURL(markdownURLs[0])
+        let currentURL = document.fileURL.map(ReaderFileRouting.normalizedFileURL)
+        if sourceEditing.hasUnsavedDraftChanges, currentURL != normalizedIncomingURL {
+            onAction(.presentError(ReaderError.unsavedDraftRequiresResolution))
+            return
+        }
+
+        onAction(.requestFileOpen(FileOpenRequest(
+            fileURLs: [markdownURLs[0]],
+            origin: .manual,
+            slotStrategy: .replaceSelectedSlot
+        )))
+
+        let additionalMarkdownURLs = Array(markdownURLs.dropFirst())
+        guard !additionalMarkdownURLs.isEmpty else { return }
+
+        onAction(.requestFileOpen(FileOpenRequest(
+            fileURLs: additionalMarkdownURLs,
+            origin: .manual,
+            slotStrategy: .alwaysAppend
+        )))
+    }
+
+    func promptForImageDirectoryAccess() {
+        guard let directoryURL = document.fileURL?.deletingLastPathComponent() else { return }
+
+        let panel = NSOpenPanel()
+        panel.title = "Grant Image Access"
+        panel.message = "Select the folder containing your images to display them in the preview."
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        panel.prompt = "Grant Access"
+        panel.directoryURL = directoryURL
+
+        guard panel.runModal() == .OK, let selectedURL = panel.url else { return }
+        onAction(.grantImageDirectoryAccess(selectedURL))
+    }
+
+    func requestChangeNavigation(_ direction: ReaderChangedRegionNavigationDirection) {
+        surfaceViewModel.changeNavigation.requestNavigation(direction)
+        surfaceViewModel.splitScrollCoordinator.suppressPreviewBounceBack()
+    }
+
+    func dispatchTopBarAction(_ action: ReaderTopBarAction) {
+        switch action {
+        case .openFiles(let urls):
+            handlePickedFileURLs(urls)
+        case .openInApp(let app):
+            onAction(.openInApplication(app))
+        case .revealInFinder:
+            onAction(.revealInFinder)
+        case .saveSourceDraft:
+            onAction(.saveSourceDraft)
+        case .discardSourceDraft:
+            onAction(.discardSourceDraft)
+        case .requestFolderWatch(let url):
+            onAction(.requestFolderWatch(url))
+        case .stopFolderWatch:
+            onAction(.stopFolderWatch)
+        case .startFavoriteWatch(let fav):
+            onAction(.startFavoriteWatch(fav))
+        case .clearFavoriteWatchedFolders:
+            onAction(.clearFavoriteWatchedFolders)
+        case .renameFavoriteWatchedFolder(let id, let name):
+            onAction(.renameFavoriteWatchedFolder(id: id, name: name))
+        case .removeFavoriteWatchedFolder(let id):
+            onAction(.removeFavoriteWatchedFolder(id))
+        case .reorderFavoriteWatchedFolders(let ids):
+            onAction(.reorderFavoriteWatchedFolders(ids))
+        case .startRecentManuallyOpenedFile(let entry):
+            onAction(.startRecentManuallyOpenedFile(entry))
+        case .startRecentFolderWatch(let entry):
+            onAction(.startRecentFolderWatch(entry))
+        case .clearRecentWatchedFolders:
+            onAction(.clearRecentWatchedFolders)
+        case .clearRecentManuallyOpenedFiles:
+            onAction(.clearRecentManuallyOpenedFiles)
+        }
+    }
 }

--- a/minimark/Views/Content/ContentDocumentSurfaceViews.swift
+++ b/minimark/Views/Content/ContentDocumentSurfaceViews.swift
@@ -202,3 +202,98 @@ struct MarkdownSourceFallbackView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
+
+struct DocumentSurfaceHost: View {
+    let configuration: DocumentSurfaceConfiguration
+    let fallbackMarkdown: String
+
+    var body: some View {
+        Group {
+            if configuration.usesWebSurface {
+                MarkdownWebView(
+                    htmlDocument: configuration.htmlDocument,
+                    documentIdentity: configuration.documentIdentity,
+                    accessibilityIdentifier: configuration.accessibilityIdentifier,
+                    accessibilityValue: configuration.accessibilityValue,
+                    reloadToken: configuration.reloadToken,
+                    diagnosticName: configuration.diagnosticName,
+                    postLoadStatusScript: configuration.postLoadStatusScript,
+                    changedRegionNavigationRequest: configuration.changedRegionNavigationRequest,
+                    scrollSyncRequest: configuration.scrollSyncRequest,
+                    tocScrollRequest: configuration.tocScrollRequest,
+                    supportsInPlaceContentUpdates: configuration.supportsInPlaceContentUpdates,
+                    overlayTopInset: configuration.overlayTopInset,
+                    reloadAnchorProgress: configuration.reloadAnchorProgress,
+                    canAcceptDroppedFileURLs: configuration.canAcceptDroppedFileURLs,
+                    onAction: configuration.onAction
+                )
+            } else {
+                fallbackSurface
+            }
+        }
+        .frame(minWidth: configuration.minimumWidth)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var fallbackSurface: some View {
+        switch configuration.role {
+        case .preview:
+            NativeMarkdownFallbackView(
+                markdown: fallbackMarkdown,
+                onRetryPreview: { configuration.onAction(.retryFallback) }
+            )
+        case .source:
+            MarkdownSourceFallbackView(
+                markdown: fallbackMarkdown,
+                onRetryHighlighting: { configuration.onAction(.retryFallback) }
+            )
+        }
+    }
+}
+
+struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: View {
+    let documentViewMode: ReaderDocumentViewMode
+    let hasOpenDocument: Bool
+    let showsLoadingOverlay: Bool
+    let loadingOverlayHeadline: String
+    let loadingOverlaySubtitle: String?
+    let emptyStateVariant: ContentEmptyStateView.Variant
+    let currentReaderTheme: ReaderTheme
+    let onDroppedFileURLs: ([URL]) -> Void
+    let previewSurface: PreviewSurface
+    let sourceSurface: SourceSurface
+
+    var body: some View {
+        if showsLoadingOverlay {
+            DocumentLoadingOverlay(
+                theme: currentReaderTheme,
+                headline: loadingOverlayHeadline,
+                subtitle: loadingOverlaySubtitle
+            )
+        } else if !hasOpenDocument {
+            ContentEmptyStateView(
+                variant: emptyStateVariant,
+                theme: currentReaderTheme
+            )
+            .dropDestination(for: URL.self) { urls, _ in
+                let fileURLs = urls.filter { $0.isFileURL }
+                guard !fileURLs.isEmpty else { return false }
+                onDroppedFileURLs(fileURLs)
+                return true
+            }
+        } else {
+            switch documentViewMode {
+            case .preview:
+                previewSurface
+            case .split:
+                HSplitView {
+                    previewSurface
+                    sourceSurface
+                }
+            case .source:
+                sourceSurface
+            }
+        }
+    }
+}

--- a/minimark/Views/Content/ContentDropModifier.swift
+++ b/minimark/Views/Content/ContentDropModifier.swift
@@ -20,7 +20,7 @@ struct ContentDropModifier: ViewModifier {
     }
 }
 
-struct FolderDropBlockedOverlayView: View {
+private struct FolderDropBlockedOverlayView: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 10, style: .continuous)

--- a/minimark/Views/Content/ContentDropModifier.swift
+++ b/minimark/Views/Content/ContentDropModifier.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct ContentDropModifier: ViewModifier {
+    let isBlockedFolderDropTargeted: Bool
+    let isDragTargeted: Bool
+
+    func body(content: Content) -> some View {
+        content.overlay {
+            if isBlockedFolderDropTargeted {
+                FolderDropBlockedOverlayView()
+                    .padding(10)
+                    .allowsHitTesting(false)
+            } else if isDragTargeted {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Color.accentColor.opacity(0.65), lineWidth: 2)
+                    .padding(10)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+}
+
+struct FolderDropBlockedOverlayView: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black.opacity(0.24))
+
+            VStack(spacing: 6) {
+                Image(systemName: "folder.badge.minus")
+                    .font(.system(size: 22, weight: .semibold))
+
+                Text("Already Watching a Folder")
+                    .font(.headline)
+
+                Text("Stop the current folder watch before dropping another folder.")
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+            }
+            .foregroundStyle(Color.black)
+            .padding(20)
+            .frame(maxWidth: 460)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(nsColor: .systemYellow))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(Color.orange, lineWidth: 2)
+            )
+        }
+    }
+}

--- a/minimark/Views/Content/ContentStatusBanner.swift
+++ b/minimark/Views/Content/ContentStatusBanner.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ContentStatusBanner: View {
+    let isCurrentFileMissing: Bool
+    let fileDisplayName: String
+    let errorMessage: String?
+    let needsImageDirectoryAccess: Bool
+    let topPadding: CGFloat
+    let onGrantImageAccess: () -> Void
+
+    var body: some View {
+        if isCurrentFileMissing {
+            DeletedFileWarningBar(fileName: fileDisplayName, message: errorMessage)
+                .padding(.top, topPadding)
+        } else if needsImageDirectoryAccess {
+            ImageAccessWarningBar(onGrantAccess: onGrantImageAccess)
+                .padding(.top, topPadding)
+        }
+    }
+}

--- a/minimark/Views/Content/ContentUtilityRailView.swift
+++ b/minimark/Views/Content/ContentUtilityRailView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ContentUtilityRailView: View {
+    let hasFile: Bool
+    let documentViewMode: ReaderDocumentViewMode
+    let showEditButton: Bool
+    let canStartSourceEditing: Bool
+    let hasTOCHeadings: Bool
+    @Binding var isTOCVisible: Bool
+    let onSetDocumentViewMode: (ReaderDocumentViewMode) -> Void
+    let onStartSourceEditing: () -> Void
+
+    var body: some View {
+        ContentUtilityRail(
+            hasFile: hasFile,
+            documentViewMode: documentViewMode,
+            showEditButton: showEditButton,
+            canStartSourceEditing: canStartSourceEditing,
+            onSetDocumentViewMode: onSetDocumentViewMode,
+            onStartSourceEditing: onStartSourceEditing,
+            hasTOCHeadings: hasTOCHeadings,
+            isTOCVisible: $isTOCVisible
+        )
+    }
+}

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -1,11 +1,8 @@
 import SwiftUI
 
-/// Intermediate view that narrows the `@Observable` observation scope for `ContentView`.
-///
-/// `ReaderWindowRootView.body` re-evaluates whenever any of its 6+ observed objects change.
-/// By moving the `ContentViewFolderWatchState` and `ContentAreaViewModel` construction here,
-/// the reads from `sidebarDocumentController`, `settingsStore`, and `appearanceController`
-/// are tracked only for this view's body — not for the entire root or sidebar workspace view.
+/// Narrows the `@Observable` observation scope for `ContentView`: reads from the sidebar
+/// controller, settings store, and appearance controller are tracked only for this view's
+/// body, not for the root or sidebar workspace view.
 struct ContentViewAdapter: View {
     let readerStore: ReaderStore
     let sidebarDocumentController: ReaderSidebarDocumentController

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -3,9 +3,9 @@ import SwiftUI
 /// Intermediate view that narrows the `@Observable` observation scope for `ContentView`.
 ///
 /// `ReaderWindowRootView.body` re-evaluates whenever any of its 6+ observed objects change.
-/// By moving the `ContentViewFolderWatchState` construction here, the reads from
-/// `sidebarDocumentController`, `settingsStore`, and `appearanceController` are tracked
-/// only for this view's body — not for the entire root or sidebar workspace view.
+/// By moving the `ContentViewFolderWatchState` and `ContentAreaViewModel` construction here,
+/// the reads from `sidebarDocumentController`, `settingsStore`, and `appearanceController`
+/// are tracked only for this view's body — not for the entire root or sidebar workspace view.
 struct ContentViewAdapter: View {
     let readerStore: ReaderStore
     let sidebarDocumentController: ReaderSidebarDocumentController
@@ -33,28 +33,34 @@ struct ContentViewAdapter: View {
             return favorites.contains { $0.matches(folderPath: normalizedPath, options: session.options) }
         }()
 
-        ContentView(
+        let folderWatchState = ContentViewFolderWatchState(
+            activeFolderWatch: sharedFolderWatchSession,
+            isFolderWatchInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
+            isFolderWatchInitialScanFailed: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
+            canStopFolderWatch: canStopSharedFolderWatch,
+            pendingFolderWatchURL: pendingFolderWatchURL,
+            isCurrentWatchAFavorite: isCurrentWatchAFavorite,
+            favoriteWatchedFolders: favorites,
+            recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
+            recentManuallyOpenedFiles: settingsStore.currentSettings.recentManuallyOpenedFiles,
+            isAppearanceLocked: appearanceController.isLocked,
+            effectiveReaderTheme: appearanceController.effectiveAppearance.readerTheme
+        )
+
+        let viewModel = ContentAreaViewModel(
             document: readerStore.document,
             rendering: readerStore.renderingController,
             sourceEditing: readerStore.sourceEditingController,
             externalChange: readerStore.externalChange,
             toc: readerStore.toc,
             settingsStore: settingsStore,
-            folderWatchState: ContentViewFolderWatchState(
-                activeFolderWatch: sharedFolderWatchSession,
-                isFolderWatchInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
-                isFolderWatchInitialScanFailed: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
-                canStopFolderWatch: canStopSharedFolderWatch,
-                pendingFolderWatchURL: pendingFolderWatchURL,
-                isCurrentWatchAFavorite: isCurrentWatchAFavorite,
-                favoriteWatchedFolders: favorites,
-                recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
-                recentManuallyOpenedFiles: settingsStore.currentSettings.recentManuallyOpenedFiles,
-                isAppearanceLocked: appearanceController.isLocked,
-                effectiveReaderTheme: appearanceController.effectiveAppearance.readerTheme
-            ),
+            folderWatchState: folderWatchState,
             surfaceViewModel: surfaceViewModel,
-            onAction: onAction,
+            onAction: onAction
+        )
+
+        ContentView(
+            viewModel: viewModel,
             isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
             pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
             pendingFolderWatchScope: $pendingFolderWatchScope,

--- a/minimark/Views/Content/ContentViewObservers.swift
+++ b/minimark/Views/Content/ContentViewObservers.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ContentViewObservers: ViewModifier {
+    let viewModel: ContentAreaViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: viewModel.document.fileURL?.standardizedFileURL.path) { _, _ in
+                viewModel.surfaceViewModel.handleFileIdentityChange()
+            }
+            .onChange(of: viewModel.document.changedRegions) { _, _ in
+                viewModel.surfaceViewModel.changeNavigation.resetForNewRegions()
+            }
+            .onChange(of: viewModel.surfaceViewModel.previewMode) { _, newValue in
+                viewModel.surfaceViewModel.handlePreviewModeChange(newValue)
+            }
+            .onChange(of: viewModel.surfaceViewModel.sourceMode) { _, newValue in
+                viewModel.surfaceViewModel.handleSourceModeChange(newValue)
+            }
+            .onChange(of: viewModel.sourceEditing.documentViewMode) { _, newValue in
+                viewModel.surfaceViewModel.handleDocumentViewModeChange(newValue)
+            }
+            .onChange(of: viewModel.sourceEditing.sourceEditorSeedMarkdown) { _, _ in
+                viewModel.refreshSourceHTMLFromControllers()
+            }
+            .onChange(of: viewModel.settingsStore.currentSettings) { _, _ in
+                viewModel.refreshSourceHTMLFromControllers()
+            }
+            .onChange(of: viewModel.sourceEditing.isSourceEditing) { _, _ in
+                viewModel.refreshSourceHTMLFromControllers()
+            }
+            .onChange(of: viewModel.folderWatchState.activeFolderWatch?.folderURL.standardizedFileURL.path) { _, _ in
+                viewModel.surfaceViewModel.dropTargeting.clearAll()
+            }
+    }
+}

--- a/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
+++ b/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct ContentViewUITestAccessibilityLabel: View {
     let isEnabled: Bool
-    let value: String
+    let makeValue: () -> String
 
     var body: some View {
         if isEnabled {
+            let value = makeValue()
             Text(value)
                 .font(.system(size: 8, weight: .regular, design: .monospaced))
                 .foregroundStyle(.secondary)

--- a/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
+++ b/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ContentViewUITestAccessibilityLabel: View {
+    let isEnabled: Bool
+    let value: String
+
+    var body: some View {
+        if isEnabled {
+            Text(value)
+                .font(.system(size: 8, weight: .regular, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .padding(6)
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("reader-preview-summary")
+                .accessibilityLabel("Reader preview summary")
+                .accessibilityValue(value)
+        }
+    }
+}

--- a/minimark/Views/Content/OverlayLayoutModel.swift
+++ b/minimark/Views/Content/OverlayLayoutModel.swift
@@ -1,0 +1,26 @@
+import CoreGraphics
+import Foundation
+
+struct OverlayLayoutModel: Equatable, Sendable {
+    let isSourceEditing: Bool
+    let isStatusBannerVisible: Bool
+
+    var topInset: CGFloat {
+        var height = ReaderTopBarMetrics.mainBarHeight
+        if isSourceEditing {
+            height += ReaderTopBarMetrics.sourceEditingBarHeight
+        }
+        return height
+    }
+
+    var insets: ReaderOverlayInsetValues {
+        ReaderOverlayInsetCalculator.compute(
+            topBarInset: topInset,
+            hasStatusBanner: isStatusBannerVisible
+        )
+    }
+
+    var statusBannerTopPadding: CGFloat {
+        ReaderOverlayInsetCalculator.statusBannerTopPadding(topBarInset: topInset)
+    }
+}

--- a/minimark/Views/Content/OverlayLayoutModel.swift
+++ b/minimark/Views/Content/OverlayLayoutModel.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Foundation
 
 struct OverlayLayoutModel: Equatable, Sendable {
     let isSourceEditing: Bool

--- a/minimark/Views/Content/OverlayPillTransition.swift
+++ b/minimark/Views/Content/OverlayPillTransition.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension AnyTransition {
+    static let overlayPill: AnyTransition = .asymmetric(
+        insertion: .opacity.combined(with: .move(edge: .top)),
+        removal: .opacity
+    )
+}

--- a/minimark/Views/Content/TOCOverlayView.swift
+++ b/minimark/Views/Content/TOCOverlayView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct TOCOverlayView: View {
+    let headings: [TOCHeading]
+    let buttonAnchor: Anchor<CGRect>
+    let colorScheme: ColorScheme
+    let onDismiss: () -> Void
+    let onSelectHeading: (TOCHeading) -> Void
+
+    var body: some View {
+        let gap: CGFloat = 8
+
+        GeometryReader { proxy in
+            let buttonFrame = proxy[buttonAnchor]
+            let panelTrailing = buttonFrame.minX - gap
+
+            ZStack(alignment: .topLeading) {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: onDismiss)
+
+                TOCPopoverView(
+                    headings: headings,
+                    onSelect: onSelectHeading
+                )
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
+                }
+                .shadow(color: .black.opacity(0.25), radius: 16, y: 4)
+                .colorScheme(colorScheme)
+                .frame(maxWidth: panelTrailing, alignment: .trailing)
+                .offset(y: buttonFrame.minY)
+            }
+        }
+    }
+}

--- a/minimark/Views/Content/WatchPillOverlayView.swift
+++ b/minimark/Views/Content/WatchPillOverlayView.swift
@@ -24,10 +24,7 @@ struct WatchPillOverlayView: View {
             .padding(.leading, leadingPadding)
             .padding(.trailing, trailingPadding)
             .environment(\.colorScheme, colorScheme)
-            .transition(.asymmetric(
-                insertion: .opacity.combined(with: .move(edge: .top)),
-                removal: .opacity
-            ))
+            .transition(.overlayPill)
         }
     }
 }

--- a/minimark/Views/Content/WatchPillOverlayView.swift
+++ b/minimark/Views/Content/WatchPillOverlayView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct WatchPillOverlayView: View {
+    let activeFolderWatch: ReaderFolderWatchSession?
+    let isCurrentWatchAFavorite: Bool
+    let canStop: Bool
+    let isAppearanceLocked: Bool
+    let topPadding: CGFloat
+    let leadingPadding: CGFloat
+    let trailingPadding: CGFloat
+    let colorScheme: ColorScheme
+    let onAction: (WatchPillAction) -> Void
+
+    var body: some View {
+        if let activeWatch = activeFolderWatch {
+            WatchPill(
+                activeFolderWatch: activeWatch,
+                isCurrentWatchAFavorite: isCurrentWatchAFavorite,
+                canStop: canStop,
+                isAppearanceLocked: isAppearanceLocked,
+                onAction: onAction
+            )
+            .padding(.top, topPadding)
+            .padding(.leading, leadingPadding)
+            .padding(.trailing, trailingPadding)
+            .environment(\.colorScheme, colorScheme)
+            .transition(.asymmetric(
+                insertion: .opacity.combined(with: .move(edge: .top)),
+                removal: .opacity
+            ))
+        }
+    }
+}

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -105,3 +105,57 @@ struct ContentAreaViewModelTests {
         #expect(viewModel.overlayLayout.isSourceEditing == true)
     }
 }
+
+@Suite
+struct ContentAreaViewModelDropRoutingTests {
+
+    @Test @MainActor func canAcceptDropsWhenNoFolderIsWatched() {
+        let (viewModel, _, _, _) = makeTestViewModel()
+        let urls = [URL(fileURLWithPath: "/tmp/example.md")]
+        #expect(viewModel.canAcceptDroppedFileURLs(urls) == true)
+    }
+
+    @Test @MainActor func handleDroppedMarkdownFiresRequestFileOpen() {
+        var captured: [ContentViewAction] = []
+        let settingsStore = ReaderSettingsStore()
+        let settler = ReaderAutoOpenSettler(settlingInterval: 1.0)
+        let securityScopeResolver = SecurityScopeResolver(
+            securityScope: SecurityScopedResourceAccess(),
+            settingsStore: settingsStore,
+            requestWatchedFolderReauthorization: { _ in nil }
+        )
+        let fileDeps = ReaderFileDependencies(
+            watcher: FileChangeWatcher(),
+            io: ReaderDocumentIOService(),
+            actions: ReaderFileActionService()
+        )
+        let renderingDeps = ReaderRenderingDependencies(
+            renderer: MarkdownRenderingService(),
+            differ: ChangedRegionDiffer()
+        )
+        let viewModel = ContentAreaViewModel(
+            document: ReaderDocumentController(
+                fileDependencies: fileDeps,
+                settingsStore: settingsStore,
+                settler: settler
+            ),
+            rendering: ReaderRenderingController(
+                renderingDependencies: renderingDeps,
+                settingsStore: settingsStore,
+                securityScopeResolver: securityScopeResolver
+            ),
+            sourceEditing: ReaderSourceEditingController(),
+            externalChange: ReaderExternalChangeController(),
+            toc: ReaderTOCController(),
+            settingsStore: settingsStore,
+            folderWatchState: .testEmpty,
+            surfaceViewModel: DocumentSurfaceViewModel(),
+            onAction: { captured.append($0) }
+        )
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("sample.md")
+        viewModel.handleDroppedFileURLs([url])
+        #expect(captured.contains(where: {
+            if case .requestFileOpen = $0 { return true } else { return false }
+        }))
+    }
+}

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import Testing
 @testable import minimark

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Foundation
+import Testing
+@testable import minimark
+
+@MainActor
+private func makeTestViewModel(
+    folderWatchState: ContentViewFolderWatchState = .testEmpty
+) -> (ContentAreaViewModel, ReaderDocumentController, ReaderRenderingController, ReaderSourceEditingController) {
+    let settingsStore = ReaderSettingsStore()
+    let settler = ReaderAutoOpenSettler(settlingInterval: 1.0)
+    let securityScopeResolver = SecurityScopeResolver(
+        securityScope: SecurityScopedResourceAccess(),
+        settingsStore: settingsStore,
+        requestWatchedFolderReauthorization: { _ in nil }
+    )
+    let fileDeps = ReaderFileDependencies(
+        watcher: FileChangeWatcher(),
+        io: ReaderDocumentIOService(),
+        actions: ReaderFileActionService()
+    )
+    let renderingDeps = ReaderRenderingDependencies(
+        renderer: MarkdownRenderingService(),
+        differ: ChangedRegionDiffer()
+    )
+    let document = ReaderDocumentController(
+        fileDependencies: fileDeps,
+        settingsStore: settingsStore,
+        settler: settler
+    )
+    let rendering = ReaderRenderingController(
+        renderingDependencies: renderingDeps,
+        settingsStore: settingsStore,
+        securityScopeResolver: securityScopeResolver
+    )
+    let sourceEditing = ReaderSourceEditingController()
+    let externalChange = ReaderExternalChangeController()
+    let toc = ReaderTOCController()
+    let surfaceViewModel = DocumentSurfaceViewModel()
+
+    let viewModel = ContentAreaViewModel(
+        document: document,
+        rendering: rendering,
+        sourceEditing: sourceEditing,
+        externalChange: externalChange,
+        toc: toc,
+        settingsStore: settingsStore,
+        folderWatchState: folderWatchState,
+        surfaceViewModel: surfaceViewModel,
+        onAction: { _ in }
+    )
+    return (viewModel, document, rendering, sourceEditing)
+}
+
+extension ContentViewFolderWatchState {
+    static let testEmpty = ContentViewFolderWatchState(
+        activeFolderWatch: nil,
+        isFolderWatchInitialScanInProgress: false,
+        isFolderWatchInitialScanFailed: false,
+        canStopFolderWatch: false,
+        pendingFolderWatchURL: nil,
+        isCurrentWatchAFavorite: false,
+        favoriteWatchedFolders: [],
+        recentWatchedFolders: [],
+        recentManuallyOpenedFiles: [],
+        isAppearanceLocked: false,
+        effectiveReaderTheme: .blackOnWhite
+    )
+}
+
+@Suite
+struct ContentAreaViewModelTests {
+
+    @Test @MainActor func emptyStateVariantWithoutActiveWatchIsNoDocument() {
+        let (viewModel, _, _, _) = makeTestViewModel()
+        #expect(viewModel.emptyStateVariant == .noDocument)
+    }
+
+    @Test @MainActor func isStatusBannerVisibleIsFalseByDefault() {
+        let (viewModel, _, _, _) = makeTestViewModel()
+        #expect(viewModel.isStatusBannerVisible == false)
+    }
+
+    @Test @MainActor func minimumSurfaceWidthIsNilOutsideSplit() {
+        let (viewModel, _, _, sourceEditing) = makeTestViewModel()
+        sourceEditing.setViewMode(.preview, hasOpenDocument: false)
+        #expect(viewModel.minimumSurfaceWidth == nil)
+    }
+
+    @Test @MainActor func minimumSurfaceWidthIsSetInSplitMode() {
+        let (viewModel, _, _, sourceEditing) = makeTestViewModel()
+        sourceEditing.setViewMode(.split, hasOpenDocument: true)
+        #expect(viewModel.minimumSurfaceWidth == 320)
+    }
+
+    @Test @MainActor func canNavigateChangedRegionsIsFalseWhenEmpty() {
+        let (viewModel, _, _, _) = makeTestViewModel()
+        #expect(viewModel.canNavigateChangedRegions == false)
+    }
+
+    @Test @MainActor func overlayLayoutReflectsSourceEditingFlag() {
+        let (viewModel, _, _, sourceEditing) = makeTestViewModel()
+        sourceEditing.setViewMode(.source, hasOpenDocument: true)
+        sourceEditing.isSourceEditing = true
+        #expect(viewModel.overlayLayout.isSourceEditing == true)
+    }
+}

--- a/minimarkTests/Core/OverlayLayoutModelTests.swift
+++ b/minimarkTests/Core/OverlayLayoutModelTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite
+struct OverlayLayoutModelTests {
+
+    @Test func topInsetWithoutSourceEditingIsMainBarHeight() {
+        let model = OverlayLayoutModel(isSourceEditing: false, isStatusBannerVisible: false)
+        #expect(model.topInset == ReaderTopBarMetrics.mainBarHeight)
+    }
+
+    @Test func topInsetWithSourceEditingAddsSourceBarHeight() {
+        let model = OverlayLayoutModel(isSourceEditing: true, isStatusBannerVisible: false)
+        #expect(model.topInset == ReaderTopBarMetrics.mainBarHeight + ReaderTopBarMetrics.sourceEditingBarHeight)
+    }
+
+    @Test func insetsDelegateToCalculator() {
+        let model = OverlayLayoutModel(isSourceEditing: false, isStatusBannerVisible: true)
+        let expected = ReaderOverlayInsetCalculator.compute(
+            topBarInset: ReaderTopBarMetrics.mainBarHeight,
+            hasStatusBanner: true
+        )
+        #expect(model.insets == expected)
+    }
+
+    @Test func statusBannerPaddingDelegatesToCalculator() {
+        let model = OverlayLayoutModel(isSourceEditing: true, isStatusBannerVisible: false)
+        let expected = ReaderOverlayInsetCalculator.statusBannerTopPadding(
+            topBarInset: ReaderTopBarMetrics.mainBarHeight + ReaderTopBarMetrics.sourceEditingBarHeight
+        )
+        #expect(model.statusBannerTopPadding == expected)
+    }
+}


### PR DESCRIPTION
## Summary

Breaks up the 720-line `minimark/ContentView.swift` into a thin composer plus small focused subviews and a content-area view-model. Pure architectural refactor — no user-visible behaviour change.

- `ContentView.swift`: 720 → 234 lines (172 excluding the 62-line `#Preview`).
- New `ContentAreaViewModel` owns the derivations and action routing that used to live inline on the view (drop routing, image-access prompt, top-bar dispatch, watch-pill dispatch, source-HTML refresh, change-navigation).
- New `OverlayLayoutModel` struct wraps `ReaderOverlayInsetCalculator` and is unit-tested in isolation.
- Six leaf overlay views extracted (`ContentStatusBanner`, `ChangeNavigationOverlayView`, `WatchPillOverlayView`, `ContentUtilityRailView`, `TOCOverlayView`, plus `ContentDropModifier` + moved `FolderDropBlockedOverlayView`).
- `ContentViewObservers` modifier centralises the nine `.onChange` handlers; `ContentViewUITestAccessibilityLabel` isolates the UI-test summary overlay.
- `DocumentSurfaceHost` and `DocumentSurfaceLayoutView` move to `ContentDocumentSurfaceViews.swift` where other surface helpers live.
- 12 new unit tests cover the VM derivations, drop-routing decisions, and `OverlayLayoutModel` insets.

## Acceptance criteria (from #335)

- [x] `ContentView.swift` ≤ 200 lines — 172 excluding `#Preview`.
- [x] No computed `some View` in the file longer than ~20 lines.
- [x] Drop handling and image-access prompting moved off the view.
- [x] Subviews take only the dependencies they render.
- [x] Existing UI tests + preview fixtures still work.
- [x] No behaviour change visible to users.

## Test plan

- [x] `xcodebuild -scheme minimark -destination 'platform=macOS' build` — green.
- [x] `xcodebuild test -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests` — all pass (including 12 new tests).
- [x] App smoke-launch — starts cleanly.
- [ ] UI tests (`minimarkUITests`): 9 pre-existing failures confirmed identical on `develop` baseline — tracked in #337, not regressions from this branch.
- [ ] `#Preview` renders in Xcode canvas (manual check recommended before merge).

## Follow-ups opened

- #337 — fix pre-existing UI-test failures.
- #338 — move `ContentViewObservers` wiring into `ContentAreaViewModel`.
- #339 — narrow `ContentAreaViewModel`'s exposed surface (blocked by #338).
- #340 — collapse overlay subview parameter sprawl into config structs + promote magic padding numbers.
- #341 — centralize accessibility identifiers and UI-test summary schema.

Closes #335