### PR TITLE
Refactor: extract FolderChangeFailureReporter (closes #336)

### DIFF
--- a/minimark/Services/FolderChangeFailureReporter.swift
+++ b/minimark/Services/FolderChangeFailureReporter.swift
@@ -1,0 +1,81 @@
+import Foundation
+import OSLog
+
+struct FolderChangeWatcherFailure: Equatable, Sendable {
+    enum Stage: String, Equatable, Sendable {
+        case startupSnapshot
+        case verificationSnapshot
+        case watchedDirectoryEnumeration
+    }
+
+    let stage: Stage
+    let folderIdentifier: String
+    let errorDescription: String
+}
+
+struct FolderChangeFailureReporter: Sendable {
+    typealias FailureHandler = @Sendable (FolderChangeWatcherFailure) -> Void
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
+        category: "FolderChangeWatcher"
+    )
+
+    let onFailure: FailureHandler?
+    private var lastReportedFailureByStage: [FolderChangeWatcherFailure.Stage: String] = [:]
+
+    init(onFailure: FailureHandler? = nil) {
+        self.onFailure = onFailure
+    }
+
+    mutating func report(
+        stage: FolderChangeWatcherFailure.Stage,
+        folderURL: URL,
+        error: any Error
+    ) {
+        let errorDescription = Self.sanitizedErrorDescription(for: error)
+        let failure = FolderChangeWatcherFailure(
+            stage: stage,
+            folderIdentifier: Self.sanitizedFolderIdentifier(for: folderURL),
+            errorDescription: errorDescription
+        )
+
+        let signature = Self.stableErrorKey(for: error)
+        guard lastReportedFailureByStage[stage] != signature else {
+            return
+        }
+        lastReportedFailureByStage[stage] = signature
+
+        Self.logger.error(
+            "folder watch failure stage=\(stage.rawValue, privacy: .public) folder=\(folderURL.path, privacy: .private(mask: .hash)) error=\(errorDescription, privacy: .private(mask: .hash))"
+        )
+
+        let onFailure = self.onFailure
+        DispatchQueue.main.async {
+            onFailure?(failure)
+        }
+    }
+
+    mutating func clearReportedFailure(for stage: FolderChangeWatcherFailure.Stage) {
+        lastReportedFailureByStage.removeValue(forKey: stage)
+    }
+
+    mutating func resetAllReportedFailures() {
+        lastReportedFailureByStage.removeAll()
+    }
+
+    private static func sanitizedFolderIdentifier(for folderURL: URL) -> String {
+        let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
+        return String(normalizedPath.hashValue, radix: 16)
+    }
+
+    private static func sanitizedErrorDescription(for error: any Error) -> String {
+        let nsError = error as NSError
+        return "domain: \(nsError.domain), code: \(nsError.code)"
+    }
+
+    private static func stableErrorKey(for error: any Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain)#\(nsError.code)"
+    }
+}

--- a/minimark/Services/FolderChangeWatcher.swift
+++ b/minimark/Services/FolderChangeWatcher.swift
@@ -45,18 +45,6 @@ extension FolderChangeWatching {
     }
 }
 
-struct FolderChangeWatcherFailure: Equatable, Sendable {
-    enum Stage: String, Equatable, Sendable {
-        case startupSnapshot
-        case verificationSnapshot
-        case watchedDirectoryEnumeration
-    }
-
-    let stage: Stage
-    let folderIdentifier: String
-    let errorDescription: String
-}
-
 final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     struct ScanProgress: Equatable, Sendable {
         let completed: Int
@@ -65,10 +53,6 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     }
 
     private static let queueKey = DispatchSpecificKey<ObjectIdentifier>()
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "minimark",
-        category: "FolderChangeWatcher"
-    )
     private static let signposter = OSSignposter(
         subsystem: Bundle.main.bundleIdentifier ?? "minimark",
         category: "FolderWatchProfiling"
@@ -77,7 +61,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     private let snapshotDiffer: FolderSnapshotDiffing
     private let verificationDelay: DispatchTimeInterval
     private let makeEventSource: (_ includeSubfolders: Bool) -> any FolderEventSource
-    private let onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)?
+    private var failureReporter: FolderChangeFailureReporter
     private var eventSource: (any FolderEventSource)?
     private var pendingWorkItem: DispatchWorkItem?
     private var pendingChangedDirectoryURLs: Set<URL>?
