### PR TITLE
fix: render newest file when opening a favorite (closes #345)

### DIFF
--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -167,7 +167,19 @@ final class ReaderSidebarDocumentController {
             return
         }
 
-        let isReselection = (selectedDocumentID == documentID)
+        if selectedDocumentID == documentID {
+            // Re-selecting the same document is a no-op UNLESS the store is still
+            // deferred — in that case we must materialize (see #345). Avoid
+            // reassigning `selectedDocumentID` so Observation doesn't fire for a
+            // ready-state reselect.
+            let store = selectedReaderStore
+            guard store.document.isDeferredDocument else { return }
+            scheduleLoadWithOverlay(on: store) {
+                store.materializeDeferredDocument()
+            }
+            return
+        }
+
         selectedDocumentID = documentID
         let store = selectedReaderStore
 
@@ -175,10 +187,8 @@ final class ReaderSidebarDocumentController {
             scheduleLoadWithOverlay(on: store) {
                 store.materializeDeferredDocument()
             }
-            if !isReselection { bindSelectedStore() }
-        } else if !isReselection {
-            bindSelectedStore()
         }
+        bindSelectedStore()
     }
 
     @discardableResult

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -167,10 +167,7 @@ final class ReaderSidebarDocumentController {
             return
         }
 
-        if selectedDocumentID == documentID {
-            return
-        }
-
+        let isReselection = (selectedDocumentID == documentID)
         selectedDocumentID = documentID
         let store = selectedReaderStore
 
@@ -178,8 +175,8 @@ final class ReaderSidebarDocumentController {
             scheduleLoadWithOverlay(on: store) {
                 store.materializeDeferredDocument()
             }
-            bindSelectedStore()
-        } else {
+            if !isReselection { bindSelectedStore() }
+        } else if !isReselection {
             bindSelectedStore()
         }
     }

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -1302,4 +1302,83 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(controller.documents.count == 1)
         _ = controller
     }
