### PR TITLE
Refactor: centralize accessibility identifiers and UI-test summary

### DIFF
--- a/minimark.xcodeproj/project.pbxproj
+++ b/minimark.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		461922502F5ABC7E00DD137D /* minimark */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B10000000000000000000001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = minimark; sourceTree = "<group>"; };
 		461922602F5ABC8000DD137D /* minimarkTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = minimarkTests; sourceTree = "<group>"; };
 		4619226A2F5ABC8000DD137D /* minimarkUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = minimarkUITests; sourceTree = "<group>"; };
+		B20000000000000000000001 /* minimarkShared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = minimarkShared; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +83,7 @@
 			children = (
 				C10000000000000000000013 /* Config */,
 				461922502F5ABC7E00DD137D /* minimark */,
+				B20000000000000000000001 /* minimarkShared */,
 				461922602F5ABC8000DD137D /* minimarkTests */,
 				4619226A2F5ABC8000DD137D /* minimarkUITests */,
 				4619224F2F5ABC7E00DD137D /* Products */,
@@ -124,6 +126,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				461922502F5ABC7E00DD137D /* minimark */,
+				B20000000000000000000001 /* minimarkShared */,
 			);
 			name = minimark;
 			packageProductDependencies = (
@@ -171,6 +174,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				4619226A2F5ABC8000DD137D /* minimarkUITests */,
+				B20000000000000000000001 /* minimarkShared */,
 			);
 			name = minimarkUITests;
 			packageProductDependencies = (

--- a/minimark/Stores/Types/ReaderStoreTypes.swift
+++ b/minimark/Stores/Types/ReaderStoreTypes.swift
@@ -1,44 +1,5 @@
 import Foundation
 
-enum ReaderDocumentViewMode: String, CaseIterable, Sendable {
-    case preview
-    case split
-    case source
-
-    var displayName: String {
-        switch self {
-        case .preview:
-            return "Preview"
-        case .split:
-            return "Split"
-        case .source:
-            return "Source"
-        }
-    }
-
-    var systemImageName: String {
-        switch self {
-        case .preview:
-            return "doc.richtext"
-        case .split:
-            return "rectangle.split.2x1"
-        case .source:
-            return "text.alignleft"
-        }
-    }
-
-    var next: ReaderDocumentViewMode {
-        switch self {
-        case .preview:
-            return .split
-        case .split:
-            return .source
-        case .source:
-            return .preview
-        }
-    }
-}
-
 enum ReaderDocumentLoadState: Equatable, Sendable {
     case ready
     case loading

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -117,9 +117,16 @@ final class ContentAreaViewModel {
             && (sourceEditing.documentViewMode != .preview || sourceEditing.isSourceEditing)
     }
 
+    var previewAccessibilitySummary: ReaderPreviewAccessibilitySummary {
+        ReaderPreviewAccessibilitySummary(
+            fileName: document.fileURL?.lastPathComponent ?? "none",
+            regionCount: document.changedRegions.count,
+            mode: sourceEditing.documentViewMode
+        )
+    }
+
     var previewAccessibilityValue: String {
-        let fileName = document.fileURL?.lastPathComponent ?? "none"
-        return "file=\(fileName)|regions=\(document.changedRegions.count)|mode=\(sourceEditing.documentViewMode.rawValue)|surface=preview"
+        previewAccessibilitySummary.description
     }
 
     var isUITestModeEnabled: Bool {

--- a/minimark/Views/Content/ContentUtilityRail.swift
+++ b/minimark/Views/Content/ContentUtilityRail.swift
@@ -162,7 +162,7 @@ struct ContentUtilityRail: View {
         .buttonStyle(.plain)
         .foregroundStyle(isActive ? .primary : .secondary)
         .help("Table of Contents (⇧⌘T)")
-        .accessibilityIdentifier("toc-button")
+        .accessibilityIdentifier(.tocButton)
         .accessibilityLabel("Table of Contents")
         .accessibilityValue(isTOCVisible.wrappedValue ? "Visible" : "Hidden")
         .anchorPreference(key: TOCButtonAnchorKey.self, value: .bounds) { $0 }

--- a/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
+++ b/minimark/Views/Content/ContentViewUITestAccessibilityLabel.swift
@@ -15,7 +15,7 @@ struct ContentViewUITestAccessibilityLabel: View {
                 .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
                 .padding(6)
                 .allowsHitTesting(false)
-                .accessibilityIdentifier("reader-preview-summary")
+                .accessibilityIdentifier(.readerPreviewSummary)
                 .accessibilityLabel("Reader preview summary")
                 .accessibilityValue(value)
         }

--- a/minimark/Views/Content/FolderWatchFileSelectionSheet.swift
+++ b/minimark/Views/Content/FolderWatchFileSelectionSheet.swift
@@ -178,14 +178,14 @@ struct FolderWatchFileSelectionSheet: View {
                 Button("Skip") {
                     onSkip()
                 }
-                .accessibilityIdentifier("file-selection-skip-button")
+                .accessibilityIdentifier(.fileSelectionSkipButton)
                 .buttonStyle(FolderWatchSecondaryActionButtonStyle())
                 .keyboardShortcut(.cancelAction)
 
                 Button(openButtonTitle) {
                     onConfirm(Array(model.selectedFileURLs))
                 }
-                .accessibilityIdentifier("file-selection-open-button")
+                .accessibilityIdentifier(.fileSelectionOpenButton)
                 .buttonStyle(FolderWatchPrimaryActionButtonStyle(tint: .accentColor))
                 .controlSize(.regular)
                 .keyboardShortcut(.defaultAction)

--- a/minimark/Views/Content/FolderWatchOptionsSheet.swift
+++ b/minimark/Views/Content/FolderWatchOptionsSheet.swift
@@ -193,7 +193,7 @@ struct FolderWatchOptionsSheet: View {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
             )
-            .accessibilityIdentifier("folder-watch-summary-card")
+            .accessibilityIdentifier(.folderWatchSummaryCard)
 
             // MARK: Option rows
             VStack(spacing: 0) {
@@ -325,7 +325,7 @@ struct FolderWatchOptionsSheet: View {
                 Button("Cancel") {
                     onCancel()
                 }
-                .accessibilityIdentifier("folder-watch-cancel-button")
+                .accessibilityIdentifier(.folderWatchCancelButton)
                 .buttonStyle(FolderWatchSecondaryActionButtonStyle())
                 .keyboardShortcut(.cancelAction)
 
@@ -338,7 +338,7 @@ struct FolderWatchOptionsSheet: View {
                         Text("Start Watching")
                     }
                 }
-                .accessibilityIdentifier("folder-watch-start-button")
+                .accessibilityIdentifier(.folderWatchStartButton)
                 .buttonStyle(FolderWatchPrimaryActionButtonStyle(tint: .accentColor))
                 .controlSize(.regular)
                 .keyboardShortcut(.defaultAction)
@@ -349,7 +349,7 @@ struct FolderWatchOptionsSheet: View {
         .padding(24)
         .frame(width: Metrics.width)
         .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("folder-watch-sheet")
+        .accessibilityIdentifier(.folderWatchSheet)
         .onAppear {
             syncViewModel()
             scheduleDirectoryScanRefresh()
@@ -629,7 +629,7 @@ struct FolderWatchLargeTreeWarningCard: View {
                     } label: {
                         Label("Choose subdirectories to deactivate", systemImage: "line.3.horizontal.decrease.circle")
                     }
-                    .accessibilityIdentifier("folder-watch-choose-subdirectories-button")
+                    .accessibilityIdentifier(.folderWatchChooseSubdirectoriesButton)
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                 }
@@ -856,7 +856,7 @@ private struct LargeFolderExclusionDialog: View {
                 Button("Start Watching") {
                     onConfirm()
                 }
-                .accessibilityIdentifier("folder-watch-dialog-start-button")
+                .accessibilityIdentifier(.folderWatchDialogStartButton)
                 .buttonStyle(
                     FolderWatchPrimaryActionButtonStyle(
                         tint: remainingToDeactivateCount == 0 ? .accentColor : .orange

--- a/minimark/Views/Content/ReaderTopBarComponents.swift
+++ b/minimark/Views/Content/ReaderTopBarComponents.swift
@@ -56,7 +56,7 @@ struct FolderWatchToolbarButton: View {
             }
             .buttonStyle(.plain)
             .help(isActive ? "Watch a different folder (⌥⌘W)" : "Watch Folder… (⌥⌘W)")
-            .accessibilityIdentifier("folder-watch-toolbar-button")
+            .accessibilityIdentifier(.folderWatchToolbarButton)
             .accessibilityLabel("Watch folder")
             .accessibilityValue(isActive ? "Active" : "Inactive")
             .accessibilityHint("Opens the folder picker for starting folder watch")
@@ -156,7 +156,7 @@ struct FolderWatchToolbarButton: View {
                     isMenuPresented = false
                     onAction(.editFavoriteWatchedFolders)
                 }
-                .accessibilityIdentifier("edit-favorites-button")
+                .accessibilityIdentifier(.editFavoritesButton)
                 .buttonStyle(.plain)
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)

--- a/minimark/Views/FolderWatchAutoOpenFlowView.swift
+++ b/minimark/Views/FolderWatchAutoOpenFlowView.swift
@@ -333,13 +333,13 @@ private struct FolderWatchAutoOpenWarningSheet: View {
                 Button("Keep Current Files") {
                     onKeepCurrentFiles()
                 }
-                .accessibilityIdentifier("auto-open-keep-current-button")
+                .accessibilityIdentifier(.autoOpenKeepCurrentButton)
                 .keyboardShortcut(.cancelAction)
 
                 Button("Select More Files") {
                     onSelectMoreFiles()
                 }
-                .accessibilityIdentifier("auto-open-select-more-button")
+                .accessibilityIdentifier(.autoOpenSelectMoreButton)
                 .keyboardShortcut(.defaultAction)
             }
         }

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -478,7 +478,7 @@ private struct ReaderSidebarDocumentRow: View {
         )
         .animation(.easeInOut(duration: 0.15), value: isSelected)
         .padding(.vertical, 2)
-        .accessibilityIdentifier("sidebar-document-\(title)")
+        .accessibilityIdentifier(ReaderAccessibilityID.sidebarDocument(title: title))
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
@@ -787,7 +787,7 @@ private struct SidebarGroupListContent: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 6)
         }
-        .accessibilityIdentifier("sidebar-column")
+        .accessibilityIdentifier(.sidebarColumn)
     }
 
     private func groupedSection(
@@ -1050,7 +1050,7 @@ private struct SidebarPinnableGroupHeader: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
-        .accessibilityIdentifier("sidebar-group-toggle")
+        .accessibilityIdentifier(.sidebarGroupToggle)
         .accessibilityLabel(isExpanded ? "Collapse group" : "Expand group")
         .accessibilityValue(groupDisplayName)
     }

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -403,7 +403,7 @@ struct ReaderWindowRootView: View {
                     }
                     .help(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
                     .accessibilityLabel(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
-                    .accessibilityIdentifier("sidebar-placement-toggle")
+                    .accessibilityIdentifier(.sidebarPlacementToggle)
                 }
             }
         }

--- a/minimarkShared/ReaderAccessibilityID.swift
+++ b/minimarkShared/ReaderAccessibilityID.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Every accessibility identifier used by production views and `minimarkUITests`
+/// goes through this enum. UI tests reach the raw values via `@testable import minimark`.
+enum ReaderAccessibilityID: String {
+    case readerPreviewSummary = "reader-preview-summary"
+    case tocButton = "toc-button"
+    case sidebarColumn = "sidebar-column"
+    case sidebarGroupToggle = "sidebar-group-toggle"
+    case sidebarPlacementToggle = "sidebar-placement-toggle"
+    case folderWatchToolbarButton = "folder-watch-toolbar-button"
+    case editFavoritesButton = "edit-favorites-button"
+    case folderWatchSheet = "folder-watch-sheet"
+    case folderWatchSummaryCard = "folder-watch-summary-card"
+    case folderWatchCancelButton = "folder-watch-cancel-button"
+    case folderWatchStartButton = "folder-watch-start-button"
+    case folderWatchDialogStartButton = "folder-watch-dialog-start-button"
+    case folderWatchChooseSubdirectoriesButton = "folder-watch-choose-subdirectories-button"
+    case fileSelectionSkipButton = "file-selection-skip-button"
+    case fileSelectionOpenButton = "file-selection-open-button"
+    case autoOpenKeepCurrentButton = "auto-open-keep-current-button"
+    case autoOpenSelectMoreButton = "auto-open-select-more-button"
+
+    static func sidebarDocument(title: String) -> String {
+        "sidebar-document-\(title)"
+    }
+}
+
+extension View {
+    func accessibilityIdentifier(_ id: ReaderAccessibilityID) -> some View {
+        accessibilityIdentifier(id.rawValue)
+    }
+}

--- a/minimarkShared/ReaderDocumentViewMode.swift
+++ b/minimarkShared/ReaderDocumentViewMode.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum ReaderDocumentViewMode: String, CaseIterable, Sendable {
+    case preview
+    case split
+    case source
+
+    var displayName: String {
+        switch self {
+        case .preview:
+            return "Preview"
+        case .split:
+            return "Split"
+        case .source:
+            return "Source"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .preview:
+            return "doc.richtext"
+        case .split:
+            return "rectangle.split.2x1"
+        case .source:
+            return "text.alignleft"
+        }
+    }
+
+    var next: ReaderDocumentViewMode {
+        switch self {
+        case .preview:
+            return .split
+        case .split:
+            return .source
+        case .source:
+            return .preview
+        }
+    }
+}

--- a/minimarkShared/ReaderPreviewAccessibilitySummary.swift
+++ b/minimarkShared/ReaderPreviewAccessibilitySummary.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Typed representation of the accessibility value carried by the reader
+/// preview surface. Producer and consumer both round-trip through this type so
+/// a change in one side is a build-time error on the other.
+struct ReaderPreviewAccessibilitySummary: Equatable, CustomStringConvertible {
+    enum Surface: String {
+        case preview
+    }
+
+    let fileName: String
+    let regionCount: Int
+    let mode: ReaderDocumentViewMode
+    let surface: Surface
+
+    init(
+        fileName: String,
+        regionCount: Int,
+        mode: ReaderDocumentViewMode,
+        surface: Surface = .preview
+    ) {
+        self.fileName = fileName
+        self.regionCount = regionCount
+        self.mode = mode
+        self.surface = surface
+    }
+
+    var description: String {
+        "file=\(fileName)|regions=\(regionCount)|mode=\(mode.rawValue)|surface=\(surface.rawValue)"
+    }
+
+    init?(rawValue: String) {
+        var fields: [String: String] = [:]
+        for component in rawValue.split(separator: "|", omittingEmptySubsequences: false) {
+            guard let equalsIndex = component.firstIndex(of: "=") else { return nil }
+            let key = String(component[..<equalsIndex])
+            let value = String(component[component.index(after: equalsIndex)...])
+            fields[key] = value
+        }
+
+        guard
+            let fileName = fields["file"],
+            let regionsRaw = fields["regions"],
+            let regionCount = Int(regionsRaw),
+            let modeRaw = fields["mode"],
+            let mode = ReaderDocumentViewMode(rawValue: modeRaw),
+            let surfaceRaw = fields["surface"],
+            let surface = Surface(rawValue: surfaceRaw)
+        else {
+            return nil
+        }
+
+        self.init(fileName: fileName, regionCount: regionCount, mode: mode, surface: surface)
+    }
+}

--- a/minimarkTests/Core/ReaderAccessibilityIDTests.swift
+++ b/minimarkTests/Core/ReaderAccessibilityIDTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite
+struct ReaderAccessibilityIDTests {
+
+    // Raw values are part of the UI-test contract. A change here is a breaking
+    // change to external UI tests and must be made deliberately.
+    @Test func rawValuesAreStable() {
+        let expected: [(ReaderAccessibilityID, String)] = [
+            (.readerPreviewSummary, "reader-preview-summary"),
+            (.tocButton, "toc-button"),
+            (.sidebarColumn, "sidebar-column"),
+            (.sidebarGroupToggle, "sidebar-group-toggle"),
+            (.sidebarPlacementToggle, "sidebar-placement-toggle"),
+            (.folderWatchToolbarButton, "folder-watch-toolbar-button"),
+            (.editFavoritesButton, "edit-favorites-button"),
+            (.folderWatchSheet, "folder-watch-sheet"),
+            (.folderWatchSummaryCard, "folder-watch-summary-card"),
+            (.folderWatchCancelButton, "folder-watch-cancel-button"),
+            (.folderWatchStartButton, "folder-watch-start-button"),
+            (.folderWatchDialogStartButton, "folder-watch-dialog-start-button"),
+            (.folderWatchChooseSubdirectoriesButton, "folder-watch-choose-subdirectories-button"),
+            (.fileSelectionSkipButton, "file-selection-skip-button"),
+            (.fileSelectionOpenButton, "file-selection-open-button"),
+            (.autoOpenKeepCurrentButton, "auto-open-keep-current-button"),
+            (.autoOpenSelectMoreButton, "auto-open-select-more-button"),
+        ]
+
+        for (id, raw) in expected {
+            #expect(id.rawValue == raw)
+        }
+    }
+
+    @Test func sidebarDocumentIdentifierMatchesLegacyFormat() {
+        #expect(ReaderAccessibilityID.sidebarDocument(title: "notes.md") == "sidebar-document-notes.md")
+    }
+}

--- a/minimarkTests/Core/ReaderPreviewAccessibilitySummaryTests.swift
+++ b/minimarkTests/Core/ReaderPreviewAccessibilitySummaryTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite
+struct ReaderPreviewAccessibilitySummaryTests {
+
+    @Test func descriptionMatchesLegacyFormat() {
+        let summary = ReaderPreviewAccessibilitySummary(
+            fileName: "notes.md",
+            regionCount: 3,
+            mode: .split
+        )
+
+        #expect(summary.description == "file=notes.md|regions=3|mode=split|surface=preview")
+    }
+
+    @Test func descriptionEscapesNothingForPlainFilenames() {
+        let summary = ReaderPreviewAccessibilitySummary(
+            fileName: "none",
+            regionCount: 0,
+            mode: .preview
+        )
+
+        #expect(summary.description == "file=none|regions=0|mode=preview|surface=preview")
+    }
+
+    @Test func roundTripRecoversOriginalValue() {
+        let original = ReaderPreviewAccessibilitySummary(
+            fileName: "auto-open.md",
+            regionCount: 7,
+            mode: .source
+        )
+
+        let parsed = ReaderPreviewAccessibilitySummary(rawValue: original.description)
+
+        #expect(parsed == original)
+    }
+
+    @Test func parsesEachSupportedMode() {
+        for mode in ReaderDocumentViewMode.allCases {
+            let raw = "file=x.md|regions=0|mode=\(mode.rawValue)|surface=preview"
+            let parsed = ReaderPreviewAccessibilitySummary(rawValue: raw)
+
+            #expect(parsed?.mode == mode, "failed for \(mode)")
+        }
+    }
+
+    @Test func parsesFilenameContainingSpaces() {
+        let parsed = ReaderPreviewAccessibilitySummary(
+            rawValue: "file=my notes.md|regions=2|mode=preview|surface=preview"
+        )
+
+        #expect(parsed?.fileName == "my notes.md")
+        #expect(parsed?.regionCount == 2)
+    }
+
+    @Test func rejectsMissingKey() {
+        let parsed = ReaderPreviewAccessibilitySummary(
+            rawValue: "file=x.md|regions=0|surface=preview"
+        )
+
+        #expect(parsed == nil)
+    }
+
+    @Test func rejectsUnknownMode() {
+        let parsed = ReaderPreviewAccessibilitySummary(
+            rawValue: "file=x.md|regions=0|mode=banana|surface=preview"
+        )
+
+        #expect(parsed == nil)
+    }
+
+    @Test func rejectsNonIntegerRegionCount() {
+        let parsed = ReaderPreviewAccessibilitySummary(
+            rawValue: "file=x.md|regions=many|mode=preview|surface=preview"
+        )
+
+        #expect(parsed == nil)
+    }
+
+    @Test func rejectsUnknownSurface() {
+        let parsed = ReaderPreviewAccessibilitySummary(
+            rawValue: "file=x.md|regions=0|mode=preview|surface=mystery"
+        )
+
+        #expect(parsed == nil)
+    }
+}

--- a/minimarkUITests/minimarkUITests.swift
+++ b/minimarkUITests/minimarkUITests.swift
@@ -7,10 +7,10 @@
 import XCTest
 
 final class minimarkUITests: XCTestCase {
-    private let watchFolderSheetIdentifier = "folder-watch-sheet"
-    private let cancelButtonIdentifier = "folder-watch-cancel-button"
-    private let startButtonIdentifier = "folder-watch-start-button"
-    private let previewSummaryIdentifier = "reader-preview-summary"
+    private let watchFolderSheetIdentifier = ReaderAccessibilityID.folderWatchSheet.rawValue
+    private let cancelButtonIdentifier = ReaderAccessibilityID.folderWatchCancelButton.rawValue
+    private let startButtonIdentifier = ReaderAccessibilityID.folderWatchStartButton.rawValue
+    private let previewSummaryIdentifier = ReaderAccessibilityID.readerPreviewSummary.rawValue
     private let uiTestModeArgument = "-minimark-ui-test"
     private let presentWatchFolderSheetArgument = "-minimark-present-watch-folder-sheet"
     private let autoStartWatchFolderArgument = "-minimark-auto-start-watch-folder"
@@ -20,7 +20,9 @@ final class minimarkUITests: XCTestCase {
     private let reviewExclusionsButtonTitle = "Choose subdirectories to deactivate"
     private let deactivateAllButtonTitle = "Deactivate All"
     private let startWatchingAnywayButtonTitle = "Start Watching Anyway"
-    private let dialogStartButtonIdentifier = "folder-watch-dialog-start-button"
+    private let dialogStartButtonIdentifier = ReaderAccessibilityID.folderWatchDialogStartButton.rawValue
+    private let sidebarGroupToggleIdentifier = ReaderAccessibilityID.sidebarGroupToggle.rawValue
+    private let sidebarColumnIdentifier = ReaderAccessibilityID.sidebarColumn.rawValue
     private let simulateGroupedSidebarArgument = "-minimark-simulate-grouped-sidebar"
 
     override func setUpWithError() throws {
@@ -73,14 +75,14 @@ final class minimarkUITests: XCTestCase {
 
         let preview = app.descendants(matching: .any).matching(identifier: previewSummaryIdentifier).firstMatch
         XCTAssertTrue(preview.waitForExistence(timeout: 5))
-        waitForElement(preview, valueContaining: "file=auto-open.md", timeout: 8)
+        waitForPreviewSummary(preview, matching: { $0.fileName == "auto-open.md" }, timeout: 8)
 
-        waitForElement(preview, valueNotContaining: "regions=0", timeout: 12)
-        waitForElement(preview, valueContaining: "file=auto-open.md", timeout: 8)
+        waitForPreviewSummary(preview, matching: { $0.regionCount > 0 }, timeout: 12)
+        waitForPreviewSummary(preview, matching: { $0.fileName == "auto-open.md" }, timeout: 8)
 
-        let previewValue = preview.value as? String
-        XCTAssertNotNil(previewValue)
-        XCTAssertFalse(previewValue?.contains("regions=0") ?? true)
+        let parsed = currentPreviewSummary(preview)
+        XCTAssertNotNil(parsed)
+        XCTAssertGreaterThan(parsed?.regionCount ?? 0, 0)
     }
 
     @MainActor
@@ -116,7 +118,7 @@ final class minimarkUITests: XCTestCase {
 
         let preview = app.descendants(matching: .any).matching(identifier: previewSummaryIdentifier).firstMatch
         XCTAssertTrue(preview.waitForExistence(timeout: 5))
-        waitForElement(preview, valueContaining: "file=none", timeout: 3)
+        waitForPreviewSummary(preview, matching: { $0.fileName == "none" }, timeout: 3)
     }
 
     @MainActor
@@ -188,7 +190,7 @@ final class minimarkUITests: XCTestCase {
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
         app.launch()
 
-        let groupToggles = app.buttons.matching(identifier: "sidebar-group-toggle")
+        let groupToggles = app.buttons.matching(identifier: sidebarGroupToggleIdentifier)
         waitForCondition(timeout: 8) {
             groupToggles.count >= 3
         }
@@ -196,7 +198,8 @@ final class minimarkUITests: XCTestCase {
         XCTAssertGreaterThanOrEqual(groupToggles.count, 3, "Should have at least 3 folder groups")
 
         let groupPredicate = NSPredicate(
-            format: "identifier == 'sidebar-group-toggle' AND (value CONTAINS[c] 'project' OR value CONTAINS[c] 'docs' OR value CONTAINS[c] 'plans')"
+            format: "identifier == %@ AND (value CONTAINS[c] 'project' OR value CONTAINS[c] 'docs' OR value CONTAINS[c] 'plans')",
+            sidebarGroupToggleIdentifier
         )
         let groupHeaders = app.buttons.matching(groupPredicate)
         XCTAssertGreaterThanOrEqual(groupHeaders.count, 2, "Should show disambiguated folder group headers")
@@ -218,7 +221,7 @@ final class minimarkUITests: XCTestCase {
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
         app.launch()
 
-        let customToggle = app.buttons.matching(identifier: "sidebar-group-toggle").firstMatch
+        let customToggle = app.buttons.matching(identifier: sidebarGroupToggleIdentifier).firstMatch
         XCTAssertTrue(customToggle.waitForExistence(timeout: 8), "Grouped sidebar should expose custom group toggle buttons")
     }
 
@@ -233,7 +236,7 @@ final class minimarkUITests: XCTestCase {
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 10), "Window should appear")
 
-        let groupToggles = app.buttons.matching(identifier: "sidebar-group-toggle")
+        let groupToggles = app.buttons.matching(identifier: sidebarGroupToggleIdentifier)
         waitForCondition(timeout: 10) {
             groupToggles.count >= 3
         }
@@ -266,7 +269,7 @@ final class minimarkUITests: XCTestCase {
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
         app.launch()
 
-        let sidebar = app.scrollViews.matching(identifier: "sidebar-column").firstMatch
+        let sidebar = app.scrollViews.matching(identifier: sidebarColumnIdentifier).firstMatch
         XCTAssertTrue(sidebar.waitForExistence(timeout: 8), "Sidebar should appear")
 
         waitForCondition(timeout: 8) {
@@ -328,16 +331,26 @@ final class minimarkUITests: XCTestCase {
         return directoryURL
     }
 
-    private func waitForElement(_ element: XCUIElement, valueContaining substring: String, timeout: TimeInterval) {
-        let predicate = NSPredicate(format: "value CONTAINS %@", substring)
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed)
+    private func currentPreviewSummary(_ element: XCUIElement) -> ReaderPreviewAccessibilitySummary? {
+        guard let raw = element.value as? String else { return nil }
+        return ReaderPreviewAccessibilitySummary(rawValue: raw)
     }
 
-    private func waitForElement(_ element: XCUIElement, valueNotContaining substring: String, timeout: TimeInterval) {
-        let predicate = NSPredicate(format: "NOT (value CONTAINS %@)", substring)
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed)
+    private func waitForPreviewSummary(
+        _ element: XCUIElement,
+        matching predicate: @escaping (ReaderPreviewAccessibilitySummary) -> Bool,
+        timeout: TimeInterval
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let summary = currentPreviewSummary(element), predicate(summary) {
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        XCTFail(
+            "Preview summary did not match within \(timeout)s (last value: \(String(describing: element.value)))"
+        )
     }
 
     private func waitForCondition(timeout: TimeInterval, condition: @escaping () -> Bool) {


### PR DESCRIPTION
Closes #341.

## Summary

- New `ReaderAccessibilityID` enum collects every identifier consumed by production views and `minimarkUITests`. Call sites now use `.accessibilityIdentifier(.caseName)` via a `View` overload; the dynamic `sidebar-document-<title>` goes through `ReaderAccessibilityID.sidebarDocument(title:)`.
- New `ReaderPreviewAccessibilitySummary` value type replaces the hand-concatenated `file=…|regions=…|mode=…|surface=preview` string. Producer builds it; `CustomStringConvertible.description` serializes; `init?(rawValue:)` parses back. The serialized form is byte-identical to the legacy output, so no visible change and UI tests keep matching.
- UI tests now parse the preview value through the shared type (`waitForPreviewSummary(_:matching:timeout:)`) instead of substring-checking the serialized form.

## Project layout

A new synchronized top-level group `minimarkShared/` holds the three types that must be visible to both targets (`ReaderAccessibilityID`, `ReaderPreviewAccessibilitySummary`, `ReaderDocumentViewMode`). It is referenced from `minimark` and `minimarkUITests` via `fileSystemSynchronizedGroups`, so the same source compiles into both targets — no `@testable import` link-time hop required. `ReaderDocumentViewMode` moved from `minimark/Stores/Types/ReaderStoreTypes.swift` to the shared group with no functional change.

## Tests

- New `ReaderPreviewAccessibilitySummaryTests` covers description format, round-trip, per-mode parsing, filenames with spaces, and each rejection path (missing key, unknown mode, non-integer regions, unknown surface).
- New `ReaderAccessibilityIDTests` freezes the raw-value mapping so a rename in one target can't silently desync the other.
- Full `minimarkTests` suite passes locally.
- `minimarkUITests` compiles cleanly (out-of-scope for this PR — see #337 for pre-existing UI-test failures this work was meant to guard against).

## Test plan
- [x] `xcodebuild build`
- [x] `xcodebuild test -only-testing:minimarkTests`
- [x] `xcodebuild build-for-testing -scheme minimarkUITests`