@@ -89,23 +73,10 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
     private var exclusionMatcher: FolderWatchExclusionMatcher?
     private var onMarkdownFilesAddedOrChanged: (([FolderWatchChangeEvent]) -> Void)?
     private var lastSnapshot: [URL: FolderFileSnapshot] = [:]
-    private var lastReportedFailureByStage: [FolderChangeWatcherFailure.Stage: String] = [:]
     private var startupSequence: UInt64 = 0
     private var didCompleteStartup = false
     private var scanProgressContinuation: AsyncStream<ScanProgress>.Continuation?
     private var _scanProgressStream: AsyncStream<ScanProgress>?
-
-    convenience init(
-        verificationDelay: DispatchTimeInterval = .milliseconds(75),
-        onFailure: (@Sendable (FolderChangeWatcherFailure) -> Void)? = nil
-    ) {
-        self.init(
-            snapshotDiffer: FolderSnapshotDiffer(),
-            verificationDelay: verificationDelay,
-            makeEventSource: { FolderEventSourceFactory.makeEventSource(includeSubfolders: $0) },
-            onFailure: onFailure
-        )
-    }
 
     init(
         snapshotDiffer: FolderSnapshotDiffing = FolderSnapshotDiffer(),
@@ -117,7 +88,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         self.snapshotDiffer = snapshotDiffer
         self.verificationDelay = verificationDelay
         self.makeEventSource = makeEventSource
-        self.onFailure = onFailure
+        self.failureReporter = FolderChangeFailureReporter(onFailure: onFailure)
         queue.setSpecific(key: Self.queueKey, value: ObjectIdentifier(self))
     }
 
@@ -152,7 +123,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             )
             self.onMarkdownFilesAddedOrChanged = onMarkdownFilesAddedOrChanged
             lastSnapshot = [:]
-            lastReportedFailureByStage = [:]
+            failureReporter.resetAllReportedFailures()
             didCompleteStartup = false
 
             let (stream, continuation) = AsyncStream.makeStream(of: ScanProgress.self)
@@ -188,7 +159,7 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
             self.exclusionMatcher = nil
             self.onMarkdownFilesAddedOrChanged = nil
             self.lastSnapshot = [:]
-            self.lastReportedFailureByStage = [:]
+            self.failureReporter.resetAllReportedFailures()
             self.didCompleteStartup = false
             self.scanProgressContinuation?.finish()
             self.scanProgressContinuation = nil
@@ -220,11 +191,11 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
                 includeSubfolders: includeSubfolders,
                 excludedSubdirectoryURLs: excludedSubdirectoryURLs
             )
-            clearReportedFailure(for: .startupSnapshot)
+            failureReporter.clearReportedFailure(for: .startupSnapshot)
         } catch {
             // Keep startup resilient by preserving empty-baseline behavior while surfacing the failure.
             snapshot = [:]
-            reportFailure(stage: .startupSnapshot, folderURL: folderURL, error: error)
+            failureReporter.report(stage: .startupSnapshot, folderURL: folderURL, error: error)
         }
 
         guard startupSequence == self.startupSequence else {
@@ -417,9 +388,9 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
                 "snapshotCounts",
                 "current \(currentSnapshot.count) previous \(self.lastSnapshot.count) include_subfolders \(self.includesSubfolders ? 1 : 0)"
             )
-            clearReportedFailure(for: .verificationSnapshot)
+            failureReporter.clearReportedFailure(for: .verificationSnapshot)
         } catch {
-            reportFailure(stage: .verificationSnapshot, folderURL: watchedFolderURL, error: error)
+            failureReporter.report(stage: .verificationSnapshot, folderURL: watchedFolderURL, error: error)
             return
         }
 
@@ -443,44 +414,4 @@ final class FolderChangeWatcher: FolderChangeWatching, @unchecked Sendable {
         }
     }
 
