### PR TITLE
Refactor: collapse overlay subview parameters into config structs (closes #340)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -100,13 +100,15 @@ struct ContentView: View {
 
     private var utilityRail: some View {
         ContentUtilityRailView(
-            hasFile: viewModel.document.fileURL != nil,
-            documentViewMode: viewModel.sourceEditing.documentViewMode,
-            showEditButton: viewModel.showSourceEditingControls && !viewModel.sourceEditing.isSourceEditing,
-            canStartSourceEditing: viewModel.document.hasOpenDocument
-                && !viewModel.document.isCurrentFileMissing
-                && !viewModel.sourceEditing.isSourceEditing,
-            hasTOCHeadings: !viewModel.toc.headings.isEmpty,
+            state: ContentUtilityRailState(
+                hasFile: viewModel.document.fileURL != nil,
+                documentViewMode: viewModel.sourceEditing.documentViewMode,
+                showEditButton: viewModel.showSourceEditingControls && !viewModel.sourceEditing.isSourceEditing,
+                canStartSourceEditing: viewModel.document.hasOpenDocument
+                    && !viewModel.document.isCurrentFileMissing
+                    && !viewModel.sourceEditing.isSourceEditing,
+                hasTOCHeadings: !viewModel.toc.headings.isEmpty
+            ),
             isTOCVisible: Binding(
                 get: { viewModel.toc.isVisible },
                 set: { viewModel.toc.isVisible = $0 }
@@ -122,10 +124,12 @@ struct ContentView: View {
 
     private var changeNavigationOverlay: some View {
         ChangeNavigationOverlayView(
-            canNavigate: viewModel.canNavigateChangedRegions,
-            currentIndex: viewModel.surfaceViewModel.changeNavigation.currentIndex,
-            totalCount: viewModel.document.changedRegions.count,
-            topPadding: viewModel.overlayLayout.insets.leadingOverlayTopPadding,
+            state: ChangeNavigationState(
+                canNavigate: viewModel.canNavigateChangedRegions,
+                currentIndex: viewModel.surfaceViewModel.changeNavigation.currentIndex,
+                totalCount: viewModel.document.changedRegions.count
+            ),
+            insets: viewModel.overlayLayout.insets,
             colorScheme: viewModel.overlayColorScheme,
             settingsStore: viewModel.settingsStore,
             onNavigate: viewModel.requestChangeNavigation
@@ -134,13 +138,14 @@ struct ContentView: View {
 
     private var watchPillOverlay: some View {
         WatchPillOverlayView(
-            activeFolderWatch: viewModel.folderWatchState.activeFolderWatch,
-            isCurrentWatchAFavorite: viewModel.folderWatchState.isCurrentWatchAFavorite,
-            canStop: viewModel.folderWatchState.canStopFolderWatch,
-            isAppearanceLocked: viewModel.folderWatchState.isAppearanceLocked,
-            topPadding: viewModel.overlayLayout.insets.leadingOverlayTopPadding,
-            leadingPadding: viewModel.canNavigateChangedRegions ? 150 : 60,
-            trailingPadding: 70,
+            state: WatchPillState(
+                activeFolderWatch: viewModel.folderWatchState.activeFolderWatch,
+                isCurrentWatchAFavorite: viewModel.folderWatchState.isCurrentWatchAFavorite,
+                canStop: viewModel.folderWatchState.canStopFolderWatch,
+                isAppearanceLocked: viewModel.folderWatchState.isAppearanceLocked
+            ),
+            insets: viewModel.overlayLayout.insets,
+            hasChangeNavigation: viewModel.canNavigateChangedRegions,
             colorScheme: viewModel.overlayColorScheme,
             onAction: viewModel.dispatchWatchPillAction
         )

--- a/minimark/Support/ReaderOverlayInsetCalculator.swift
+++ b/minimark/Support/ReaderOverlayInsetCalculator.swift
@@ -5,12 +5,20 @@ struct ReaderOverlayInsetValues: Equatable {
     let railTopPadding: CGFloat
     let leadingOverlayTopPadding: CGFloat
     let scrollTargetTopInset: CGFloat
+    let watchPillLeadingWithChangeNav: CGFloat
+    let watchPillLeadingWithoutChangeNav: CGFloat
+    let watchPillTrailing: CGFloat
+    let changeNavigationLeadingPadding: CGFloat
 }
 
 enum ReaderOverlayInsetCalculator {
     static let overlayBaseGap: CGFloat = 8
     static let leadingOverlayAlignmentAdjustment: CGFloat = 8
     static let overlayControlHeight: CGFloat = 30
+
+    static let watchPillLeadingWithChangeNav: CGFloat = 150
+    static let watchPillLeadingWithoutChangeNav: CGFloat = 60
+    static let watchPillTrailing: CGFloat = 70
 
     static let scrollLandingGap: CGFloat = {
         if let raw = Bundle.main.object(forInfoDictionaryKey: "ScrollLandingGap") as? String,
@@ -37,7 +45,11 @@ enum ReaderOverlayInsetCalculator {
         return ReaderOverlayInsetValues(
             railTopPadding: railTopPadding,
             leadingOverlayTopPadding: leadingOverlayTopPadding,
-            scrollTargetTopInset: scrollTargetTopInset
+            scrollTargetTopInset: scrollTargetTopInset,
+            watchPillLeadingWithChangeNav: watchPillLeadingWithChangeNav,
+            watchPillLeadingWithoutChangeNav: watchPillLeadingWithoutChangeNav,
+            watchPillTrailing: watchPillTrailing,
+            changeNavigationLeadingPadding: leadingOverlayAlignmentAdjustment
         )
     }
 }

--- a/minimark/Support/ReaderOverlayInsetCalculator.swift
+++ b/minimark/Support/ReaderOverlayInsetCalculator.swift
@@ -19,6 +19,7 @@ enum ReaderOverlayInsetCalculator {
     static let watchPillLeadingWithChangeNav: CGFloat = 150
     static let watchPillLeadingWithoutChangeNav: CGFloat = 60
     static let watchPillTrailing: CGFloat = 70
+    static let changeNavigationLeadingPadding: CGFloat = 8
 
     static let scrollLandingGap: CGFloat = {
         if let raw = Bundle.main.object(forInfoDictionaryKey: "ScrollLandingGap") as? String,
@@ -49,7 +50,7 @@ enum ReaderOverlayInsetCalculator {
             watchPillLeadingWithChangeNav: watchPillLeadingWithChangeNav,
             watchPillLeadingWithoutChangeNav: watchPillLeadingWithoutChangeNav,
             watchPillTrailing: watchPillTrailing,
-            changeNavigationLeadingPadding: leadingOverlayAlignmentAdjustment
+            changeNavigationLeadingPadding: changeNavigationLeadingPadding
         )
     }
 }

--- a/minimark/Views/Content/ChangeNavigationOverlayView.swift
+++ b/minimark/Views/Content/ChangeNavigationOverlayView.swift
@@ -1,26 +1,24 @@
 import SwiftUI
 
 struct ChangeNavigationOverlayView: View {
-    let canNavigate: Bool
-    let currentIndex: Int?
-    let totalCount: Int
-    let topPadding: CGFloat
+    let state: ChangeNavigationState
+    let insets: ReaderOverlayInsetValues
     let colorScheme: ColorScheme
     let settingsStore: ReaderSettingsStore
     let onNavigate: (ReaderChangedRegionNavigationDirection) -> Void
 
     var body: some View {
-        if canNavigate {
+        if state.canNavigate {
             ChangeNavigationPill(
-                currentIndex: currentIndex,
-                totalCount: totalCount,
+                currentIndex: state.currentIndex,
+                totalCount: state.totalCount,
                 onNavigate: onNavigate
             )
             .firstUseHint(.changeNavigation,
                           message: "Use the arrows to step through changes",
                           settingsStore: settingsStore)
-            .padding(.top, topPadding)
-            .padding(.leading, 8)
+            .padding(.top, insets.leadingOverlayTopPadding)
+            .padding(.leading, insets.changeNavigationLeadingPadding)
             .environment(\.colorScheme, colorScheme)
             .transition(.overlayPill)
         }

--- a/minimark/Views/Content/ChangeNavigationState.swift
+++ b/minimark/Views/Content/ChangeNavigationState.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ChangeNavigationState {
+    let canNavigate: Bool
+    let currentIndex: Int?
+    let totalCount: Int
+}

--- a/minimark/Views/Content/ContentUtilityRailState.swift
+++ b/minimark/Views/Content/ContentUtilityRailState.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ContentUtilityRailState {
+    let hasFile: Bool
+    let documentViewMode: ReaderDocumentViewMode
+    let showEditButton: Bool
+    let canStartSourceEditing: Bool
+    let hasTOCHeadings: Bool
+}

--- a/minimark/Views/Content/ContentUtilityRailView.swift
+++ b/minimark/Views/Content/ContentUtilityRailView.swift
@@ -1,24 +1,20 @@
 import SwiftUI
 
 struct ContentUtilityRailView: View {
-    let hasFile: Bool
-    let documentViewMode: ReaderDocumentViewMode
-    let showEditButton: Bool
-    let canStartSourceEditing: Bool
-    let hasTOCHeadings: Bool
+    let state: ContentUtilityRailState
     @Binding var isTOCVisible: Bool
     let onSetDocumentViewMode: (ReaderDocumentViewMode) -> Void
     let onStartSourceEditing: () -> Void
 
     var body: some View {
         ContentUtilityRail(
-            hasFile: hasFile,
-            documentViewMode: documentViewMode,
-            showEditButton: showEditButton,
-            canStartSourceEditing: canStartSourceEditing,
+            hasFile: state.hasFile,
+            documentViewMode: state.documentViewMode,
+            showEditButton: state.showEditButton,
+            canStartSourceEditing: state.canStartSourceEditing,
             onSetDocumentViewMode: onSetDocumentViewMode,
             onStartSourceEditing: onStartSourceEditing,
-            hasTOCHeadings: hasTOCHeadings,
+            hasTOCHeadings: state.hasTOCHeadings,
             isTOCVisible: $isTOCVisible
         )
     }

--- a/minimark/Views/Content/WatchPillOverlayView.swift
+++ b/minimark/Views/Content/WatchPillOverlayView.swift
@@ -1,28 +1,26 @@
 import SwiftUI
 
 struct WatchPillOverlayView: View {
-    let activeFolderWatch: FolderWatchSession?
-    let isCurrentWatchAFavorite: Bool
-    let canStop: Bool
-    let isAppearanceLocked: Bool
-    let topPadding: CGFloat
-    let leadingPadding: CGFloat
-    let trailingPadding: CGFloat
+    let state: WatchPillState
+    let insets: ReaderOverlayInsetValues
+    let hasChangeNavigation: Bool
     let colorScheme: ColorScheme
     let onAction: (WatchPillAction) -> Void
 
     var body: some View {
-        if let activeWatch = activeFolderWatch {
+        if let activeWatch = state.activeFolderWatch {
             WatchPill(
                 activeFolderWatch: activeWatch,
-                isCurrentWatchAFavorite: isCurrentWatchAFavorite,
-                canStop: canStop,
-                isAppearanceLocked: isAppearanceLocked,
+                isCurrentWatchAFavorite: state.isCurrentWatchAFavorite,
+                canStop: state.canStop,
+                isAppearanceLocked: state.isAppearanceLocked,
                 onAction: onAction
             )
-            .padding(.top, topPadding)
-            .padding(.leading, leadingPadding)
-            .padding(.trailing, trailingPadding)
+            .padding(.top, insets.leadingOverlayTopPadding)
+            .padding(.leading, hasChangeNavigation
+                ? insets.watchPillLeadingWithChangeNav
+                : insets.watchPillLeadingWithoutChangeNav)
+            .padding(.trailing, insets.watchPillTrailing)
             .environment(\.colorScheme, colorScheme)
             .transition(.overlayPill)
         }

--- a/minimark/Views/Content/WatchPillState.swift
+++ b/minimark/Views/Content/WatchPillState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct WatchPillState {
+    let activeFolderWatch: FolderWatchSession?
+    let isCurrentWatchAFavorite: Bool
+    let canStop: Bool
+    let isAppearanceLocked: Bool
+}

--- a/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
+++ b/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
@@ -59,4 +59,56 @@ struct ReaderOverlayInsetCalculatorTests {
         let padding = ReaderOverlayInsetCalculator.statusBannerTopPadding(topBarInset: -10)
         #expect(padding == 0)
     }
+
+    @Test func emitsWatchPillLeadingWithChangeNav() {
+        let result = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 44,
+            hasStatusBanner: false
+        )
+
+        #expect(result.watchPillLeadingWithChangeNav == 150)
+    }
+
+    @Test func emitsWatchPillLeadingWithoutChangeNav() {
+        let result = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 44,
+            hasStatusBanner: false
+        )
+
+        #expect(result.watchPillLeadingWithoutChangeNav == 60)
+    }
+
+    @Test func emitsWatchPillTrailing() {
+        let result = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 44,
+            hasStatusBanner: false
+        )
+
+        #expect(result.watchPillTrailing == 70)
+    }
+
+    @Test func changeNavigationLeadingPaddingMatchesLeadingAlignmentAdjustment() {
+        let result = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 44,
+            hasStatusBanner: false
+        )
+
+        #expect(result.changeNavigationLeadingPadding == ReaderOverlayInsetCalculator.leadingOverlayAlignmentAdjustment)
+    }
+
+    @Test func watchPillAndChangeNavInsetsAreConstantAcrossTopBarConfigurations() {
+        let withBanner = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 66,
+            hasStatusBanner: true
+        )
+        let withoutBanner = ReaderOverlayInsetCalculator.compute(
+            topBarInset: 44,
+            hasStatusBanner: false
+        )
+
+        #expect(withBanner.watchPillLeadingWithChangeNav == withoutBanner.watchPillLeadingWithChangeNav)
+        #expect(withBanner.watchPillLeadingWithoutChangeNav == withoutBanner.watchPillLeadingWithoutChangeNav)
+        #expect(withBanner.watchPillTrailing == withoutBanner.watchPillTrailing)
+        #expect(withBanner.changeNavigationLeadingPadding == withoutBanner.changeNavigationLeadingPadding)
+    }
 }

--- a/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
+++ b/minimarkTests/Core/ReaderOverlayInsetCalculatorTests.swift
@@ -87,13 +87,13 @@ struct ReaderOverlayInsetCalculatorTests {
         #expect(result.watchPillTrailing == 70)
     }
 
-    @Test func changeNavigationLeadingPaddingMatchesLeadingAlignmentAdjustment() {
+    @Test func emitsChangeNavigationLeadingPadding() {
         let result = ReaderOverlayInsetCalculator.compute(
             topBarInset: 44,
             hasStatusBanner: false
         )
 
-        #expect(result.changeNavigationLeadingPadding == ReaderOverlayInsetCalculator.leadingOverlayAlignmentAdjustment)
+        #expect(result.changeNavigationLeadingPadding == 8)
     }
 
     @Test func watchPillAndChangeNavInsetsAreConstantAcrossTopBarConfigurations() {


### PR DESCRIPTION
## Summary
- Bundles state fields on the three overlay subviews (`WatchPillOverlayView`, `ChangeNavigationOverlayView`, `ContentUtilityRailView`) into small config structs (`WatchPillState`, `ChangeNavigationState`, `ContentUtilityRailState`), bringing each view down to ≤ 5 parameters.
- Moves the magic padding constants (`150`, `60`, `70`, `8`) off `ContentView.swift` onto `ReaderOverlayInsetValues` / `ReaderOverlayInsetCalculator`, where the other overlay insets already live.
- No user-visible behaviour change.

## Acceptance criteria
- [x] Each overlay subview takes ≤ 5 parameters.
- [x] Magic padding numbers live on `ReaderOverlayInsetValues` alongside `leadingOverlayTopPadding`.
- [x] No user-visible behaviour change.
- [x] Unit tests for the new inset fields on `ReaderOverlayInsetCalculator`.

Closes #340.

## Test plan
- [x] `xcodebuild ... build` — succeeds.
- [x] Unit tests pass (`minimarkTests`): all existing tests plus 5 new ones covering the added inset fields.
- [ ] Manual smoke: launch app, confirm watch pill + change-nav pill overlays still render at their previous positions.