+
+    // MARK: - #345 selectDocumentWithNewestModificationDate materializes deferred target
+
+    /// Regression for #345. When `discoverNewFilesForFavorite` appends new files with
+    /// `.deferOnly` and then asks the controller to select the newest, the newest
+    /// doc's id equals `selectedDocumentID` (set by the last appended assignment).
+    /// The early-return guard in `selectDocument` must not skip materialization.
+    @Test @MainActor
+    func sidebarControllerMaterializesNewestDeferredDocumentWhenSelectionDoesNotChange() async throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        // Deterministic mtimes: secondary (zeta.md) is newer so it ends up the "newest".
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_000_000)],
+            ofItemAtPath: harness.primaryFileURL.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000_000)],
+            ofItemAtPath: harness.secondaryFileURL.path
+        )
+
+        // Simulate the buggy `discoverNewFilesForFavorite` inner call: append deferred slots.
+        let coordinator = FileOpenCoordinator(controller: harness.controller)
+        coordinator.open(FileOpenRequest(
+            fileURLs: [harness.primaryFileURL, harness.secondaryFileURL],
+            origin: .folderWatchInitialBatchAutoOpen,
+            slotStrategy: .alwaysAppend,
+            materializationStrategy: .deferOnly
+        ))
+
+        // Both appended docs deferred; selection is on the last appended doc (zeta.md by sort order).
+        let newestDoc = try #require(
+            harness.controller.documents.first { $0.readerStore.document.fileURL?.path == harness.secondaryFileURL.path }
+        )
+        let primaryDoc = try #require(
+            harness.controller.documents.first { $0.readerStore.document.fileURL?.path == harness.primaryFileURL.path }
+        )
+        #expect(newestDoc.readerStore.document.isDeferredDocument)
+        #expect(primaryDoc.readerStore.document.isDeferredDocument)
+        #expect(harness.controller.selectedDocumentID == newestDoc.id)
+
+        // Trigger the code path `FavoriteWorkspaceController.discoverNewFilesForFavorite` uses.
+        harness.controller.selectDocumentWithNewestModificationDate()
+
+        // `scheduleLoadWithOverlay` defers the materialization one run-loop turn.
+        await Task.yield()
+        await Task.yield()
+
+        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.secondaryFileURL.path)
+        #expect(!harness.controller.selectedReaderStore.document.isDeferredDocument)
+    }
+
+    /// Guards the ready-state path: re-selecting an already materialized document
+    /// must remain a no-op and must not re-enter the load overlay.
+    @Test @MainActor
+    func sidebarControllerReselectingLoadedDocumentDoesNotReenterLoadingState() async throws {
+        let harness = try ReaderSidebarControllerTestHarness()
+        defer { harness.cleanup() }
+
+        let coordinator = FileOpenCoordinator(controller: harness.controller)
+        coordinator.open(FileOpenRequest(
+            fileURLs: [harness.primaryFileURL],
+            origin: .manual,
+            slotStrategy: .reuseEmptySlotForFirst,
+            materializationStrategy: .loadAll
+        ))
+
+        let documentID = try #require(harness.controller.documents.first?.id)
+        #expect(harness.controller.selectedDocumentID == documentID)
+        #expect(harness.controller.selectedReaderStore.document.documentLoadState == .ready)
+
+        // Re-selecting the already-ready document should not regress it into loading.
+        harness.controller.selectDocument(documentID)
+        await Task.yield()
+
+        #expect(harness.controller.selectedReaderStore.document.documentLoadState == .ready)
+        #expect(harness.controller.selectedFileURL?.path == harness.primaryFileURL.path)
+    }
 }

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -1347,12 +1347,10 @@ struct ReaderSidebarDocumentControllerTests {
         // Trigger the code path `FavoriteWorkspaceController.discoverNewFilesForFavorite` uses.
         harness.controller.selectDocumentWithNewestModificationDate()
 
-        // `scheduleLoadWithOverlay` defers the materialization one run-loop turn.
-        await Task.yield()
-        await Task.yield()
-
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            !harness.controller.selectedReaderStore.document.isDeferredDocument
+        })
         #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.secondaryFileURL.path)
-        #expect(!harness.controller.selectedReaderStore.document.isDeferredDocument)
     }
 
     /// Guards the ready-state path: re-selecting an already materialized document


### PR DESCRIPTION
## Summary

Fixes #345 — opening a favorite sometimes left the sidebar showing the newest `.md` file as selected while the content area stayed empty. Clicking any other file and back was the only workaround.

## Root cause

`FavoriteWorkspaceController.discoverNewFilesForFavorite` appends new files with `slotStrategy: .alwaysAppend` + `materializationStrategy: .deferOnly`, which leaves `selectedDocumentID` pointing at the last-appended doc (set inside `FileOpenPlanExecutor.executePlan`). It then calls `selectDocumentWithNewestModificationDate()`. When the newest-by-modtime doc matches the already-selected doc, the early-return guard in `ReaderSidebarDocumentController.selectDocument`

```swift
if selectedDocumentID == documentID { return }
```

skipped the materialization branch. The document stayed deferred and no HTML was rendered.

## Fix

`minimark/Stores/ReaderSidebarDocumentController.swift` — make the guard fall through when the currently-selected store is still deferred, so re-selection reliably triggers materialization. Re-selecting an already-ready document remains a true no-op (no observer rebind).

## Test plan

- [x] New test `sidebarControllerMaterializesNewestDeferredDocumentWhenSelectionDoesNotChange` reproduces the bug (fails without the fix, passes with it).
- [x] New test `sidebarControllerReselectingLoadedDocumentDoesNotReenterLoadingState` guards the no-op path for already-materialized documents.
- [x] Full `minimarkTests` suite: 1006 tests pass.
- [x] Debug build succeeds.
- [x] Manual verification: open a favorite with `openAllMarkdownFiles` + a newer external file added after the favorite was saved; the newest file should render immediately.