-    private func reportFailure(stage: FolderChangeWatcherFailure.Stage, folderURL: URL, error: any Error) {
-        let errorDescription = sanitizedErrorDescription(for: error)
-        let failure = FolderChangeWatcherFailure(
-            stage: stage,
-            folderIdentifier: sanitizedFolderIdentifier(for: folderURL),
-            errorDescription: errorDescription
-        )
-
-        let signature = stableErrorKey(for: error)
-        if lastReportedFailureByStage[stage] != signature {
-            lastReportedFailureByStage[stage] = signature
-            Self.logger.error(
-                "folder watch failure stage=\(stage.rawValue, privacy: .public) folder=\(folderURL.path, privacy: .private(mask: .hash)) error=\(errorDescription, privacy: .private(mask: .hash))"
-            )
-
-            let onFailure = self.onFailure
-            DispatchQueue.main.async {
-                onFailure?(failure)
-            }
-        }
-    }
-
-    private func clearReportedFailure(for stage: FolderChangeWatcherFailure.Stage) {
-        lastReportedFailureByStage.removeValue(forKey: stage)
-    }
-
-    private func sanitizedFolderIdentifier(for folderURL: URL) -> String {
-        let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
-        return String(normalizedPath.hashValue, radix: 16)
-    }
-
-    private func sanitizedErrorDescription(for error: any Error) -> String {
-        let nsError = error as NSError
-        return "domain: \(nsError.domain), code: \(nsError.code)"
-    }
-
-    private func stableErrorKey(for error: any Error) -> String {
-        let nsError = error as NSError
-        return "\(nsError.domain)#\(nsError.code)"
-    }
 }

--- a/minimarkTests/FolderWatch/FolderChangeFailureReporterTests.swift
+++ b/minimarkTests/FolderWatch/FolderChangeFailureReporterTests.swift
@@ -157,18 +157,10 @@ struct FolderChangeFailureReporterTests {
         #expect(identifiers[0] == identifiers[1])
     }
 
-    @Test func reportWithoutHandlerStillUpdatesDedupState() async throws {
+    @Test func reportWithoutHandlerDoesNotCrash() async throws {
         var reporter = FolderChangeFailureReporter(onFailure: nil)
         reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
         reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
-
-        let collector = FailureCollector()
-        // New reporter with a handler to prove clearing allows delivery.
-        var observedReporter = FolderChangeFailureReporter(onFailure: { failure in
-            collector.append(failure, isMainThread: Thread.isMainThread)
-        })
-        observedReporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
-        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 1 })
     }
 }
 

--- a/minimarkTests/FolderWatch/FolderChangeFailureReporterTests.swift
+++ b/minimarkTests/FolderWatch/FolderChangeFailureReporterTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite("FolderChangeFailureReporter")
+@MainActor
+struct FolderChangeFailureReporterTests {
+
+    private static let folderURL = URL(fileURLWithPath: "/private/tmp/folder-change-reporter-tests")
+
+    private func makeError(domain: String = "TestDomain", code: Int = 42) -> NSError {
+        NSError(domain: domain, code: code, userInfo: nil)
+    }
+
+    @Test func reportDeliversFailureOnMainThreadWithSanitizedFields() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 1 })
+
+        let failure = try #require(collector.first)
+        #expect(failure.stage == .startupSnapshot)
+        #expect(!failure.folderIdentifier.contains("/"))
+        #expect(!failure.folderIdentifier.contains(Self.folderURL.path))
+        #expect(failure.errorDescription == "domain: TestDomain, code: 42")
+        #expect(collector.allObservedOnMainThread)
+    }
+
+    @Test func reportDeduplicatesRepeatedFailuresWithSameSignatureForSameStage() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 1 })
+
+        // Give any spurious extra dispatches a chance to arrive before asserting deduplication.
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(collector.count == 1)
+    }
+
+    @Test func reportEmitsSeparateFailuresWhenErrorSignatureChanges() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError(code: 1))
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError(code: 1))
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError(code: 2))
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError(domain: "OtherDomain", code: 2))
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 3 })
+        let descriptions = collector.snapshot.map(\.errorDescription)
+        #expect(descriptions == [
+            "domain: TestDomain, code: 1",
+            "domain: TestDomain, code: 2",
+            "domain: OtherDomain, code: 2"
+        ])
+    }
+
+    @Test func reportDedupIsTrackedPerStage() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .watchedDirectoryEnumeration, folderURL: Self.folderURL, error: makeError())
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 3 })
+        #expect(collector.snapshot.map(\.stage) == [
+            .startupSnapshot,
+            .verificationSnapshot,
+            .watchedDirectoryEnumeration
+        ])
+    }
+
+    @Test func clearReportedFailureForStageAllowsNextIdenticalErrorThrough() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 1 })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(collector.count == 1)
+
+        reporter.clearReportedFailure(for: .startupSnapshot)
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 2 })
+    }
+
+    @Test func clearReportedFailureDoesNotAffectOtherStages() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 2 })
+
+        reporter.clearReportedFailure(for: .startupSnapshot)
+
+        // Verification stage still deduplicated.
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(collector.count == 2)
+    }
+
+    @Test func resetAllReportedFailuresClearsEveryStage() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 2 })
+
+        reporter.resetAllReportedFailures()
+
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .verificationSnapshot, folderURL: Self.folderURL, error: makeError())
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 4 })
+    }
+
+    @Test func sanitizedFolderIdentifierIsStableForEquivalentURLs() async throws {
+        let collector = FailureCollector()
+        var reporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+
+        let resolvedURL = Self.folderURL.resolvingSymlinksInPath()
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError(code: 1))
+        reporter.clearReportedFailure(for: .startupSnapshot)
+        reporter.report(stage: .startupSnapshot, folderURL: resolvedURL, error: makeError(code: 1))
+
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 2 })
+        let identifiers = collector.snapshot.map(\.folderIdentifier)
+        #expect(identifiers.count == 2)
+        #expect(identifiers[0] == identifiers[1])
+    }
+
+    @Test func reportWithoutHandlerStillUpdatesDedupState() async throws {
+        var reporter = FolderChangeFailureReporter(onFailure: nil)
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        reporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+
+        let collector = FailureCollector()
+        // New reporter with a handler to prove clearing allows delivery.
+        var observedReporter = FolderChangeFailureReporter(onFailure: { failure in
+            collector.append(failure, isMainThread: Thread.isMainThread)
+        })
+        observedReporter.report(stage: .startupSnapshot, folderURL: Self.folderURL, error: makeError())
+        #expect(await waitUntil(timeout: .seconds(1)) { collector.count == 1 })
+    }
+}
+
+private final class FailureCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var failures: [FolderChangeWatcherFailure] = []
+    private var mainThreadFlags: [Bool] = []
+
+    func append(_ failure: FolderChangeWatcherFailure, isMainThread: Bool) {
+        lock.lock()
+        failures.append(failure)
+        mainThreadFlags.append(isMainThread)
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return failures.count
+    }
+
+    var first: FolderChangeWatcherFailure? {
+        lock.lock()
+        defer { lock.unlock() }
+        return failures.first
+    }
+
+    var snapshot: [FolderChangeWatcherFailure] {
+        lock.lock()
+        defer { lock.unlock() }
+        return failures
+    }
+
+    var allObservedOnMainThread: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return mainThreadFlags.allSatisfy { $0 }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts failure reporting, path sanitization, and stage-keyed deduplication out of `FolderChangeWatcher` into a new `FolderChangeFailureReporter` struct.
- `FolderChangeWatcher.swift`: 486 → 417 lines; removes five methods, one piece of mutable state (`lastReportedFailureByStage`), and the failure-specific `Logger`.
- Also drops a redundant convenience init whose parameters were a strict subset of the designated init's defaulted parameters, and colocates `FolderChangeWatcherFailure` with the reporter that emits it.

Closes #336.

## Acceptance criteria

- [x] New type `FolderChangeFailureReporter` with unit tests covering dedup + sanitization (9 new tests in `FolderChangeFailureReporterTests`).
- [x] `FolderChangeWatcher` no longer references `lastReportedFailureByStage` directly.
- [x] `FolderChangeWatcher.swift` ≤ 420 lines (417).
- [x] Existing `FolderWatch` test suite still passes.
- [x] No observable change in reported failures — both integration tests that verify main-thread delivery and stage-keyed dedup (`folderChangeWatcherFailureCallbacksArriveOnMainThreadAndDeduplicateRepeatedVerificationErrors`, `folderChangeWatcherSignalsStartupSnapshotFailureAndRecoversAfterFolderAppears`) still pass.

## Test plan

- [x] `xcodebuild build`
- [x] All FolderWatch-related suites pass (`FileRoutingAndWatcherTests`, `FolderChangeWatcherScanProgressTests`, `FolderEventSourceTests`, `FolderWatchExclusionLogicTests`, `EditFolderWatchExclusionsTests`, `FolderWatchControllerScanProgressTests`, `FolderWatchControllerUpdateExclusionsTests`, `FolderWatchCoordinationTests`, `FolderWatchFileSelectionModelTests`)
- [x] Full `minimarkTests` suite passes
- [x] New `FolderChangeFailureReporterTests` suite: 9 tests pass (dedup per stage, clear, reset-all, sanitization stability, delivery on main thread, handling of nil handler)