### PR TITLE
Refactor: drop Reader prefix from Models/ (batch 1 of #355)

### DIFF
--- a/minimark/Commands/ReaderCommands.swift
+++ b/minimark/Commands/ReaderCommands.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct ReaderCommands: Commands {
     var settingsStore: ReaderSettingsStore
-    let multiFileDisplayMode: ReaderMultiFileDisplayMode
+    let multiFileDisplayMode: MultiFileDisplayMode
 
     @Environment(\.openWindow) private var openWindow
     @FocusedValue(\.readerOpenDocument) private var openDocument
@@ -218,9 +218,9 @@ struct ReaderCommands: Commands {
         }
     }
 
-    private func openRecentOpenedFile(_ entry: ReaderRecentOpenedFile) {
+    private func openRecentOpenedFile(_ entry: RecentOpenedFile) {
         guard let targetWindowNumber else {
-            openWindow(value: ReaderWindowSeed(recentOpenedFile: entry))
+            openWindow(value: WindowSeed(recentOpenedFile: entry))
             return
         }
 
@@ -235,9 +235,9 @@ struct ReaderCommands: Commands {
         )
     }
 
-    private func startRecentWatchedFolder(_ entry: ReaderRecentWatchedFolder) {
+    private func startRecentWatchedFolder(_ entry: RecentWatchedFolder) {
         guard let targetWindowNumber else {
-            openWindow(value: ReaderWindowSeed(recentWatchedFolder: entry))
+            openWindow(value: WindowSeed(recentWatchedFolder: entry))
             return
         }
 
@@ -284,7 +284,7 @@ struct ReaderCommands: Commands {
 
     private func openMarkdownInNewWindow(_ url: URL) {
         settingsStore.addRecentManuallyOpenedFile(url)
-        openWindow(value: ReaderWindowSeed(fileURL: url))
+        openWindow(value: WindowSeed(fileURL: url))
     }
 
     private var targetWindowNumber: Int? {

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -180,12 +180,12 @@ struct ContentView: View {
         settingsStore: settingsStore,
         requestWatchedFolderReauthorization: { _ in nil }
     )
-    let fileDeps = ReaderFileDependencies(
+    let fileDeps = FileDependencies(
         watcher: FileChangeWatcher(),
         io: ReaderDocumentIOService(),
         actions: ReaderFileActionService()
     )
-    let renderingDeps = ReaderRenderingDependencies(
+    let renderingDeps = RenderingDependencies(
         renderer: MarkdownRenderingService(),
         differ: ChangedRegionDiffer()
     )

--- a/minimark/Models/AmberTerminalTheme.swift
+++ b/minimark/Models/AmberTerminalTheme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum AmberTerminalTheme {
     static let definition = ThemeDefinition(
         kind: .amberTerminal,
-        displayName: ReaderThemeKind.amberTerminal.displayName,
-        colors: ReaderTheme.theme(for: .amberTerminal),
+        displayName: ThemeKind.amberTerminal.displayName,
+        colors: Theme.theme(for: .amberTerminal),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: true,

--- a/minimark/Models/Commodore64Theme.swift
+++ b/minimark/Models/Commodore64Theme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum Commodore64Theme {
     static let definition = ThemeDefinition(
         kind: .commodore64,
-        displayName: ReaderThemeKind.commodore64.displayName,
-        colors: ReaderTheme.theme(for: .commodore64),
+        displayName: ThemeKind.commodore64.displayName,
+        colors: Theme.theme(for: .commodore64),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: true,

--- a/minimark/Models/Dependencies.swift
+++ b/minimark/Models/Dependencies.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct ReaderRenderingDependencies {
+struct RenderingDependencies {
     let renderer: MarkdownRendering
     let differ: ChangedRegionDiffering
 }
 
-struct ReaderFileDependencies {
+struct FileDependencies {
     let watcher: FileChangeWatching
     let io: ReaderDocumentIO
     let actions: ReaderFileActionHandling

--- a/minimark/Models/ExternalApplication.swift
+++ b/minimark/Models/ExternalApplication.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ReaderExternalApplication: Identifiable, Hashable, Sendable {
+struct ExternalApplication: Identifiable, Hashable, Sendable {
     let id: String
     let displayName: String
     let bundleIdentifier: String?

--- a/minimark/Models/FavoriteWatchedFolder.swift
+++ b/minimark/Models/FavoriteWatchedFolder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
+nonisolated struct FavoriteWatchedFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
     let id: UUID
     var name: String
     let folderPath: String
@@ -9,7 +9,7 @@ nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Se
     let openDocumentRelativePaths: [String]
     let allKnownRelativePaths: [String]
     let createdAt: Date
-    var workspaceState: ReaderFavoriteWorkspaceState
+    var workspaceState: FavoriteWorkspaceState
 
     nonisolated var folderURL: URL {
         URL(fileURLWithPath: folderPath)
@@ -43,11 +43,11 @@ nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Se
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL] = [],
         allKnownRelativePaths: [String] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         ),
         createdAt: Date = .now
     ) {
@@ -82,11 +82,11 @@ nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Se
         bookmarkData: Data?,
         openDocumentRelativePaths: [String] = [],
         allKnownRelativePaths: [String] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         ),
         createdAt: Date
     ) {
@@ -134,13 +134,13 @@ nonisolated struct ReaderFavoriteWatchedFolder: Equatable, Hashable, Codable, Se
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? .now
 
         workspaceState = try container.decodeIfPresent(
-            ReaderFavoriteWorkspaceState.self,
+            FavoriteWorkspaceState.self,
             forKey: .workspaceState
         ) ?? .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
     }
 
@@ -325,14 +325,14 @@ nonisolated enum ReaderFavoriteHistory {
         folderURL: URL,
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         ),
-        into existingEntries: [ReaderFavoriteWatchedFolder]
-    ) -> [ReaderFavoriteWatchedFolder] {
+        into existingEntries: [FavoriteWatchedFolder]
+    ) -> [FavoriteWatchedFolder] {
         let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
 
         let alreadyExists = existingEntries.contains {
@@ -342,7 +342,7 @@ nonisolated enum ReaderFavoriteHistory {
             return existingEntries
         }
 
-        let newEntry = ReaderFavoriteWatchedFolder(
+        let newEntry = FavoriteWatchedFolder(
             name: name,
             folderURL: folderURL,
             options: options,
@@ -354,19 +354,19 @@ nonisolated enum ReaderFavoriteHistory {
 
     static func removingFavorite(
         id: UUID,
-        from existingEntries: [ReaderFavoriteWatchedFolder]
-    ) -> [ReaderFavoriteWatchedFolder] {
+        from existingEntries: [FavoriteWatchedFolder]
+    ) -> [FavoriteWatchedFolder] {
         existingEntries.filter { $0.id != id }
     }
 
     static func renamingFavorite(
         id: UUID,
         newName: String,
-        in existingEntries: [ReaderFavoriteWatchedFolder]
-    ) -> [ReaderFavoriteWatchedFolder] {
+        in existingEntries: [FavoriteWatchedFolder]
+    ) -> [FavoriteWatchedFolder] {
         existingEntries.map { entry in
             guard entry.id == id else { return entry }
-            return ReaderFavoriteWatchedFolder(
+            return FavoriteWatchedFolder(
                 id: entry.id,
                 name: newName,
                 folderPath: entry.folderPath,
@@ -382,8 +382,8 @@ nonisolated enum ReaderFavoriteHistory {
 
     static func reordering(
         ids orderedIDs: [UUID],
-        in existingEntries: [ReaderFavoriteWatchedFolder]
-    ) -> [ReaderFavoriteWatchedFolder] {
+        in existingEntries: [FavoriteWatchedFolder]
+    ) -> [FavoriteWatchedFolder] {
         let lookup = Dictionary(existingEntries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         var result = orderedIDs.compactMap { lookup[$0] }
         let resultIDs = Set(result.map(\.id))

--- a/minimark/Models/FavoriteWorkspaceState.swift
+++ b/minimark/Models/FavoriteWorkspaceState.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-nonisolated struct ReaderFavoriteWorkspaceState: Equatable, Hashable, Codable, Sendable {
+nonisolated struct FavoriteWorkspaceState: Equatable, Hashable, Codable, Sendable {
     static let defaultSidebarWidth: CGFloat = 250
 
-    var fileSortMode: ReaderSidebarSortMode
-    var groupSortMode: ReaderSidebarSortMode
-    var sidebarPosition: ReaderMultiFileDisplayMode
+    var fileSortMode: SidebarSortMode
+    var groupSortMode: SidebarSortMode
+    var sidebarPosition: MultiFileDisplayMode
     var sidebarWidth: CGFloat
     var pinnedGroupIDs: Set<String>
     var collapsedGroupIDs: Set<String>
@@ -24,9 +24,9 @@ nonisolated struct ReaderFavoriteWorkspaceState: Equatable, Hashable, Codable, S
     }
 
     init(
-        fileSortMode: ReaderSidebarSortMode,
-        groupSortMode: ReaderSidebarSortMode,
-        sidebarPosition: ReaderMultiFileDisplayMode,
+        fileSortMode: SidebarSortMode,
+        groupSortMode: SidebarSortMode,
+        sidebarPosition: MultiFileDisplayMode,
         sidebarWidth: CGFloat,
         pinnedGroupIDs: Set<String>,
         collapsedGroupIDs: Set<String>,
@@ -45,9 +45,9 @@ nonisolated struct ReaderFavoriteWorkspaceState: Equatable, Hashable, Codable, S
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        fileSortMode = try container.decode(ReaderSidebarSortMode.self, forKey: .fileSortMode)
-        groupSortMode = try container.decode(ReaderSidebarSortMode.self, forKey: .groupSortMode)
-        sidebarPosition = try container.decode(ReaderMultiFileDisplayMode.self, forKey: .sidebarPosition)
+        fileSortMode = try container.decode(SidebarSortMode.self, forKey: .fileSortMode)
+        groupSortMode = try container.decode(SidebarSortMode.self, forKey: .groupSortMode)
+        sidebarPosition = try container.decode(MultiFileDisplayMode.self, forKey: .sidebarPosition)
         sidebarWidth = try container.decode(CGFloat.self, forKey: .sidebarWidth)
         pinnedGroupIDs = try container.decode(Set<String>.self, forKey: .pinnedGroupIDs)
         collapsedGroupIDs = try container.decode(Set<String>.self, forKey: .collapsedGroupIDs)
@@ -60,8 +60,8 @@ nonisolated struct ReaderFavoriteWorkspaceState: Equatable, Hashable, Codable, S
         pinnedGroupIDs: Set<String>,
         collapsedGroupIDs: Set<String>,
         sidebarWidth: CGFloat
-    ) -> ReaderFavoriteWorkspaceState {
-        ReaderFavoriteWorkspaceState(
+    ) -> FavoriteWorkspaceState {
+        FavoriteWorkspaceState(
             fileSortMode: settings.sidebarSortMode,
             groupSortMode: settings.sidebarGroupSortMode,
             sidebarPosition: settings.multiFileDisplayMode,

--- a/minimark/Models/FocusTheme.swift
+++ b/minimark/Models/FocusTheme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum FocusTheme {
     static let definition = ThemeDefinition(
         kind: .focus,
-        displayName: ReaderThemeKind.focus.displayName,
-        colors: ReaderTheme.theme(for: .focus),
+        displayName: ThemeKind.focus.displayName,
+        colors: Theme.theme(for: .focus),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: false,

--- a/minimark/Models/GameBoyTheme.swift
+++ b/minimark/Models/GameBoyTheme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum GameBoyTheme {
     static let definition = ThemeDefinition(
         kind: .gameBoy,
-        displayName: ReaderThemeKind.gameBoy.displayName,
-        colors: ReaderTheme.theme(for: .gameBoy),
+        displayName: ThemeKind.gameBoy.displayName,
+        colors: Theme.theme(for: .gameBoy),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: true,

--- a/minimark/Models/GreenTerminalTheme.swift
+++ b/minimark/Models/GreenTerminalTheme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum GreenTerminalTheme {
     static let definition = ThemeDefinition(
         kind: .greenTerminal,
-        displayName: ReaderThemeKind.greenTerminal.displayName,
-        colors: ReaderTheme.theme(for: .greenTerminal),
+        displayName: ThemeKind.greenTerminal.displayName,
+        colors: Theme.theme(for: .greenTerminal),
         customCSS: customCSS,
         customJavaScript: digitalRainJavaScript,
         providesSyntaxHighlighting: true,
@@ -14,8 +14,8 @@ enum GreenTerminalTheme {
 
     static let staticDefinition = ThemeDefinition(
         kind: .greenTerminalStatic,
-        displayName: ReaderThemeKind.greenTerminalStatic.displayName,
-        colors: ReaderTheme.theme(for: .greenTerminalStatic),
+        displayName: ThemeKind.greenTerminalStatic.displayName,
+        colors: Theme.theme(for: .greenTerminalStatic),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: true,

--- a/minimark/Models/LockedAppearance.swift
+++ b/minimark/Models/LockedAppearance.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 nonisolated struct LockedAppearance: Equatable, Hashable, Codable, Sendable {
-    let readerTheme: ReaderThemeKind
+    let readerTheme: ThemeKind
     let baseFontSize: Double
     let syntaxTheme: SyntaxThemeKind
 }

--- a/minimark/Models/MultiFileDisplayMode.swift
+++ b/minimark/Models/MultiFileDisplayMode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated enum ReaderMultiFileDisplayMode: String, CaseIterable, Codable, Sendable {
+nonisolated enum MultiFileDisplayMode: String, CaseIterable, Codable, Sendable {
     case sidebarLeft
     case sidebarRight
 
@@ -35,7 +35,7 @@ nonisolated enum ReaderMultiFileDisplayMode: String, CaseIterable, Codable, Send
         }
     }
 
-    var toggledSidebarPlacementMode: ReaderMultiFileDisplayMode {
+    var toggledSidebarPlacementMode: MultiFileDisplayMode {
         switch self {
         case .sidebarLeft:
             return .sidebarRight
@@ -44,7 +44,7 @@ nonisolated enum ReaderMultiFileDisplayMode: String, CaseIterable, Codable, Send
         }
     }
 
-    func requiresRestart(from launchedMode: ReaderMultiFileDisplayMode) -> Bool {
+    func requiresRestart(from launchedMode: MultiFileDisplayMode) -> Bool {
         false
     }
 
@@ -60,7 +60,7 @@ nonisolated enum ReaderMultiFileDisplayMode: String, CaseIterable, Codable, Send
         default:
             throw DecodingError.dataCorruptedError(
                 in: container,
-                debugDescription: "Unknown ReaderMultiFileDisplayMode raw value: \(rawValue)"
+                debugDescription: "Unknown MultiFileDisplayMode raw value: \(rawValue)"
             )
         }
     }

--- a/minimark/Models/NewspaperTheme.swift
+++ b/minimark/Models/NewspaperTheme.swift
@@ -3,8 +3,8 @@ import Foundation
 enum NewspaperTheme {
     static let definition = ThemeDefinition(
         kind: .newspaper,
-        displayName: ReaderThemeKind.newspaper.displayName,
-        colors: ReaderTheme.theme(for: .newspaper),
+        displayName: ThemeKind.newspaper.displayName,
+        colors: Theme.theme(for: .newspaper),
         customCSS: customCSS,
         customJavaScript: nil,
         providesSyntaxHighlighting: false,

--- a/minimark/Models/PresentableError.swift
+++ b/minimark/Models/PresentableError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ReaderPresentableError: Equatable, Sendable {
+struct PresentableError: Equatable, Sendable {
     enum Kind: Equatable, Sendable {
         case fileRead
         case fileWrite

--- a/minimark/Models/RecentOpenedFile.swift
+++ b/minimark/Models/RecentOpenedFile.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated struct ReaderRecentOpenedFile: Equatable, Hashable, Codable, Sendable, Identifiable {
+nonisolated struct RecentOpenedFile: Equatable, Hashable, Codable, Sendable, Identifiable {
     static let maximumCount = 15
 
     let filePath: String

--- a/minimark/Models/RecentWatchedFolder.swift
+++ b/minimark/Models/RecentWatchedFolder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated struct ReaderRecentWatchedFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
+nonisolated struct RecentWatchedFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
     static let maximumCount = 15
 
     let folderPath: String

--- a/minimark/Models/SidebarGrouping.swift
+++ b/minimark/Models/SidebarGrouping.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @MainActor
-enum ReaderSidebarGrouping: Equatable {
+enum SidebarGrouping: Equatable {
     case flat([ReaderSidebarDocumentController.Document])
     case grouped([Group])
 
@@ -36,12 +36,12 @@ enum ReaderSidebarGrouping: Equatable {
 
     static func group(
         _ documents: [ReaderSidebarDocumentController.Document],
-        sortMode: ReaderSidebarSortMode = .lastChangedNewestFirst,
+        sortMode: SidebarSortMode = .lastChangedNewestFirst,
         directoryOrderSourceDocuments: [ReaderSidebarDocumentController.Document]? = nil,
         pinnedGroupIDs: Set<String> = [],
         precomputedIndicatorStates: [String: [ReaderDocumentIndicatorState]]? = nil,
         precomputedIndicatorPulseTokens: [String: Int]? = nil
-    ) -> ReaderSidebarGrouping {
+    ) -> SidebarGrouping {
         let grouped = Dictionary(grouping: documents) { document -> String in
             directoryURL(for: document)?.path(percentEncoded: false) ?? ""
         }
@@ -172,7 +172,7 @@ enum ReaderSidebarGrouping: Equatable {
         return ordered
     }
 
-    private static func sorted(_ groups: [Group], mode: ReaderSidebarSortMode) -> [Group] {
+    private static func sorted(_ groups: [Group], mode: SidebarSortMode) -> [Group] {
         groups.enumerated()
             .sorted { lhs, rhs in
                 let left = lhs.element

--- a/minimark/Models/SidebarSortMode.swift
+++ b/minimark/Models/SidebarSortMode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated enum ReaderSidebarSortMode: String, Codable, Sendable {
+nonisolated enum SidebarSortMode: String, Codable, Sendable {
     case openOrder
     case nameAscending
     case nameDescending
@@ -8,7 +8,7 @@ nonisolated enum ReaderSidebarSortMode: String, Codable, Sendable {
     case lastChangedOldestFirst
     case manualOrder
 
-    static let allCases: [ReaderSidebarSortMode] = [
+    static let allCases: [SidebarSortMode] = [
         .openOrder,
         .nameAscending,
         .nameDescending,
@@ -16,7 +16,7 @@ nonisolated enum ReaderSidebarSortMode: String, Codable, Sendable {
         .lastChangedOldestFirst
     ]
 
-    static func availableCases(hasManualOrder: Bool) -> [ReaderSidebarSortMode] {
+    static func availableCases(hasManualOrder: Bool) -> [SidebarSortMode] {
         hasManualOrder ? allCases + [.manualOrder] : allCases
     }
 

--- a/minimark/Models/Theme.swift
+++ b/minimark/Models/Theme.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated enum ReaderThemeKind: String, CaseIterable, Codable, Sendable {
+nonisolated enum ThemeKind: String, CaseIterable, Codable, Sendable {
     case blackOnWhite
     case whiteOnBlack
     case darkGreyOnLightGrey
@@ -21,7 +21,7 @@ nonisolated enum ReaderThemeKind: String, CaseIterable, Codable, Sendable {
         let container = try decoder.singleValueContainer()
         let rawValue = try container.decode(String.self)
 
-        if let kind = ReaderThemeKind(rawValue: rawValue) {
+        if let kind = ThemeKind(rawValue: rawValue) {
             self = kind
             return
         }
@@ -36,7 +36,7 @@ nonisolated enum ReaderThemeKind: String, CaseIterable, Codable, Sendable {
         default:
             throw DecodingError.dataCorruptedError(
                 in: container,
-                debugDescription: "Unknown ReaderThemeKind: \(rawValue)"
+                debugDescription: "Unknown ThemeKind: \(rawValue)"
             )
         }
     }
@@ -86,8 +86,8 @@ nonisolated enum ReaderThemeKind: String, CaseIterable, Codable, Sendable {
     }
 }
 
-nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
-    let kind: ReaderThemeKind
+nonisolated struct Theme: Equatable, Codable, Sendable {
+    let kind: ThemeKind
     let backgroundHex: String
     let foregroundHex: String
     let secondaryForegroundHex: String
@@ -103,12 +103,12 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
     let h2Hex: String?
     let h3Hex: String?
 
-    static let `default` = ReaderTheme.theme(for: .blackOnWhite)
+    static let `default` = Theme.theme(for: .blackOnWhite)
 
-    static func theme(for kind: ReaderThemeKind) -> ReaderTheme {
+    static func theme(for kind: ThemeKind) -> Theme {
         switch kind {
         case .blackOnWhite:
-            return ReaderTheme(
+            return Theme(
                 kind: .blackOnWhite,
                 backgroundHex: "#FFFFFF",
                 foregroundHex: "#111111",
@@ -124,7 +124,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .whiteOnBlack:
-            return ReaderTheme(
+            return Theme(
                 kind: .whiteOnBlack,
                 backgroundHex: "#0D0D0D",
                 foregroundHex: "#F5F5F5",
@@ -140,7 +140,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .darkGreyOnLightGrey:
-            return ReaderTheme(
+            return Theme(
                 kind: .darkGreyOnLightGrey,
                 backgroundHex: "#E6E6E6",
                 foregroundHex: "#2A2A2A",
@@ -156,7 +156,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .lightGreyOnDarkGrey:
-            return ReaderTheme(
+            return Theme(
                 kind: .lightGreyOnDarkGrey,
                 backgroundHex: "#2B2B2B",
                 foregroundHex: "#DCDCDC",
@@ -172,7 +172,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .amberTerminal:
-            return ReaderTheme(
+            return Theme(
                 kind: .amberTerminal,
                 backgroundHex: "#1A1200",
                 foregroundHex: "#FFB000",
@@ -188,7 +188,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .greenTerminal, .greenTerminalStatic:
-            return ReaderTheme(
+            return Theme(
                 kind: kind,
                 backgroundHex: "#0D0208",
                 foregroundHex: "#00FF41",
@@ -204,7 +204,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .newspaper:
-            return ReaderTheme(
+            return Theme(
                 kind: .newspaper,
                 backgroundHex: "#FAF7F0",
                 foregroundHex: "#1A1A1A",
@@ -220,7 +220,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .focus:
-            return ReaderTheme(
+            return Theme(
                 kind: .focus,
                 backgroundHex: "#FAFAFA",
                 foregroundHex: "#2C2C2C",
@@ -236,7 +236,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .commodore64:
-            return ReaderTheme(
+            return Theme(
                 kind: .commodore64,
                 backgroundHex: "#40318D",
                 foregroundHex: "#C8C8FF",
@@ -252,7 +252,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .gameBoy:
-            return ReaderTheme(
+            return Theme(
                 kind: .gameBoy,
                 backgroundHex: "#9BBC0F",
                 foregroundHex: "#0F380F",
@@ -268,7 +268,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h1Hex: nil, h2Hex: nil, h3Hex: nil
             )
         case .gruvboxDark:
-            return ReaderTheme(
+            return Theme(
                 kind: .gruvboxDark,
                 backgroundHex: "#282828",
                 foregroundHex: "#EBDBB2",
@@ -286,7 +286,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h3Hex: "#83A598"
             )
         case .gruvboxLight:
-            return ReaderTheme(
+            return Theme(
                 kind: .gruvboxLight,
                 backgroundHex: "#FBF1C7",
                 foregroundHex: "#3C3836",
@@ -304,7 +304,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h3Hex: "#076678"
             )
         case .dracula:
-            return ReaderTheme(
+            return Theme(
                 kind: .dracula,
                 backgroundHex: "#282A36",
                 foregroundHex: "#F8F8F2",
@@ -322,7 +322,7 @@ nonisolated struct ReaderTheme: Equatable, Codable, Sendable {
                 h3Hex: "#8BE9FD"
             )
         case .monokai:
-            return ReaderTheme(
+            return Theme(
                 kind: .monokai,
                 backgroundHex: "#272822",
                 foregroundHex: "#F8F8F2",

--- a/minimark/Models/ThemeDefinition.swift
+++ b/minimark/Models/ThemeDefinition.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 struct ThemeDefinition: Equatable, Sendable {
-    let kind: ReaderThemeKind
+    let kind: ThemeKind
     let displayName: String
-    let colors: ReaderTheme
+    let colors: Theme
     let customCSS: String?
     let customJavaScript: String?
     let providesSyntaxHighlighting: Bool
@@ -11,14 +11,14 @@ struct ThemeDefinition: Equatable, Sendable {
     let syntaxPreviewPalette: SyntaxThemePreviewPalette?
 }
 
-extension ReaderThemeKind {
+extension ThemeKind {
     var themeDefinition: ThemeDefinition {
         switch self {
         case .blackOnWhite, .whiteOnBlack, .darkGreyOnLightGrey, .lightGreyOnDarkGrey, .gruvboxDark, .gruvboxLight, .dracula, .monokai:
             return ThemeDefinition(
                 kind: self,
                 displayName: displayName,
-                colors: ReaderTheme.theme(for: self),
+                colors: Theme.theme(for: self),
                 customCSS: nil,
                 customJavaScript: nil,
                 providesSyntaxHighlighting: false,

--- a/minimark/Models/TrustedImageFolder.swift
+++ b/minimark/Models/TrustedImageFolder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated struct ReaderTrustedImageFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
+nonisolated struct TrustedImageFolder: Equatable, Hashable, Codable, Sendable, Identifiable {
     static let maximumCount = 30
 
     let folderPath: String
@@ -33,10 +33,10 @@ nonisolated struct ReaderTrustedImageFolder: Equatable, Hashable, Codable, Senda
 nonisolated enum ReaderTrustedImageFolderHistory {
     static func insertingUnique(
         _ folderURL: URL,
-        into existingEntries: [ReaderTrustedImageFolder]
-    ) -> [ReaderTrustedImageFolder] {
-        let newEntry = ReaderTrustedImageFolder(folderURL: folderURL)
+        into existingEntries: [TrustedImageFolder]
+    ) -> [TrustedImageFolder] {
+        let newEntry = TrustedImageFolder(folderURL: folderURL)
         let deduplicated = existingEntries.filter { $0.folderPath != newEntry.folderPath }
-        return Array(([newEntry] + deduplicated).prefix(ReaderTrustedImageFolder.maximumCount))
+        return Array(([newEntry] + deduplicated).prefix(TrustedImageFolder.maximumCount))
     }
 }

--- a/minimark/Models/WindowSeed.swift
+++ b/minimark/Models/WindowSeed.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ReaderOpenOrigin: String, Hashable, Codable, Sendable {
+enum OpenOrigin: String, Hashable, Codable, Sendable {
     case manual
     case folderWatchAutoOpen
     case folderWatchInitialBatchAutoOpen
@@ -19,22 +19,22 @@ enum ReaderOpenOrigin: String, Hashable, Codable, Sendable {
     }
 }
 
-struct ReaderWindowSeed: Hashable, Codable, Sendable {
+struct WindowSeed: Hashable, Codable, Sendable {
     let id: UUID
     let filePath: String?
     let folderWatchSession: FolderWatchSession?
-    let recentOpenedFile: ReaderRecentOpenedFile?
-    let recentWatchedFolder: ReaderRecentWatchedFolder?
-    let openOrigin: ReaderOpenOrigin
+    let recentOpenedFile: RecentOpenedFile?
+    let recentWatchedFolder: RecentWatchedFolder?
+    let openOrigin: OpenOrigin
     let initialDiffBaselineMarkdown: String?
 
     init(
         id: UUID = UUID(),
         fileURL: URL? = nil,
         folderWatchSession: FolderWatchSession? = nil,
-        recentOpenedFile: ReaderRecentOpenedFile? = nil,
-        recentWatchedFolder: ReaderRecentWatchedFolder? = nil,
-        openOrigin: ReaderOpenOrigin = .manual,
+        recentOpenedFile: RecentOpenedFile? = nil,
+        recentWatchedFolder: RecentWatchedFolder? = nil,
+        openOrigin: OpenOrigin = .manual,
         initialDiffBaselineMarkdown: String? = nil
     ) {
         self.id = id
@@ -50,7 +50,7 @@ struct ReaderWindowSeed: Hashable, Codable, Sendable {
         id: UUID = UUID(),
         fileURL: URL? = nil,
         folderWatchSession: FolderWatchSession? = nil,
-        openOrigin: ReaderOpenOrigin = .manual,
+        openOrigin: OpenOrigin = .manual,
         initialDiffBaselineMarkdown: String? = nil
     ) {
         self.init(
@@ -79,9 +79,9 @@ struct ReaderWindowSeed: Hashable, Codable, Sendable {
         id = try container.decode(UUID.self, forKey: .id)
         filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
         folderWatchSession = try container.decodeIfPresent(FolderWatchSession.self, forKey: .folderWatchSession)
-        recentOpenedFile = try container.decodeIfPresent(ReaderRecentOpenedFile.self, forKey: .recentOpenedFile)
-        recentWatchedFolder = try container.decodeIfPresent(ReaderRecentWatchedFolder.self, forKey: .recentWatchedFolder)
-        openOrigin = try container.decodeIfPresent(ReaderOpenOrigin.self, forKey: .openOrigin) ?? .manual
+        recentOpenedFile = try container.decodeIfPresent(RecentOpenedFile.self, forKey: .recentOpenedFile)
+        recentWatchedFolder = try container.decodeIfPresent(RecentWatchedFolder.self, forKey: .recentWatchedFolder)
+        openOrigin = try container.decodeIfPresent(OpenOrigin.self, forKey: .openOrigin) ?? .manual
         initialDiffBaselineMarkdown = try container.decodeIfPresent(String.self, forKey: .initialDiffBaselineMarkdown)
     }
 

--- a/minimark/Services/FileOpenCoordinator.swift
+++ b/minimark/Services/FileOpenCoordinator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct FileOpenRequest {
     let fileURLs: [URL]
-    let origin: ReaderOpenOrigin
+    let origin: OpenOrigin
     let folderWatchSession: FolderWatchSession?
     let initialDiffBaselineMarkdownByURL: [URL: String]
     let slotStrategy: SlotStrategy
@@ -10,7 +10,7 @@ struct FileOpenRequest {
 
     init(
         fileURLs: [URL],
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         folderWatchSession: FolderWatchSession? = nil,
         initialDiffBaselineMarkdownByURL: [URL: String] = [:],
         slotStrategy: SlotStrategy = .reuseEmptySlotForFirst,
@@ -66,7 +66,7 @@ struct FileOpenPlan {
     }
 
     let assignments: [SlotAssignment]
-    let origin: ReaderOpenOrigin
+    let origin: OpenOrigin
     let folderWatchSession: FolderWatchSession?
     let materializationStrategy: FileOpenRequest.MaterializationStrategy
 }

--- a/minimark/Services/ReaderFileActionService.swift
+++ b/minimark/Services/ReaderFileActionService.swift
@@ -2,8 +2,8 @@ import AppKit
 import Foundation
 
 protocol ReaderFileActionHandling {
-    func registeredApplications(for fileURL: URL) throws -> [ReaderExternalApplication]
-    func open(fileURL: URL, in application: ReaderExternalApplication?) throws
+    func registeredApplications(for fileURL: URL) throws -> [ExternalApplication]
+    func open(fileURL: URL, in application: ExternalApplication?) throws
     func revealInFinder(fileURL: URL) throws
 }
 
@@ -14,7 +14,7 @@ final class ReaderFileActionService: ReaderFileActionHandling {
         self.workspace = workspace
     }
 
-    func registeredApplications(for fileURL: URL) throws -> [ReaderExternalApplication] {
+    func registeredApplications(for fileURL: URL) throws -> [ExternalApplication] {
         try validateReachableFileURL(fileURL)
 
         return uniquedApplications(
@@ -31,7 +31,7 @@ final class ReaderFileActionService: ReaderFileActionHandling {
             }
     }
 
-    private func uniquedApplications(from applications: [ReaderExternalApplication]) -> [ReaderExternalApplication] {
+    private func uniquedApplications(from applications: [ExternalApplication]) -> [ExternalApplication] {
         var seenIdentifiers = Set<String>()
 
         return applications.filter { application in
@@ -39,7 +39,7 @@ final class ReaderFileActionService: ReaderFileActionHandling {
         }
     }
 
-    func open(fileURL: URL, in application: ReaderExternalApplication?) throws {
+    func open(fileURL: URL, in application: ExternalApplication?) throws {
         try validateReachableFileURL(fileURL)
 
         if let application {
@@ -72,7 +72,7 @@ final class ReaderFileActionService: ReaderFileActionHandling {
         }
     }
 
-    private func mapApplication(bundleURL: URL) -> ReaderExternalApplication? {
+    private func mapApplication(bundleURL: URL) -> ExternalApplication? {
         guard let bundle = Bundle(url: bundleURL) else {
             return nil
         }
@@ -85,7 +85,7 @@ final class ReaderFileActionService: ReaderFileActionHandling {
 
         let identifier = bundleIdentifier ?? bundleURL.path
 
-        return ReaderExternalApplication(
+        return ExternalApplication(
             id: identifier,
             displayName: displayName,
             bundleIdentifier: bundleIdentifier,

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -13,7 +13,7 @@ final class FavoriteWorkspaceController {
     private weak var appearanceController: WindowAppearanceController?
 
     private(set) var activeFavoriteID: UUID?
-    private(set) var activeFavoriteWorkspaceState: ReaderFavoriteWorkspaceState?
+    private(set) var activeFavoriteWorkspaceState: FavoriteWorkspaceState?
 
     var isActive: Bool { activeFavoriteID != nil }
 
@@ -35,7 +35,7 @@ final class FavoriteWorkspaceController {
 
     // MARK: - State Mutations
 
-    func activate(id: UUID, workspaceState: ReaderFavoriteWorkspaceState) {
+    func activate(id: UUID, workspaceState: FavoriteWorkspaceState) {
         activeFavoriteID = id
         activeFavoriteWorkspaceState = workspaceState
     }
@@ -49,7 +49,7 @@ final class FavoriteWorkspaceController {
         activeFavoriteWorkspaceState?.sidebarWidth = width
     }
 
-    func updateSidebarPosition(_ position: ReaderMultiFileDisplayMode) {
+    func updateSidebarPosition(_ position: MultiFileDisplayMode) {
         activeFavoriteWorkspaceState?.sidebarPosition = position
     }
 
@@ -60,8 +60,8 @@ final class FavoriteWorkspaceController {
     func updateGroupState(
         pinnedGroupIDs: Set<String>,
         collapsedGroupIDs: Set<String>,
-        groupSortMode: ReaderSidebarSortMode,
-        fileSortMode: ReaderSidebarSortMode,
+        groupSortMode: SidebarSortMode,
+        fileSortMode: SidebarSortMode,
         manualGroupOrder: [String]?
     ) {
         activeFavoriteWorkspaceState?.pinnedGroupIDs = pinnedGroupIDs
@@ -76,13 +76,13 @@ final class FavoriteWorkspaceController {
     func matchingFavorite(
         folderURL: URL,
         options: FolderWatchOptions,
-        in favorites: [ReaderFavoriteWatchedFolder]
-    ) -> ReaderFavoriteWatchedFolder? {
+        in favorites: [FavoriteWatchedFolder]
+    ) -> FavoriteWatchedFolder? {
         let normalizedPath = ReaderFileRouting.normalizedFileURL(folderURL).path
         return favorites.first { $0.matches(folderPath: normalizedPath, options: options) }
     }
 
-    func matchingCurrentSession() -> ReaderFavoriteWatchedFolder? {
+    func matchingCurrentSession() -> FavoriteWatchedFolder? {
         guard let session = folderWatchFlowController?.sharedFolderWatchSession else { return nil }
         return matchingFavorite(
             folderURL: session.folderURL,
@@ -118,7 +118,7 @@ final class FavoriteWorkspaceController {
         guard let session = folderWatchFlowController?.sharedFolderWatchSession,
               let groupStateController else { return }
         let groupSnapshot = groupStateController.persistenceSnapshot
-        var workspaceState = ReaderFavoriteWorkspaceState.from(
+        var workspaceState = FavoriteWorkspaceState.from(
             settings: settingsStore.currentSettings,
             pinnedGroupIDs: groupSnapshot.pinnedGroupIDs,
             collapsedGroupIDs: groupSnapshot.collapsedGroupIDs,
@@ -148,7 +148,7 @@ final class FavoriteWorkspaceController {
     }
 
     /// Returns the sidebar width from the favorite's workspace state (so the caller can apply it to window state).
-    func startFavoriteWatch(_ entry: ReaderFavoriteWatchedFolder) -> CGFloat {
+    func startFavoriteWatch(_ entry: FavoriteWatchedFolder) -> CGFloat {
         // Restore appearance FIRST
         if let lockedAppearance = entry.workspaceState.lockedAppearance {
             appearanceController?.restore(from: lockedAppearance)
@@ -220,7 +220,7 @@ final class FavoriteWorkspaceController {
     // MARK: - Private
 
     private func discoverNewFilesForFavorite(
-        _ entry: ReaderFavoriteWatchedFolder,
+        _ entry: FavoriteWatchedFolder,
         resolvedFolderURL: URL
     ) {
         sidebarDocumentController?.folderWatchCoordinator.scanCurrentMarkdownFiles { [weak self] scannedURLs in

--- a/minimark/Stores/FolderWatchControllerDelegate.swift
+++ b/minimark/Stores/FolderWatchControllerDelegate.swift
@@ -4,7 +4,7 @@ import Foundation
 protocol FolderWatchControllerDelegate: AnyObject {
     func folderWatchControllerCurrentDocumentFileURL(_ controller: FolderWatchController) -> URL?
     func folderWatchControllerOpenDocumentFileURLs(_ controller: FolderWatchController) -> [URL]
-    func folderWatchController(_ controller: FolderWatchController, handleEvents events: [FolderWatchChangeEvent], in session: FolderWatchSession, origin: ReaderOpenOrigin)
+    func folderWatchController(_ controller: FolderWatchController, handleEvents events: [FolderWatchChangeEvent], in session: FolderWatchSession, origin: OpenOrigin)
     func folderWatchControllerShouldSelectNewestDocument(_ controller: FolderWatchController)
     func folderWatchController(_ controller: FolderWatchController, didLiveAutoOpenFileURLs urls: [URL])
     func folderWatchControllerStateDidChange(_ controller: FolderWatchController)

--- a/minimark/Stores/FolderWatchDispatcher.swift
+++ b/minimark/Stores/FolderWatchDispatcher.swift
@@ -37,7 +37,7 @@ final class FolderWatchDispatcher {
     }
 
     func setAdditionalOpenHandler(
-        _ handler: @escaping (FolderWatchChangeEvent, FolderWatchSession?, ReaderOpenOrigin) -> Void
+        _ handler: @escaping (FolderWatchChangeEvent, FolderWatchSession?, OpenOrigin) -> Void
     ) {
         eventDispatchCoordinator.setAdditionalOpenHandler(handler)
     }
@@ -49,7 +49,7 @@ final class FolderWatchDispatcher {
     func handleObservedWatchedFolderChanges(
         _ markdownFileEvents: [FolderWatchChangeEvent],
         currentDocumentFileURL: URL?,
-        openPrimary: @escaping (FolderWatchChangeEvent, FolderWatchSession, ReaderOpenOrigin) -> Void
+        openPrimary: @escaping (FolderWatchChangeEvent, FolderWatchSession, OpenOrigin) -> Void
     ) {
         guard let session = activeFolderWatchSession else { return }
         lastWatchedFolderEventAt = .now
@@ -75,7 +75,7 @@ final class FolderWatchDispatcher {
     func openInitialMarkdownFilesFromWatchedFolder(
         _ markdownFileEvents: [FolderWatchChangeEvent],
         session: FolderWatchSession,
-        openPrimary: @escaping (FolderWatchChangeEvent, FolderWatchSession, ReaderOpenOrigin) -> Void
+        openPrimary: @escaping (FolderWatchChangeEvent, FolderWatchSession, OpenOrigin) -> Void
     ) {
         eventDispatchCoordinator.dispatchInitialEvents(
             markdownFileEvents,
@@ -87,8 +87,8 @@ final class FolderWatchDispatcher {
     // MARK: - Internal dispatch coordinator
 
     private struct FolderWatchEventDispatchCoordinator {
-        typealias AdditionalOpenHandler = (FolderWatchChangeEvent, FolderWatchSession?, ReaderOpenOrigin) -> Void
-        typealias PrimaryOpenHandler = (FolderWatchChangeEvent, FolderWatchSession, ReaderOpenOrigin) -> Void
+        typealias AdditionalOpenHandler = (FolderWatchChangeEvent, FolderWatchSession?, OpenOrigin) -> Void
+        typealias PrimaryOpenHandler = (FolderWatchChangeEvent, FolderWatchSession, OpenOrigin) -> Void
 
         private(set) var additionalOpenHandler: AdditionalOpenHandler?
 
@@ -99,7 +99,7 @@ final class FolderWatchDispatcher {
         func dispatchLiveEvents(
             _ plannedEvents: [FolderWatchChangeEvent],
             session: FolderWatchSession,
-            origin: ReaderOpenOrigin,
+            origin: OpenOrigin,
             openPrimary: PrimaryOpenHandler
         ) {
             guard !plannedEvents.isEmpty else { return }
@@ -118,7 +118,7 @@ final class FolderWatchDispatcher {
             openPrimary: PrimaryOpenHandler
         ) {
             guard let firstEvent = events.first else { return }
-            let initialOrigin: ReaderOpenOrigin = events.count > 1
+            let initialOrigin: OpenOrigin = events.count > 1
                 ? .folderWatchInitialBatchAutoOpen
                 : .folderWatchAutoOpen
             openPrimary(firstEvent, session, initialOrigin)

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -59,7 +59,7 @@ final class FolderWatchFlowController {
         presentOptions(for: folderURL, options: .default)
     }
 
-    func prepareRecentWatch(_ entry: ReaderRecentWatchedFolder) {
+    func prepareRecentWatch(_ entry: RecentWatchedFolder) {
         let resolvedFolderURL = settingsStore.resolvedRecentWatchedFolderURL(matching: entry.folderURL) ?? entry.folderURL
         presentOptions(for: resolvedFolderURL, options: entry.options)
     }

--- a/minimark/Stores/FolderWatchSessionCoordinator.swift
+++ b/minimark/Stores/FolderWatchSessionCoordinator.swift
@@ -205,7 +205,7 @@ extension FolderWatchSessionCoordinator: FolderWatchControllerDelegate {
         _ controller: FolderWatchController,
         handleEvents events: [FolderWatchChangeEvent],
         in session: FolderWatchSession,
-        origin: ReaderOpenOrigin
+        origin: OpenOrigin
     ) {
         let diffBaselineByURL: [URL: String] = Dictionary(
             uniqueKeysWithValues: events.compactMap { event in

--- a/minimark/Stores/Reader/DocumentOpener.swift
+++ b/minimark/Stores/Reader/DocumentOpener.swift
@@ -47,7 +47,7 @@ final class DocumentOpener {
 
     func open(
         at url: URL,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         folderWatchSession: FolderWatchSession? = nil,
         initialDiffBaselineMarkdown: String? = nil
     ) {
@@ -94,7 +94,7 @@ final class DocumentOpener {
     }
 
     func materializeDeferred(
-        origin: ReaderOpenOrigin? = nil,
+        origin: OpenOrigin? = nil,
         folderWatchSession: FolderWatchSession? = nil,
         initialDiffBaselineMarkdown: String? = nil
     ) {
@@ -128,7 +128,7 @@ final class DocumentOpener {
 
     func handleIncomingURL(
         _ url: URL,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         folderWatchSession: FolderWatchSession? = nil,
         initialDiffBaselineMarkdown: String? = nil
     ) {
@@ -155,7 +155,7 @@ final class DocumentOpener {
 
     func deferFile(
         at url: URL,
-        origin: ReaderOpenOrigin = .folderWatchInitialBatchAutoOpen,
+        origin: OpenOrigin = .folderWatchInitialBatchAutoOpen,
         folderWatchSession: FolderWatchSession?
     ) {
         document.deferFile(at: url, origin: origin)

--- a/minimark/Stores/Reader/DocumentPresenter.swift
+++ b/minimark/Stores/Reader/DocumentPresenter.swift
@@ -94,7 +94,7 @@ final class DocumentPresenter {
         document.fileLastModifiedAt = nil
         document.openInApplications = []
         document.isCurrentFileMissing = true
-        document.lastError = ReaderPresentableError(from: error)
+        document.lastError = PresentableError(from: error)
         settler.clearSettling()
     }
 

--- a/minimark/Stores/Reader/PostOpenEffects.swift
+++ b/minimark/Stores/Reader/PostOpenEffects.swift
@@ -30,7 +30,7 @@ final class PostOpenEffects {
     func apply(
         accessibleURL: URL,
         normalizedURL: URL,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         initialDiffBaselineMarkdown: String?,
         loadedMarkdown: String
     ) {
@@ -76,7 +76,7 @@ final class PostOpenEffects {
         }
     }
 
-    private func recordRecentManualOpenIfNeeded(_ accessibleURL: URL, origin: ReaderOpenOrigin) {
+    private func recordRecentManualOpenIfNeeded(_ accessibleURL: URL, origin: OpenOrigin) {
         guard origin == .manual else {
             return
         }
@@ -85,7 +85,7 @@ final class PostOpenEffects {
 
     private func notifyAutoLoadedFileIfNeeded(
         _ normalizedURL: URL,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         initialDiffBaselineMarkdown: String?
     ) {
         guard origin.shouldNotifyFileAutoLoaded,

--- a/minimark/Stores/ReaderAutoOpenSettler.swift
+++ b/minimark/Stores/ReaderAutoOpenSettler.swift
@@ -3,7 +3,7 @@ import Foundation
 @MainActor protocol ReaderAutoOpenSettling: AnyObject {
     var pendingContext: PendingAutoOpenSettlingContext? { get }
     func makePendingContext(
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         initialDiffBaselineMarkdown: String?,
         loadedMarkdown: String,
         now: Date
@@ -67,7 +67,7 @@ final class ReaderAutoOpenSettler: ReaderAutoOpenSettling {
     }
 
     func makePendingContext(
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         initialDiffBaselineMarkdown: String?,
         loadedMarkdown: String,
         now: Date

--- a/minimark/Stores/ReaderDocumentController.swift
+++ b/minimark/Stores/ReaderDocumentController.swift
@@ -15,9 +15,9 @@ final class ReaderDocumentController {
     var fileDisplayName: String = ""
     var documentLoadState: ReaderDocumentLoadState = .ready
     var isCurrentFileMissing: Bool = false
-    var lastError: ReaderPresentableError?
-    var openInApplications: [ReaderExternalApplication] = []
-    var currentOpenOrigin: ReaderOpenOrigin = .manual
+    var lastError: PresentableError?
+    var openInApplications: [ExternalApplication] = []
+    var currentOpenOrigin: OpenOrigin = .manual
 
     // MARK: - Content state
     var sourceMarkdown: String = ""
@@ -35,14 +35,14 @@ final class ReaderDocumentController {
     }
 
     // MARK: - Dependencies
-    let fileDependencies: ReaderFileDependencies
+    let fileDependencies: FileDependencies
     let settingsStore: ReaderSettingsReading
     let settler: ReaderAutoOpenSettling
 
     @ObservationIgnored private var loadingOverlayHoldGeneration: UInt = 0
 
     init(
-        fileDependencies: ReaderFileDependencies,
+        fileDependencies: FileDependencies,
         settingsStore: ReaderSettingsReading,
         settler: ReaderAutoOpenSettling
     ) {
@@ -75,7 +75,7 @@ final class ReaderDocumentController {
         self.fileLastModifiedAt = nil
         self.openInApplications = []
         self.isCurrentFileMissing = true
-        self.lastError = ReaderPresentableError(from: error)
+        self.lastError = PresentableError(from: error)
         settler.clearSettling()
     }
 
@@ -97,7 +97,7 @@ final class ReaderDocumentController {
 
     func deferFile(
         at url: URL,
-        origin: ReaderOpenOrigin = .folderWatchInitialBatchAutoOpen
+        origin: OpenOrigin = .folderWatchInitialBatchAutoOpen
     ) {
         let normalizedURL = ReaderFileRouting.normalizedFileURL(url)
         fileURL = normalizedURL
@@ -149,7 +149,7 @@ final class ReaderDocumentController {
         }
     }
 
-    func openInApplication(_ application: ReaderExternalApplication?) {
+    func openInApplication(_ application: ExternalApplication?) {
         guard let fileURL else {
             handle(ReaderError.noOpenFileInReader)
             return
@@ -182,7 +182,7 @@ final class ReaderDocumentController {
     // MARK: - Error handling
 
     func handle(_ error: Error) {
-        lastError = ReaderPresentableError(from: error)
+        lastError = PresentableError(from: error)
     }
 
     func clearLastError() {

--- a/minimark/Stores/ReaderRenderingController.swift
+++ b/minimark/Stores/ReaderRenderingController.swift
@@ -14,12 +14,12 @@ final class ReaderRenderingController {
     @ObservationIgnored var appearanceOverride: LockedAppearance?
     @ObservationIgnored var pendingDraftPreviewRenderTask: Task<Void, Never>?
 
-    private let renderingDependencies: ReaderRenderingDependencies
+    private let renderingDependencies: RenderingDependencies
     private let settingsStore: ReaderSettingsReading
     private let securityScopeResolver: SecurityScopeResolver
 
     init(
-        renderingDependencies: ReaderRenderingDependencies,
+        renderingDependencies: RenderingDependencies,
         settingsStore: ReaderSettingsReading,
         securityScopeResolver: SecurityScopeResolver
     ) {

--- a/minimark/Stores/ReaderSettingsStore.swift
+++ b/minimark/Stores/ReaderSettingsStore.swift
@@ -5,35 +5,35 @@ import OSLog
 
 nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     var appAppearance: AppAppearance
-    var readerTheme: ReaderThemeKind
+    var readerTheme: ThemeKind
     var syntaxTheme: SyntaxThemeKind
     var baseFontSize: Double
     var autoRefreshOnExternalChange: Bool
     var notificationsEnabled: Bool
-    var multiFileDisplayMode: ReaderMultiFileDisplayMode
-    var sidebarSortMode: ReaderSidebarSortMode
-    var sidebarGroupSortMode: ReaderSidebarSortMode
-    var favoriteWatchedFolders: [ReaderFavoriteWatchedFolder]
-    var recentWatchedFolders: [ReaderRecentWatchedFolder]
-    var recentManuallyOpenedFiles: [ReaderRecentOpenedFile]
-    var trustedImageFolders: [ReaderTrustedImageFolder]
+    var multiFileDisplayMode: MultiFileDisplayMode
+    var sidebarSortMode: SidebarSortMode
+    var sidebarGroupSortMode: SidebarSortMode
+    var favoriteWatchedFolders: [FavoriteWatchedFolder]
+    var recentWatchedFolders: [RecentWatchedFolder]
+    var recentManuallyOpenedFiles: [RecentOpenedFile]
+    var trustedImageFolders: [TrustedImageFolder]
     var diffBaselineLookback: DiffBaselineLookback
     var dismissedHints: Set<FirstUseHint>
 
     init(
         appAppearance: AppAppearance,
-        readerTheme: ReaderThemeKind,
+        readerTheme: ThemeKind,
         syntaxTheme: SyntaxThemeKind,
         baseFontSize: Double,
         autoRefreshOnExternalChange: Bool,
         notificationsEnabled: Bool,
-        multiFileDisplayMode: ReaderMultiFileDisplayMode,
-        sidebarSortMode: ReaderSidebarSortMode,
-        sidebarGroupSortMode: ReaderSidebarSortMode = .lastChangedNewestFirst,
-        favoriteWatchedFolders: [ReaderFavoriteWatchedFolder] = [],
-        recentWatchedFolders: [ReaderRecentWatchedFolder],
-        recentManuallyOpenedFiles: [ReaderRecentOpenedFile],
-        trustedImageFolders: [ReaderTrustedImageFolder] = [],
+        multiFileDisplayMode: MultiFileDisplayMode,
+        sidebarSortMode: SidebarSortMode,
+        sidebarGroupSortMode: SidebarSortMode = .lastChangedNewestFirst,
+        favoriteWatchedFolders: [FavoriteWatchedFolder] = [],
+        recentWatchedFolders: [RecentWatchedFolder],
+        recentManuallyOpenedFiles: [RecentOpenedFile],
+        trustedImageFolders: [TrustedImageFolder] = [],
         diffBaselineLookback: DiffBaselineLookback = .twoMinutes,
         dismissedHints: Set<FirstUseHint> = []
     ) {
@@ -93,33 +93,33 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         appAppearance = try container.decodeIfPresent(AppAppearance.self, forKey: .appAppearance) ?? .system
-        readerTheme = try container.decode(ReaderThemeKind.self, forKey: .readerTheme)
+        readerTheme = try container.decode(ThemeKind.self, forKey: .readerTheme)
         syntaxTheme = try container.decode(SyntaxThemeKind.self, forKey: .syntaxTheme)
         baseFontSize = try container.decode(Double.self, forKey: .baseFontSize)
         autoRefreshOnExternalChange = try container.decode(Bool.self, forKey: .autoRefreshOnExternalChange)
         notificationsEnabled = try container.decodeIfPresent(Bool.self, forKey: .notificationsEnabled) ?? true
-        multiFileDisplayMode = try container.decode(ReaderMultiFileDisplayMode.self, forKey: .multiFileDisplayMode)
-        sidebarSortMode = try container.decodeIfPresent(ReaderSidebarSortMode.self, forKey: .sidebarSortMode) ?? .openOrder
-        sidebarGroupSortMode = try container.decodeIfPresent(ReaderSidebarSortMode.self, forKey: .sidebarGroupSortMode) ?? .lastChangedNewestFirst
-        let decodedFavorites = try container.decodeIfPresent([ReaderFavoriteWatchedFolder].self, forKey: .favoriteWatchedFolders) ?? []
-        recentWatchedFolders = try container.decodeIfPresent([ReaderRecentWatchedFolder].self, forKey: .recentWatchedFolders) ?? []
-        recentManuallyOpenedFiles = try container.decodeIfPresent([ReaderRecentOpenedFile].self, forKey: .recentManuallyOpenedFiles) ?? []
-        trustedImageFolders = try container.decodeIfPresent([ReaderTrustedImageFolder].self, forKey: .trustedImageFolders) ?? []
+        multiFileDisplayMode = try container.decode(MultiFileDisplayMode.self, forKey: .multiFileDisplayMode)
+        sidebarSortMode = try container.decodeIfPresent(SidebarSortMode.self, forKey: .sidebarSortMode) ?? .openOrder
+        sidebarGroupSortMode = try container.decodeIfPresent(SidebarSortMode.self, forKey: .sidebarGroupSortMode) ?? .lastChangedNewestFirst
+        let decodedFavorites = try container.decodeIfPresent([FavoriteWatchedFolder].self, forKey: .favoriteWatchedFolders) ?? []
+        recentWatchedFolders = try container.decodeIfPresent([RecentWatchedFolder].self, forKey: .recentWatchedFolders) ?? []
+        recentManuallyOpenedFiles = try container.decodeIfPresent([RecentOpenedFile].self, forKey: .recentManuallyOpenedFiles) ?? []
+        trustedImageFolders = try container.decodeIfPresent([TrustedImageFolder].self, forKey: .trustedImageFolders) ?? []
         diffBaselineLookback = try container.decodeIfPresent(DiffBaselineLookback.self, forKey: .diffBaselineLookback) ?? .twoMinutes
         dismissedHints = try container.decodeIfPresent(Set<FirstUseHint>.self, forKey: .dismissedHints) ?? []
 
         // Migrate legacy favorites: replace hardcoded-default workspace state with decoded global settings
-        let legacyDefaultState = ReaderFavoriteWorkspaceState.from(
+        let legacyDefaultState = FavoriteWorkspaceState.from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
-        let globalWorkspaceState = ReaderFavoriteWorkspaceState(
+        let globalWorkspaceState = FavoriteWorkspaceState(
             fileSortMode: sidebarSortMode,
             groupSortMode: sidebarGroupSortMode,
             sidebarPosition: multiFileDisplayMode,
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth,
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth,
             pinnedGroupIDs: [],
             collapsedGroupIDs: []
         )
@@ -144,7 +144,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
 
 @MainActor protocol ReaderThemeWriting: AnyObject {
     func updateAppAppearance(_ appearance: AppAppearance)
-    func updateTheme(_ kind: ReaderThemeKind)
+    func updateTheme(_ kind: ThemeKind)
     func updateSyntaxTheme(_ kind: SyntaxThemeKind)
     func updateBaseFontSize(_ value: Double)
     func increaseFontSize(step: Double)
@@ -154,9 +154,9 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
 
 @MainActor protocol ReaderPreferencesWriting: AnyObject {
     func updateNotificationsEnabled(_ isEnabled: Bool)
-    func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode)
-    func updateSidebarSortMode(_ mode: ReaderSidebarSortMode)
-    func updateSidebarGroupSortMode(_ mode: ReaderSidebarSortMode)
+    func updateMultiFileDisplayMode(_ mode: MultiFileDisplayMode)
+    func updateSidebarSortMode(_ mode: SidebarSortMode)
+    func updateSidebarGroupSortMode(_ mode: SidebarSortMode)
     func updateDiffBaselineLookback(_ lookback: DiffBaselineLookback)
 }
 
@@ -166,7 +166,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
         folderURL: URL,
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL],
-        workspaceState: ReaderFavoriteWorkspaceState
+        workspaceState: FavoriteWorkspaceState
     )
     func removeFavoriteWatchedFolder(id: UUID)
     func renameFavoriteWatchedFolder(id: UUID, newName: String)
@@ -180,8 +180,8 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
         folderURL: URL,
         knownDocumentFileURLs: [URL]
     )
-    func updateFavoriteWorkspaceState(id: UUID, workspaceState: ReaderFavoriteWorkspaceState)
-    func resolvedFavoriteWatchedFolderURL(for entry: ReaderFavoriteWatchedFolder) -> URL
+    func updateFavoriteWorkspaceState(id: UUID, workspaceState: FavoriteWorkspaceState)
+    func resolvedFavoriteWatchedFolderURL(for entry: FavoriteWatchedFolder) -> URL
     func clearFavoriteWatchedFolders()
     func reorderFavoriteWatchedFolders(orderedIDs: [UUID])
     func updateFavoriteWatchedFolderExclusions(id: UUID, excludedSubdirectoryPaths: [String])
@@ -369,7 +369,7 @@ typealias ReaderSettingsStoring = ReaderSettingsReading & ReaderSettingsWriting
     // MARK: - ReaderThemeWriting
 
     func updateAppAppearance(_ appearance: AppAppearance) { preferences.updateAppAppearance(appearance) }
-    func updateTheme(_ kind: ReaderThemeKind) { preferences.updateTheme(kind) }
+    func updateTheme(_ kind: ThemeKind) { preferences.updateTheme(kind) }
     func updateSyntaxTheme(_ kind: SyntaxThemeKind) { preferences.updateSyntaxTheme(kind) }
     func updateBaseFontSize(_ value: Double) { preferences.updateBaseFontSize(value) }
     func increaseFontSize(step: Double = 1.0) { preferences.increaseFontSize(step: step) }
@@ -379,9 +379,9 @@ typealias ReaderSettingsStoring = ReaderSettingsReading & ReaderSettingsWriting
     // MARK: - ReaderPreferencesWriting
 
     func updateNotificationsEnabled(_ isEnabled: Bool) { preferences.updateNotificationsEnabled(isEnabled) }
-    func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode) { preferences.updateMultiFileDisplayMode(mode) }
-    func updateSidebarSortMode(_ mode: ReaderSidebarSortMode) { preferences.updateSidebarSortMode(mode) }
-    func updateSidebarGroupSortMode(_ mode: ReaderSidebarSortMode) { preferences.updateSidebarGroupSortMode(mode) }
+    func updateMultiFileDisplayMode(_ mode: MultiFileDisplayMode) { preferences.updateMultiFileDisplayMode(mode) }
+    func updateSidebarSortMode(_ mode: SidebarSortMode) { preferences.updateSidebarSortMode(mode) }
+    func updateSidebarGroupSortMode(_ mode: SidebarSortMode) { preferences.updateSidebarGroupSortMode(mode) }
     func updateDiffBaselineLookback(_ lookback: DiffBaselineLookback) { preferences.updateDiffBaselineLookback(lookback) }
 
     // MARK: - ReaderHintWriting
@@ -396,11 +396,11 @@ typealias ReaderSettingsStoring = ReaderSettingsReading & ReaderSettingsWriting
         folderURL: URL,
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
     ) {
         favorites.addFavoriteWatchedFolder(
@@ -429,10 +429,10 @@ typealias ReaderSettingsStoring = ReaderSettingsReading & ReaderSettingsWriting
             knownDocumentFileURLs: knownDocumentFileURLs
         )
     }
-    func updateFavoriteWorkspaceState(id: UUID, workspaceState: ReaderFavoriteWorkspaceState) {
+    func updateFavoriteWorkspaceState(id: UUID, workspaceState: FavoriteWorkspaceState) {
         favorites.updateFavoriteWorkspaceState(id: id, workspaceState: workspaceState)
     }
-    func resolvedFavoriteWatchedFolderURL(for entry: ReaderFavoriteWatchedFolder) -> URL {
+    func resolvedFavoriteWatchedFolderURL(for entry: FavoriteWatchedFolder) -> URL {
         favorites.resolvedFavoriteWatchedFolderURL(for: entry)
     }
     func clearFavoriteWatchedFolders() { favorites.clearFavoriteWatchedFolders() }

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -81,11 +81,11 @@ final class ReaderSidebarDocumentController {
                 }
             )
             let store = ReaderStore(
-                rendering: ReaderRenderingDependencies(
+                rendering: RenderingDependencies(
                     renderer: MarkdownRenderingService(),
                     differ: ChangedRegionDiffer()
                 ),
-                file: ReaderFileDependencies(
+                file: FileDependencies(
                     watcher: FileChangeWatcher(),
                     io: ReaderDocumentIOService(),
                     actions: ReaderFileActionService()
@@ -240,7 +240,7 @@ final class ReaderSidebarDocumentController {
 
     // MARK: - Document actions
 
-    func openDocumentsInApplication(_ application: ReaderExternalApplication?, documentIDs: Set<UUID>) {
+    func openDocumentsInApplication(_ application: ExternalApplication?, documentIDs: Set<UUID>) {
         for tab in documentList.orderedDocuments(matching: documentIDs) where tab.readerStore.document.fileURL != nil {
             tab.readerStore.document.openInApplication(application)
         }

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -326,7 +326,7 @@ final class FolderWatchController {
     private func dispatchOpenEvents(
         _ events: [FolderWatchChangeEvent],
         session: FolderWatchSession,
-        origin: ReaderOpenOrigin
+        origin: OpenOrigin
     ) {
         guard !events.isEmpty else {
             return

--- a/minimark/Stores/ReaderStore.swift
+++ b/minimark/Stores/ReaderStore.swift
@@ -22,8 +22,8 @@ final class ReaderStore {
 
     // MARK: - Dependencies (exposed for wiring + logging + tests)
 
-    let rendering: ReaderRenderingDependencies
-    let file: ReaderFileDependencies
+    let rendering: RenderingDependencies
+    let file: FileDependencies
     let folderWatch: FolderWatchDependencies
     let settingsStore: ReaderSettingsReading & ReaderRecentWriting
     let securityScopeResolver: SecurityScopeResolver
@@ -63,8 +63,8 @@ final class ReaderStore {
     var onFolderWatchStopped: (() -> Void)? { folderWatchDispatcher.onFolderWatchStopped }
 
     init(
-        rendering: ReaderRenderingDependencies,
-        file: ReaderFileDependencies,
+        rendering: RenderingDependencies,
+        file: FileDependencies,
         folderWatch: FolderWatchDependencies,
         settingsStore: ReaderSettingsReading & ReaderRecentWriting,
         securityScopeResolver: SecurityScopeResolver,

--- a/minimark/Stores/RecentHistoryCoordinator.swift
+++ b/minimark/Stores/RecentHistoryCoordinator.swift
@@ -17,7 +17,7 @@ final class RecentHistoryCoordinator {
 
     // MARK: - Recent Folder Watch
 
-    func startRecentFolderWatch(_ entry: ReaderRecentWatchedFolder) {
+    func startRecentFolderWatch(_ entry: RecentWatchedFolder) {
         folderWatchFlowController?.prepareRecentWatch(entry)
     }
 
@@ -32,7 +32,7 @@ final class RecentHistoryCoordinator {
     }
 
     func openRecentFile(
-        _ entry: ReaderRecentOpenedFile,
+        _ entry: RecentOpenedFile,
         using fileOpenCoordinator: FileOpenCoordinator,
         session: FolderWatchSession?
     ) {

--- a/minimark/Stores/Settings/FavoriteWatchedFoldersStore.swift
+++ b/minimark/Stores/Settings/FavoriteWatchedFoldersStore.swift
@@ -3,21 +3,21 @@ import Combine
 import Observation
 
 @MainActor @Observable final class FavoriteWatchedFoldersStore: ReaderFavoriteWriting {
-    private(set) var currentFavorites: [ReaderFavoriteWatchedFolder]
+    private(set) var currentFavorites: [FavoriteWatchedFolder]
 
     weak var coordinator: ChildStoreCoordinating?
 
     @ObservationIgnored
-    private let subject: CurrentValueSubject<[ReaderFavoriteWatchedFolder], Never>
+    private let subject: CurrentValueSubject<[FavoriteWatchedFolder], Never>
 
     @ObservationIgnored
     private let bookmarkRefreshing: BookmarkRefreshing
 
-    var favoritesPublisher: AnyPublisher<[ReaderFavoriteWatchedFolder], Never> {
+    var favoritesPublisher: AnyPublisher<[FavoriteWatchedFolder], Never> {
         subject.eraseToAnyPublisher()
     }
 
-    init(initial: [ReaderFavoriteWatchedFolder], bookmarkRefreshing: BookmarkRefreshing) {
+    init(initial: [FavoriteWatchedFolder], bookmarkRefreshing: BookmarkRefreshing) {
         self.currentFavorites = initial
         self.subject = CurrentValueSubject(initial)
         self.bookmarkRefreshing = bookmarkRefreshing
@@ -28,11 +28,11 @@ import Observation
         folderURL: URL,
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
     ) {
         mutate(coalescePersistence: false) { favorites in
@@ -68,7 +68,7 @@ import Observation
             guard let index = favorites.firstIndex(where: { $0.id == id }) else { return }
 
             let existing = favorites[index]
-            let scopedRelativePaths = ReaderFavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
+            let scopedRelativePaths = FavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
                 from: openDocumentFileURLs,
                 relativeTo: folderURL,
                 options: existing.options
@@ -96,7 +96,7 @@ import Observation
             guard let index = favorites.firstIndex(where: { $0.id == id }) else { return }
 
             let existing = favorites[index]
-            let scopedRelativePaths = ReaderFavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
+            let scopedRelativePaths = FavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
                 from: knownDocumentFileURLs,
                 relativeTo: folderURL,
                 options: existing.options
@@ -110,7 +110,7 @@ import Observation
         }
     }
 
-    func updateFavoriteWorkspaceState(id: UUID, workspaceState: ReaderFavoriteWorkspaceState) {
+    func updateFavoriteWorkspaceState(id: UUID, workspaceState: FavoriteWorkspaceState) {
         mutate(coalescePersistence: true) { favorites in
             guard let index = favorites.firstIndex(where: { $0.id == id }) else { return }
             let existing = favorites[index]
@@ -119,7 +119,7 @@ import Observation
         }
     }
 
-    func resolvedFavoriteWatchedFolderURL(for entry: ReaderFavoriteWatchedFolder) -> URL {
+    func resolvedFavoriteWatchedFolderURL(for entry: FavoriteWatchedFolder) -> URL {
         bookmarkRefreshing.resolveURL(
             bookmarkData: entry.bookmarkData,
             fallbackURL: entry.folderURL,
@@ -196,15 +196,15 @@ import Observation
     }
 
     private static func copy(
-        _ entry: ReaderFavoriteWatchedFolder,
+        _ entry: FavoriteWatchedFolder,
         folderPath: String? = nil,
         options: FolderWatchOptions? = nil,
         bookmarkData: Data?? = nil,
         openDocumentRelativePaths: [String]? = nil,
         allKnownRelativePaths: [String]? = nil,
-        workspaceState: ReaderFavoriteWorkspaceState? = nil
-    ) -> ReaderFavoriteWatchedFolder {
-        ReaderFavoriteWatchedFolder(
+        workspaceState: FavoriteWorkspaceState? = nil
+    ) -> FavoriteWatchedFolder {
+        FavoriteWatchedFolder(
             id: entry.id,
             name: entry.name,
             folderPath: folderPath ?? entry.folderPath,
@@ -219,7 +219,7 @@ import Observation
 
     private func mutate(
         coalescePersistence: Bool,
-        _ transform: (inout [ReaderFavoriteWatchedFolder]) -> Void
+        _ transform: (inout [FavoriteWatchedFolder]) -> Void
     ) {
         var updated = currentFavorites
         transform(&updated)

--- a/minimark/Stores/Settings/ReaderPreferencesStore.swift
+++ b/minimark/Stores/Settings/ReaderPreferencesStore.swift
@@ -4,14 +4,14 @@ import Observation
 
 nonisolated struct ReaderPreferencesSlice: Equatable, Sendable {
     var appAppearance: AppAppearance
-    var readerTheme: ReaderThemeKind
+    var readerTheme: ThemeKind
     var syntaxTheme: SyntaxThemeKind
     var baseFontSize: Double
     var autoRefreshOnExternalChange: Bool
     var notificationsEnabled: Bool
-    var multiFileDisplayMode: ReaderMultiFileDisplayMode
-    var sidebarSortMode: ReaderSidebarSortMode
-    var sidebarGroupSortMode: ReaderSidebarSortMode
+    var multiFileDisplayMode: MultiFileDisplayMode
+    var sidebarSortMode: SidebarSortMode
+    var sidebarGroupSortMode: SidebarSortMode
     var diffBaselineLookback: DiffBaselineLookback
     var dismissedHints: Set<FirstUseHint>
 }
@@ -42,7 +42,7 @@ nonisolated struct ReaderPreferencesSlice: Equatable, Sendable {
         }
     }
 
-    func updateTheme(_ kind: ReaderThemeKind) {
+    func updateTheme(_ kind: ThemeKind) {
         mutate(coalescePersistence: true) { slice in
             slice.readerTheme = kind
         }
@@ -79,19 +79,19 @@ nonisolated struct ReaderPreferencesSlice: Equatable, Sendable {
         }
     }
 
-    func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode) {
+    func updateMultiFileDisplayMode(_ mode: MultiFileDisplayMode) {
         mutate(coalescePersistence: true) { slice in
             slice.multiFileDisplayMode = mode
         }
     }
 
-    func updateSidebarSortMode(_ mode: ReaderSidebarSortMode) {
+    func updateSidebarSortMode(_ mode: SidebarSortMode) {
         mutate(coalescePersistence: true) { slice in
             slice.sidebarSortMode = mode
         }
     }
 
-    func updateSidebarGroupSortMode(_ mode: ReaderSidebarSortMode) {
+    func updateSidebarGroupSortMode(_ mode: SidebarSortMode) {
         mutate(coalescePersistence: true) { slice in
             slice.sidebarGroupSortMode = mode
         }

--- a/minimark/Stores/Settings/RecentOpenedFilesStore.swift
+++ b/minimark/Stores/Settings/RecentOpenedFilesStore.swift
@@ -3,21 +3,21 @@ import Combine
 import Observation
 
 @MainActor @Observable final class RecentOpenedFilesStore: ReaderRecentOpenedFileWriting {
-    private(set) var currentRecentOpenedFiles: [ReaderRecentOpenedFile]
+    private(set) var currentRecentOpenedFiles: [RecentOpenedFile]
 
     weak var coordinator: ChildStoreCoordinating?
 
     @ObservationIgnored
-    private let subject: CurrentValueSubject<[ReaderRecentOpenedFile], Never>
+    private let subject: CurrentValueSubject<[RecentOpenedFile], Never>
 
     @ObservationIgnored
     private let bookmarkRefreshing: BookmarkRefreshing
 
-    var recentOpenedFilesPublisher: AnyPublisher<[ReaderRecentOpenedFile], Never> {
+    var recentOpenedFilesPublisher: AnyPublisher<[RecentOpenedFile], Never> {
         subject.eraseToAnyPublisher()
     }
 
-    init(initial: [ReaderRecentOpenedFile], bookmarkRefreshing: BookmarkRefreshing) {
+    init(initial: [RecentOpenedFile], bookmarkRefreshing: BookmarkRefreshing) {
         self.currentRecentOpenedFiles = initial
         self.subject = CurrentValueSubject(initial)
         self.bookmarkRefreshing = bookmarkRefreshing
@@ -60,7 +60,7 @@ import Observation
             guard let index = entries.firstIndex(where: { $0.filePath == filePath }) else { return }
             let existing = entries[index]
             guard existing.bookmarkData != bookmarkData else { return }
-            entries[index] = ReaderRecentOpenedFile(
+            entries[index] = RecentOpenedFile(
                 filePath: existing.filePath,
                 bookmarkData: bookmarkData
             )
@@ -69,7 +69,7 @@ import Observation
 
     private func mutate(
         coalescePersistence: Bool,
-        _ transform: (inout [ReaderRecentOpenedFile]) -> Void
+        _ transform: (inout [RecentOpenedFile]) -> Void
     ) {
         var updated = currentRecentOpenedFiles
         transform(&updated)

--- a/minimark/Stores/Settings/RecentWatchedFoldersStore.swift
+++ b/minimark/Stores/Settings/RecentWatchedFoldersStore.swift
@@ -3,21 +3,21 @@ import Combine
 import Observation
 
 @MainActor @Observable final class RecentWatchedFoldersStore: ReaderRecentWatchedFolderWriting {
-    private(set) var currentRecentWatchedFolders: [ReaderRecentWatchedFolder]
+    private(set) var currentRecentWatchedFolders: [RecentWatchedFolder]
 
     weak var coordinator: ChildStoreCoordinating?
 
     @ObservationIgnored
-    private let subject: CurrentValueSubject<[ReaderRecentWatchedFolder], Never>
+    private let subject: CurrentValueSubject<[RecentWatchedFolder], Never>
 
     @ObservationIgnored
     private let bookmarkRefreshing: BookmarkRefreshing
 
-    var recentWatchedFoldersPublisher: AnyPublisher<[ReaderRecentWatchedFolder], Never> {
+    var recentWatchedFoldersPublisher: AnyPublisher<[RecentWatchedFolder], Never> {
         subject.eraseToAnyPublisher()
     }
 
-    init(initial: [ReaderRecentWatchedFolder], bookmarkRefreshing: BookmarkRefreshing) {
+    init(initial: [RecentWatchedFolder], bookmarkRefreshing: BookmarkRefreshing) {
         self.currentRecentWatchedFolders = initial
         self.subject = CurrentValueSubject(initial)
         self.bookmarkRefreshing = bookmarkRefreshing
@@ -64,7 +64,7 @@ import Observation
             guard let index = entries.firstIndex(where: { $0.folderPath == folderPath }) else { return }
             let existing = entries[index]
             guard existing.bookmarkData != bookmarkData else { return }
-            entries[index] = ReaderRecentWatchedFolder(
+            entries[index] = RecentWatchedFolder(
                 folderPath: existing.folderPath,
                 options: existing.options,
                 bookmarkData: bookmarkData
@@ -74,7 +74,7 @@ import Observation
 
     private func mutate(
         coalescePersistence: Bool,
-        _ transform: (inout [ReaderRecentWatchedFolder]) -> Void
+        _ transform: (inout [RecentWatchedFolder]) -> Void
     ) {
         var updated = currentRecentWatchedFolders
         transform(&updated)

--- a/minimark/Stores/Settings/TrustedImageFoldersStore.swift
+++ b/minimark/Stores/Settings/TrustedImageFoldersStore.swift
@@ -3,21 +3,21 @@ import Combine
 import Observation
 
 @MainActor @Observable final class TrustedImageFoldersStore: ReaderTrustedFolderWriting {
-    private(set) var currentTrustedFolders: [ReaderTrustedImageFolder]
+    private(set) var currentTrustedFolders: [TrustedImageFolder]
 
     weak var coordinator: ChildStoreCoordinating?
 
     @ObservationIgnored
-    private let subject: CurrentValueSubject<[ReaderTrustedImageFolder], Never>
+    private let subject: CurrentValueSubject<[TrustedImageFolder], Never>
 
     @ObservationIgnored
     private let bookmarkRefreshing: BookmarkRefreshing
 
-    var trustedFoldersPublisher: AnyPublisher<[ReaderTrustedImageFolder], Never> {
+    var trustedFoldersPublisher: AnyPublisher<[TrustedImageFolder], Never> {
         subject.eraseToAnyPublisher()
     }
 
-    init(initial: [ReaderTrustedImageFolder], bookmarkRefreshing: BookmarkRefreshing) {
+    init(initial: [TrustedImageFolder], bookmarkRefreshing: BookmarkRefreshing) {
         self.currentTrustedFolders = initial
         self.subject = CurrentValueSubject(initial)
         self.bookmarkRefreshing = bookmarkRefreshing
@@ -65,7 +65,7 @@ import Observation
             guard let index = entries.firstIndex(where: { $0.folderPath == folderPath }) else { return }
             let existing = entries[index]
             guard existing.bookmarkData != bookmarkData else { return }
-            entries[index] = ReaderTrustedImageFolder(
+            entries[index] = TrustedImageFolder(
                 folderPath: existing.folderPath,
                 bookmarkData: bookmarkData
             )
@@ -74,7 +74,7 @@ import Observation
 
     private func mutate(
         coalescePersistence: Bool,
-        _ transform: (inout [ReaderTrustedImageFolder]) -> Void
+        _ transform: (inout [TrustedImageFolder]) -> Void
     ) {
         var updated = currentTrustedFolders
         transform(&updated)

--- a/minimark/Stores/SidebarGroupStateController.swift
+++ b/minimark/Stores/SidebarGroupStateController.swift
@@ -7,12 +7,12 @@ final class SidebarGroupStateController {
 
     // MARK: - Mutable Inputs
 
-    var sortMode: ReaderSidebarSortMode = .lastChangedNewestFirst {
+    var sortMode: SidebarSortMode = .lastChangedNewestFirst {
         didSet {
             recomputeGroupingIfNeeded()
         }
     }
-    var fileSortMode: ReaderSidebarSortMode = .lastChangedNewestFirst { didSet { recomputeGroupingIfNeeded() } }
+    var fileSortMode: SidebarSortMode = .lastChangedNewestFirst { didSet { recomputeGroupingIfNeeded() } }
     var pinnedGroupIDs: Set<String> = [] { didSet { recomputeGroupingIfNeeded() } }
     var collapsedGroupIDs: Set<String> = []
     private(set) var savedCollapsedGroupIDs: Set<String>?
@@ -20,7 +20,7 @@ final class SidebarGroupStateController {
 
     // MARK: - Computed Outputs
 
-    private(set) var computedGrouping: ReaderSidebarGrouping = .flat([])
+    private(set) var computedGrouping: SidebarGrouping = .flat([])
     private(set) var isGrouped: Bool = false
     private(set) var groupIndicatorStates: [String: [ReaderDocumentIndicatorState]] = [:]
     private(set) var groupIndicatorPulseTokens: [String: Int] = [:]
@@ -35,7 +35,7 @@ final class SidebarGroupStateController {
 
     init() {}
 
-    func configureSortModes(sortMode: ReaderSidebarSortMode, fileSortMode: ReaderSidebarSortMode) {
+    func configureSortModes(sortMode: SidebarSortMode, fileSortMode: SidebarSortMode) {
         suppressRecompute = true
         self.sortMode = sortMode
         self.fileSortMode = fileSortMode
@@ -72,7 +72,7 @@ final class SidebarGroupStateController {
 
     // MARK: - Favorites Persistence
 
-    func applyWorkspaceState(_ state: ReaderFavoriteWorkspaceState) {
+    func applyWorkspaceState(_ state: FavoriteWorkspaceState) {
         suppressRecompute = true
         sortMode = state.groupSortMode
         fileSortMode = state.fileSortMode
@@ -85,8 +85,8 @@ final class SidebarGroupStateController {
     }
 
     struct WorkspaceStateSnapshot: Equatable {
-        let sortMode: ReaderSidebarSortMode
-        let fileSortMode: ReaderSidebarSortMode
+        let sortMode: SidebarSortMode
+        let fileSortMode: SidebarSortMode
         let pinnedGroupIDs: Set<String>
         let collapsedGroupIDs: Set<String>
         let manualGroupOrder: [String]?
@@ -173,8 +173,8 @@ final class SidebarGroupStateController {
     }
 
     private func recomputeGrouping(
-        sortMode: ReaderSidebarSortMode,
-        fileSortMode: ReaderSidebarSortMode,
+        sortMode: SidebarSortMode,
+        fileSortMode: SidebarSortMode,
         pinnedGroupIDs: Set<String>
     ) {
         let sortedDocuments = fileSortMode.sorted(documents) { document in
@@ -193,7 +193,7 @@ final class SidebarGroupStateController {
             directoryOrderSourceDocuments = sortedDocuments
         }
 
-        computedGrouping = ReaderSidebarGrouping.group(
+        computedGrouping = SidebarGrouping.group(
             sortedDocuments,
             sortMode: sortMode,
             directoryOrderSourceDocuments: directoryOrderSourceDocuments,
@@ -224,7 +224,7 @@ final class SidebarGroupStateController {
                 lastRowStates[doc.id]?.indicatorState
             }
             let previous = groupIndicatorStates[path] ?? []
-            let next = ReaderSidebarGrouping.indicators(from: states)
+            let next = SidebarGrouping.indicators(from: states)
             if previous != next, !next.isEmpty {
                 updatedPulseTokens[path, default: 0] += 1
             }
@@ -248,11 +248,11 @@ final class SidebarGroupStateController {
         }
     }
 
-    private func applyManualOrder(_ manualOrder: [String], to groups: [ReaderSidebarGrouping.Group]) -> [ReaderSidebarGrouping.Group] {
+    private func applyManualOrder(_ manualOrder: [String], to groups: [SidebarGrouping.Group]) -> [SidebarGrouping.Group] {
         let groupByID = Dictionary(groups.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
-        var pinnedManual: [ReaderSidebarGrouping.Group] = []
-        var unpinnedManual: [ReaderSidebarGrouping.Group] = []
+        var pinnedManual: [SidebarGrouping.Group] = []
+        var unpinnedManual: [SidebarGrouping.Group] = []
         var seen = Set<String>()
 
         for id in manualOrder {

--- a/minimark/Stores/WindowAppearanceController.swift
+++ b/minimark/Stores/WindowAppearanceController.swift
@@ -9,7 +9,7 @@ final class WindowAppearanceController {
     private(set) var isLocked = false
     private(set) var effectiveAppearance: LockedAppearance
 
-    var effectiveTheme: ReaderThemeKind { effectiveAppearance.readerTheme }
+    var effectiveTheme: ThemeKind { effectiveAppearance.readerTheme }
     var effectiveFontSize: Double { effectiveAppearance.baseFontSize }
     var effectiveSyntaxTheme: SyntaxThemeKind { effectiveAppearance.syntaxTheme }
 

--- a/minimark/Support/AccessibilityIdentifierViewModifier.swift
+++ b/minimark/Support/AccessibilityIdentifierViewModifier.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension View {
+    func accessibilityIdentifier(_ id: ReaderAccessibilityID) -> some View {
+        accessibilityIdentifier(id.rawValue)
+    }
+}

--- a/minimark/Support/FolderWatchOpenBatcher.swift
+++ b/minimark/Support/FolderWatchOpenBatcher.swift
@@ -5,14 +5,14 @@ struct FolderWatchOpenBatch: Equatable, Sendable {
     let fileURLs: [URL]
     let initialDiffBaselineMarkdownByURL: [URL: String]
     let folderWatchSession: FolderWatchSession?
-    let openOrigin: ReaderOpenOrigin
+    let openOrigin: OpenOrigin
 }
 
 @MainActor
 final class FolderWatchOpenBatcher: ObservableObject {
     private var queuedEvents: [FolderWatchChangeEvent] = []
     private var queuedFolderWatchSession: FolderWatchSession?
-    private var queuedOpenOrigin: ReaderOpenOrigin = .manual
+    private var queuedOpenOrigin: OpenOrigin = .manual
     private var flushTask: Task<Void, Never>?
     private var flushRetryCount = 0
 
@@ -27,7 +27,7 @@ final class FolderWatchOpenBatcher: ObservableObject {
     func enqueue(
         _ event: FolderWatchChangeEvent,
         folderWatchSession: FolderWatchSession?,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         onFlushRequested: @escaping @MainActor () -> Void
     ) {
         if let existingIndex = queuedEvents.firstIndex(where: { $0.fileURL == event.fileURL }) {

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -25,7 +25,7 @@ enum MarkdownSourceHTMLRenderer {
     }
 
     static func makeHTMLDocument(markdown: String, settings: ReaderSettings, isEditable: Bool) -> String {
-        let theme = ReaderTheme.theme(for: settings.readerTheme)
+        let theme = Theme.theme(for: settings.readerTheme)
         let baseCSS = theme.cssVariables(baseFontSize: settings.baseFontSize)
         let codeMirrorScriptPath = ReaderBundledAssets.availableCodeMirrorSourceViewScriptPath()
         let payloadBase64 = makePayloadBase64(
@@ -256,7 +256,7 @@ enum MarkdownSourceHTMLRenderer {
 
     private static func makePayloadBase64(
         markdown: String,
-        theme: ReaderTheme,
+        theme: Theme,
         settings: ReaderSettings,
         isEditable: Bool
     ) -> String {
@@ -342,7 +342,7 @@ enum MarkdownSourceHTMLRenderer {
         }
     }
 
-    private static func selectionHex(for theme: ReaderTheme) -> String {
+    private static func selectionHex(for theme: Theme) -> String {
         switch theme.kind {
         case .blackOnWhite: return "rgba(0, 95, 204, 0.18)"
         case .whiteOnBlack: return "rgba(125, 180, 255, 0.22)"
@@ -361,7 +361,7 @@ enum MarkdownSourceHTMLRenderer {
         }
     }
 
-    private static func isDarkTheme(_ theme: ReaderTheme) -> Bool {
+    private static func isDarkTheme(_ theme: Theme) -> Bool {
         theme.kind.isDark
     }
 }

--- a/minimark/Support/ReaderFocusedActions.swift
+++ b/minimark/Support/ReaderFocusedActions.swift
@@ -7,16 +7,16 @@ enum ReaderCommandNotification {
 
     struct Payload {
         let targetWindowNumber: Int
-        let recentFileEntry: ReaderRecentOpenedFile?
-        let recentWatchedFolderEntry: ReaderRecentWatchedFolder?
+        let recentFileEntry: RecentOpenedFile?
+        let recentWatchedFolderEntry: RecentWatchedFolder?
 
-        init(targetWindowNumber: Int, recentFileEntry: ReaderRecentOpenedFile) {
+        init(targetWindowNumber: Int, recentFileEntry: RecentOpenedFile) {
             self.targetWindowNumber = targetWindowNumber
             self.recentFileEntry = recentFileEntry
             self.recentWatchedFolderEntry = nil
         }
 
-        init(targetWindowNumber: Int, recentWatchedFolderEntry: ReaderRecentWatchedFolder) {
+        init(targetWindowNumber: Int, recentWatchedFolderEntry: RecentWatchedFolder) {
             self.targetWindowNumber = targetWindowNumber
             self.recentFileEntry = nil
             self.recentWatchedFolderEntry = recentWatchedFolderEntry
@@ -28,8 +28,8 @@ enum ReaderCommandNotification {
                 return nil
             }
             self.targetWindowNumber = targetWindowNumber
-            self.recentFileEntry = userInfo[Keys.recentFileEntry] as? ReaderRecentOpenedFile
-            self.recentWatchedFolderEntry = userInfo[Keys.recentWatchedFolderEntry] as? ReaderRecentWatchedFolder
+            self.recentFileEntry = userInfo[Keys.recentFileEntry] as? RecentOpenedFile
+            self.recentWatchedFolderEntry = userInfo[Keys.recentWatchedFolderEntry] as? RecentWatchedFolder
         }
 
         var asUserInfo: [String: Any] {
@@ -78,9 +78,9 @@ struct ReaderWatchFolderAction {
 }
 
 struct ReaderStartRecentFolderWatchAction {
-    let start: (ReaderRecentWatchedFolder) -> Void
+    let start: (RecentWatchedFolder) -> Void
 
-    func callAsFunction(_ entry: ReaderRecentWatchedFolder) {
+    func callAsFunction(_ entry: RecentWatchedFolder) {
         start(entry)
     }
 }

--- a/minimark/Support/ReaderRecentHistory.swift
+++ b/minimark/Support/ReaderRecentHistory.swift
@@ -22,26 +22,26 @@ nonisolated enum ReaderRecentHistory {
 
     static func insertingUniqueFile(
         _ fileURL: URL,
-        into existingEntries: [ReaderRecentOpenedFile]
-    ) -> [ReaderRecentOpenedFile] {
-        let newEntry = ReaderRecentOpenedFile(fileURL: fileURL)
+        into existingEntries: [RecentOpenedFile]
+    ) -> [RecentOpenedFile] {
+        let newEntry = RecentOpenedFile(fileURL: fileURL)
         let deduplicated = existingEntries.filter { $0.filePath != newEntry.filePath }
-        return Array(([newEntry] + deduplicated).prefix(ReaderRecentOpenedFile.maximumCount))
+        return Array(([newEntry] + deduplicated).prefix(RecentOpenedFile.maximumCount))
     }
 
     static func insertingUniqueWatchedFolder(
         _ folderURL: URL,
         options: FolderWatchOptions,
-        into existingEntries: [ReaderRecentWatchedFolder]
-    ) -> [ReaderRecentWatchedFolder] {
-        let newEntry = ReaderRecentWatchedFolder(folderURL: folderURL, options: options)
+        into existingEntries: [RecentWatchedFolder]
+    ) -> [RecentWatchedFolder] {
+        let newEntry = RecentWatchedFolder(folderURL: folderURL, options: options)
         let deduplicated = existingEntries.filter { $0.folderPath != newEntry.folderPath }
-        return Array(([newEntry] + deduplicated).prefix(ReaderRecentWatchedFolder.maximumCount))
+        return Array(([newEntry] + deduplicated).prefix(RecentWatchedFolder.maximumCount))
     }
 
     static func menuTitle(
-        for entry: ReaderRecentOpenedFile,
-        among entries: [ReaderRecentOpenedFile]
+        for entry: RecentOpenedFile,
+        among entries: [RecentOpenedFile]
     ) -> String {
         menuTitle(
             for: entry,
@@ -51,13 +51,13 @@ nonisolated enum ReaderRecentHistory {
         )
     }
 
-    static func menuTitles(for entries: [ReaderRecentOpenedFile]) -> [String: String] {
+    static func menuTitles(for entries: [RecentOpenedFile]) -> [String: String] {
         menuTitles(for: entries, keyPath: \.filePath, displayName: \.displayName, pathText: \.pathText)
     }
 
     static func menuTitle(
-        for entry: ReaderRecentWatchedFolder,
-        among entries: [ReaderRecentWatchedFolder]
+        for entry: RecentWatchedFolder,
+        among entries: [RecentWatchedFolder]
     ) -> String {
         let baseTitle = menuTitle(
             for: entry,
@@ -75,7 +75,7 @@ nonisolated enum ReaderRecentHistory {
         return "\(baseTitle) [\(excludedCount) filtered \(noun)]"
     }
 
-    static func menuTitles(for entries: [ReaderRecentWatchedFolder]) -> [String: String] {
+    static func menuTitles(for entries: [RecentWatchedFolder]) -> [String: String] {
         let baseTitlesByPath = menuTitles(
             for: entries,
             keyPath: \.folderPath,

--- a/minimark/Support/ReaderSettingsGuidance.swift
+++ b/minimark/Support/ReaderSettingsGuidance.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum ReaderSettingsGuidance {
-    static func layoutHelpText(selectedMode: ReaderMultiFileDisplayMode) -> String {
+    static func layoutHelpText(selectedMode: MultiFileDisplayMode) -> String {
         switch selectedMode {
         case .sidebarLeft, .sidebarRight:
             return "Sidebar placement changes immediately."

--- a/minimark/Support/SecurityScopedBookmarkResolver.swift
+++ b/minimark/Support/SecurityScopedBookmarkResolver.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Resolves security-scoped bookmark data to a URL, falling back to an
 /// original URL when bookmark data is absent or resolution fails.
 ///
-/// Shared by `ReaderRecentOpenedFile` and `ReaderRecentWatchedFolder`.
+/// Shared by `RecentOpenedFile` and `RecentWatchedFolder`.
 nonisolated enum SecurityScopedBookmarkResolver {
 
     /// Resolve security-scoped bookmark data to a URL.

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -65,8 +65,8 @@ final class ContentAreaViewModel {
         return nil
     }
 
-    var currentReaderTheme: ReaderTheme {
-        ReaderTheme.theme(for: folderWatchState.effectiveReaderTheme)
+    var currentReaderTheme: Theme {
+        Theme.theme(for: folderWatchState.effectiveReaderTheme)
     }
 
     var overlayColorScheme: ColorScheme {

--- a/minimark/Views/Content/ContentDocumentSurfaceViews.swift
+++ b/minimark/Views/Content/ContentDocumentSurfaceViews.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DocumentLoadingOverlay: View {
-    let theme: ReaderTheme
+    let theme: Theme
     let headline: String
     let subtitle: String?
 
@@ -259,7 +259,7 @@ struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: Vie
     let loadingOverlayHeadline: String
     let loadingOverlaySubtitle: String?
     let emptyStateVariant: ContentEmptyStateView.Variant
-    let currentReaderTheme: ReaderTheme
+    let currentReaderTheme: Theme
     let onDroppedFileURLs: ([URL]) -> Void
     let previewSurface: PreviewSurface
     let sourceSurface: SourceSurface

--- a/minimark/Views/Content/ContentEmptyStateView.swift
+++ b/minimark/Views/Content/ContentEmptyStateView.swift
@@ -9,7 +9,7 @@ struct ContentEmptyStateView: View {
     }
 
     let variant: Variant
-    let theme: ReaderTheme
+    let theme: Theme
 
     private var watchTintColor: Color {
         WatchActiveColor.color(for: colorScheme)

--- a/minimark/Views/Content/ContentViewAction.swift
+++ b/minimark/Views/Content/ContentViewAction.swift
@@ -9,13 +9,13 @@ enum ContentViewAction {
     case saveFolderWatchAsFavorite(String)
     case removeCurrentWatchFromFavorites
     case toggleAppearanceLock
-    case startFavoriteWatch(ReaderFavoriteWatchedFolder)
+    case startFavoriteWatch(FavoriteWatchedFolder)
     case clearFavoriteWatchedFolders
     case renameFavoriteWatchedFolder(id: UUID, name: String)
     case removeFavoriteWatchedFolder(UUID)
     case reorderFavoriteWatchedFolders([UUID])
-    case startRecentManuallyOpenedFile(ReaderRecentOpenedFile)
-    case startRecentFolderWatch(ReaderRecentWatchedFolder)
+    case startRecentManuallyOpenedFile(RecentOpenedFile)
+    case startRecentFolderWatch(RecentWatchedFolder)
     case clearRecentWatchedFolders
     case clearRecentManuallyOpenedFiles
     case editSubfolders
@@ -24,7 +24,7 @@ enum ContentViewAction {
     case startSourceEditing
     case updateSourceDraft(String)
     case grantImageDirectoryAccess(URL)
-    case openInApplication(ReaderExternalApplication?)
+    case openInApplication(ExternalApplication?)
     case revealInFinder
     case presentError(Error)
     case updateTOCHeadings([TOCHeading])

--- a/minimark/Views/Content/ContentViewFolderWatchState.swift
+++ b/minimark/Views/Content/ContentViewFolderWatchState.swift
@@ -7,9 +7,9 @@ struct ContentViewFolderWatchState: Equatable {
     let canStopFolderWatch: Bool
     let pendingFolderWatchURL: URL?
     let isCurrentWatchAFavorite: Bool
-    let favoriteWatchedFolders: [ReaderFavoriteWatchedFolder]
-    let recentWatchedFolders: [ReaderRecentWatchedFolder]
-    let recentManuallyOpenedFiles: [ReaderRecentOpenedFile]
+    let favoriteWatchedFolders: [FavoriteWatchedFolder]
+    let recentWatchedFolders: [RecentWatchedFolder]
+    let recentManuallyOpenedFiles: [RecentOpenedFile]
     let isAppearanceLocked: Bool
-    let effectiveReaderTheme: ReaderThemeKind
+    let effectiveReaderTheme: ThemeKind
 }

--- a/minimark/Views/Content/EditFavoritesSheet.swift
+++ b/minimark/Views/Content/EditFavoritesSheet.swift
@@ -8,11 +8,11 @@ enum EditFavoritesAction {
 }
 
 struct EditFavoritesSheet: View {
-    let favorites: [ReaderFavoriteWatchedFolder]
+    let favorites: [FavoriteWatchedFolder]
     let onAction: (EditFavoritesAction) -> Void
 
     @State private var draftNames: [UUID: String] = [:]
-    @State private var localOrder: [ReaderFavoriteWatchedFolder] = []
+    @State private var localOrder: [FavoriteWatchedFolder] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -36,7 +36,7 @@ struct EditFavoritesSheet: View {
                 newFavorites.map { ($0.id, $0) },
                 uniquingKeysWith: { first, _ in first }
             )
-            var updatedOrder: [ReaderFavoriteWatchedFolder] = []
+            var updatedOrder: [FavoriteWatchedFolder] = []
             var seenIDs = Set<UUID>()
             for entry in localOrder {
                 if let updated = favoritesById[entry.id] {
@@ -138,14 +138,14 @@ struct EditFavoritesSheet: View {
         )
     }
 
-    private func bindingForDraft(_ entry: ReaderFavoriteWatchedFolder) -> Binding<String> {
+    private func bindingForDraft(_ entry: FavoriteWatchedFolder) -> Binding<String> {
         Binding(
             get: { draftNames[entry.id] ?? entry.name },
             set: { draftNames[entry.id] = $0 }
         )
     }
 
-    private func commitRename(for entry: ReaderFavoriteWatchedFolder) {
+    private func commitRename(for entry: FavoriteWatchedFolder) {
         guard let draft = draftNames[entry.id] else { return }
         let trimmed = draft.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, trimmed != entry.name else { return }
@@ -161,7 +161,7 @@ struct EditFavoritesSheet: View {
         }
     }
 
-    private func deleteEntry(_ entry: ReaderFavoriteWatchedFolder) {
+    private func deleteEntry(_ entry: FavoriteWatchedFolder) {
         localOrder.removeAll { $0.id == entry.id }
         draftNames.removeValue(forKey: entry.id)
         onAction(.delete(entry.id))
@@ -175,7 +175,7 @@ struct EditFavoritesSheet: View {
 // MARK: - Favorite Row
 
 private struct FavoriteRow: View {
-    let entry: ReaderFavoriteWatchedFolder
+    let entry: FavoriteWatchedFolder
     @Binding var draftName: String
     let onCommitRename: () -> Void
     let onDelete: () -> Void

--- a/minimark/Views/Content/OpenInMenuButton.swift
+++ b/minimark/Views/Content/OpenInMenuButton.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 @MainActor
-func appIconImage(for app: ReaderExternalApplication) -> NSImage? {
+func appIconImage(for app: ExternalApplication) -> NSImage? {
     let iconPath: String
     if let bundleIdentifier = app.bundleIdentifier,
        let installedURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
@@ -23,15 +23,15 @@ func appIconImage(for app: ReaderExternalApplication) -> NSImage? {
 
 enum OpenInMenuAction {
     case openFiles([URL])
-    case openInApp(ReaderExternalApplication)
+    case openInApp(ExternalApplication)
     case revealInFinder
     case requestFolderWatch(URL)
     case stopFolderWatch
-    case startFavoriteWatch(ReaderFavoriteWatchedFolder)
+    case startFavoriteWatch(FavoriteWatchedFolder)
     case clearFavoriteWatchedFolders
     case editFavoriteWatchedFolders
-    case startRecentManuallyOpenedFile(ReaderRecentOpenedFile)
-    case startRecentFolderWatch(ReaderRecentWatchedFolder)
+    case startRecentManuallyOpenedFile(RecentOpenedFile)
+    case startRecentFolderWatch(RecentWatchedFolder)
     case clearRecentWatchedFolders
     case clearRecentManuallyOpenedFiles
 }
@@ -39,11 +39,11 @@ enum OpenInMenuAction {
 struct OpenInMenuButton: NSViewRepresentable {
     let hasFile: Bool
     let hasActiveFolderWatch: Bool
-    let apps: [ReaderExternalApplication]
-    let favoriteWatchedFolders: [ReaderFavoriteWatchedFolder]
-    let recentWatchedFolders: [ReaderRecentWatchedFolder]
-    let recentManuallyOpenedFiles: [ReaderRecentOpenedFile]
-    let iconProvider: (ReaderExternalApplication) -> NSImage?
+    let apps: [ExternalApplication]
+    let favoriteWatchedFolders: [FavoriteWatchedFolder]
+    let recentWatchedFolders: [RecentWatchedFolder]
+    let recentManuallyOpenedFiles: [RecentOpenedFile]
+    let iconProvider: (ExternalApplication) -> NSImage?
     let onAction: (OpenInMenuAction) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -88,7 +88,7 @@ struct OpenInMenuButton: NSViewRepresentable {
 
     final class Coordinator: NSObject {
         var parent: OpenInMenuButton
-        var appByID: [String: ReaderExternalApplication] = [:]
+        var appByID: [String: ExternalApplication] = [:]
         weak var button: NSButton?
 
         init(parent: OpenInMenuButton) {

--- a/minimark/Views/Content/ReaderTopBar.swift
+++ b/minimark/Views/Content/ReaderTopBar.swift
@@ -31,17 +31,17 @@ enum ReaderTopBarMetrics {
 
 enum ReaderTopBarAction {
     case openFiles([URL])
-    case openInApp(ReaderExternalApplication)
+    case openInApp(ExternalApplication)
     case revealInFinder
     case requestFolderWatch(URL)
     case stopFolderWatch
-    case startFavoriteWatch(ReaderFavoriteWatchedFolder)
+    case startFavoriteWatch(FavoriteWatchedFolder)
     case clearFavoriteWatchedFolders
     case renameFavoriteWatchedFolder(id: UUID, name: String)
     case removeFavoriteWatchedFolder(UUID)
     case reorderFavoriteWatchedFolders([UUID])
-    case startRecentManuallyOpenedFile(ReaderRecentOpenedFile)
-    case startRecentFolderWatch(ReaderRecentWatchedFolder)
+    case startRecentManuallyOpenedFile(RecentOpenedFile)
+    case startRecentFolderWatch(RecentWatchedFolder)
     case clearRecentWatchedFolders
     case clearRecentManuallyOpenedFiles
     case saveSourceDraft
@@ -70,11 +70,11 @@ struct ReaderTopBar: View {
     let sourceEditing: ReaderSourceEditingController
     let statusBarTimestamp: ReaderStatusBarTimestamp?
     let canStopFolderWatch: Bool
-    let apps: [ReaderExternalApplication]
-    let favoriteWatchedFolders: [ReaderFavoriteWatchedFolder]
-    let recentWatchedFolders: [ReaderRecentWatchedFolder]
-    let recentManuallyOpenedFiles: [ReaderRecentOpenedFile]
-    let iconProvider: (ReaderExternalApplication) -> NSImage?
+    let apps: [ExternalApplication]
+    let favoriteWatchedFolders: [FavoriteWatchedFolder]
+    let recentWatchedFolders: [RecentWatchedFolder]
+    let recentManuallyOpenedFiles: [RecentOpenedFile]
+    let iconProvider: (ExternalApplication) -> NSImage?
     let onAction: (ReaderTopBarAction) -> Void
 
     private enum Metrics {

--- a/minimark/Views/Content/ReaderTopBarComponents.swift
+++ b/minimark/Views/Content/ReaderTopBarComponents.swift
@@ -5,8 +5,8 @@ import SwiftUI
 
 enum FolderWatchToolbarAction {
     case activate
-    case startFavoriteWatch(ReaderFavoriteWatchedFolder)
-    case startRecentFolderWatch(ReaderRecentWatchedFolder)
+    case startFavoriteWatch(FavoriteWatchedFolder)
+    case startRecentFolderWatch(RecentWatchedFolder)
     case editFavoriteWatchedFolders
     case clearRecentWatchedFolders
 }
@@ -15,8 +15,8 @@ struct FolderWatchToolbarButton: View {
     let activeFolderWatch: FolderWatchSession?
     let isInitialScanInProgress: Bool
     let didInitialScanFail: Bool
-    let favoriteWatchedFolders: [ReaderFavoriteWatchedFolder]
-    let recentWatchedFolders: [ReaderRecentWatchedFolder]
+    let favoriteWatchedFolders: [FavoriteWatchedFolder]
+    let recentWatchedFolders: [RecentWatchedFolder]
     let onAction: (FolderWatchToolbarAction) -> Void
     var compact: Bool = false
 

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -107,7 +107,7 @@ struct ReaderSettingsView: View {
                     get: { settingsStore.currentSettings.multiFileDisplayMode },
                     set: { updateMultiFileDisplayMode($0) }
                 )) {
-                    ForEach(ReaderMultiFileDisplayMode.allCases, id: \.self) { mode in
+                    ForEach(MultiFileDisplayMode.allCases, id: \.self) { mode in
                         Text(mode.displayName).tag(mode)
                     }
                 }
@@ -202,7 +202,7 @@ struct ReaderSettingsView: View {
         ReaderSettingsGuidance.layoutHelpText(selectedMode: settingsStore.currentSettings.multiFileDisplayMode)
     }
 
-    private func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode) {
+    private func updateMultiFileDisplayMode(_ mode: MultiFileDisplayMode) {
         settingsStore.updateMultiFileDisplayMode(mode)
     }
 
@@ -293,8 +293,8 @@ extension Color {
 struct ThemePreviewCard: View {
     let settings: ReaderSettings
 
-    private var theme: ReaderTheme {
-        ReaderTheme.theme(for: settings.readerTheme)
+    private var theme: Theme {
+        Theme.theme(for: settings.readerTheme)
     }
 
     private var syntaxPalette: SyntaxThemePreviewPalette {
@@ -439,7 +439,7 @@ enum ThemePreviewTextRole: String, Sendable {
 }
 
 enum ThemePreviewReaderTextExamples {
-    static func reader(theme: ReaderTheme) -> [ThemePreviewColorSample] {
+    static func reader(theme: Theme) -> [ThemePreviewColorSample] {
         [
             ThemePreviewColorSample(text: "Heading accent sample", role: .heading, hex: theme.h1Hex ?? theme.foregroundHex),
             ThemePreviewColorSample(text: "Primary body sample text", role: .body, hex: theme.foregroundHex),

--- a/minimark/Views/ReaderSidebarWorkspaceView.swift
+++ b/minimark/Views/ReaderSidebarWorkspaceView.swift
@@ -12,13 +12,13 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
     var controller: ReaderSidebarDocumentController
     var settingsStore: ReaderSettingsStore
     var groupState: SidebarGroupStateController
-    let sidebarPlacement: ReaderMultiFileDisplayMode.SidebarPlacement
+    let sidebarPlacement: MultiFileDisplayMode.SidebarPlacement
     let sidebarWidth: CGFloat
     let onSidebarWidthChanged: (CGFloat) -> Void
     let detail: (ReaderStore) -> Detail
     let onToggleSidebarPlacement: () -> Void
     let onOpenInDefaultApp: (Set<UUID>) -> Void
-    let onOpenInApplication: (ReaderExternalApplication, Set<UUID>) -> Void
+    let onOpenInApplication: (ExternalApplication, Set<UUID>) -> Void
     let onRevealInFinder: (Set<UUID>) -> Void
     let onStopWatchingFolders: (Set<UUID>) -> Void
     let onCloseDocuments: (Set<UUID>) -> Void
@@ -211,7 +211,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
 
     private var sidebarGroupSortMenu: some View {
         Menu {
-            ForEach(ReaderSidebarSortMode.availableCases(hasManualOrder: groupState.manualGroupOrder != nil), id: \.self) { mode in
+            ForEach(SidebarSortMode.availableCases(hasManualOrder: groupState.manualGroupOrder != nil), id: \.self) { mode in
                 Button {
                     groupState.sortMode = mode
                 } label: {
@@ -248,7 +248,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
 
     private var sidebarFileSortMenu: some View {
         Menu {
-            ForEach(ReaderSidebarSortMode.allCases, id: \.self) { mode in
+            ForEach(SidebarSortMode.allCases, id: \.self) { mode in
                 Button {
                     groupState.fileSortMode = mode
                 } label: {
@@ -301,7 +301,7 @@ private struct ReaderSidebarDocumentRow: View {
     let showsSelectionBackground: Bool
     let canClose: Bool
     let onOpenInDefaultApp: (Set<UUID>) -> Void
-    let onOpenInApplication: (ReaderExternalApplication, Set<UUID>) -> Void
+    let onOpenInApplication: (ExternalApplication, Set<UUID>) -> Void
     let onRevealInFinder: (Set<UUID>) -> Void
     let onStopWatchingFolders: (Set<UUID>) -> Void
     let onClose: (Set<UUID>) -> Void
@@ -324,7 +324,7 @@ private struct ReaderSidebarDocumentRow: View {
         effectiveDocuments.map(\.readerStore)
     }
 
-    private var effectiveOpenInApplications: [ReaderExternalApplication] {
+    private var effectiveOpenInApplications: [ExternalApplication] {
         guard let firstReaderStore = effectiveReaderStores.first(where: { $0.document.fileURL != nil }) else {
             return []
         }
@@ -722,7 +722,7 @@ private struct SidebarGroupListContent: View {
     let watchedDocumentIDs: Set<UUID>
     let onUpdateSelection: (Set<UUID>) -> Void
     let onOpenInDefaultApp: (Set<UUID>) -> Void
-    let onOpenInApplication: (ReaderExternalApplication, Set<UUID>) -> Void
+    let onOpenInApplication: (ExternalApplication, Set<UUID>) -> Void
     let onRevealInFinder: (Set<UUID>) -> Void
     let onStopWatchingFolders: (Set<UUID>) -> Void
     let onCloseDocuments: (Set<UUID>) -> Void
@@ -763,7 +763,7 @@ private struct SidebarGroupListContent: View {
 
     @ViewBuilder
     private func groupedSidebarList(
-        groups: [ReaderSidebarGrouping.Group]
+        groups: [SidebarGrouping.Group]
     ) -> some View {
         let dragSourceIndex = draggedGroupID.flatMap { id in
             groups.firstIndex { $0.id == id }
@@ -791,7 +791,7 @@ private struct SidebarGroupListContent: View {
     }
 
     private func groupedSection(
-        for group: ReaderSidebarGrouping.Group,
+        for group: SidebarGrouping.Group,
         at index: Int
     ) -> some View {
         let isExpanded = groupState.isGroupExpanded(group.id)
@@ -872,7 +872,7 @@ private struct SidebarGroupListContent: View {
         }
     }
 
-    private func handleDragEnd(_ value: DragGesture.Value, groups grouping: ReaderSidebarGrouping) {
+    private func handleDragEnd(_ value: DragGesture.Value, groups grouping: SidebarGrouping) {
         guard let draggedID = draggedGroupID,
               case .grouped(let groups) = grouping,
               let sourceIndex = groups.firstIndex(where: { $0.id == draggedID }),
@@ -908,7 +908,7 @@ private struct SidebarGroupListContent: View {
         }
     }
 
-    private func targetIndexFromGlobalY(_ globalY: CGFloat, groups: [ReaderSidebarGrouping.Group]) -> Int {
+    private func targetIndexFromGlobalY(_ globalY: CGFloat, groups: [SidebarGrouping.Group]) -> Int {
         for (index, group) in groups.enumerated() {
             if group.id == draggedGroupID { continue }
             guard let frame = groupFrameCache.frames[group.id] else { continue }

--- a/minimark/Views/ReaderWindowRootView.swift
+++ b/minimark/Views/ReaderWindowRootView.swift
@@ -2,9 +2,9 @@ import AppKit
 import SwiftUI
 
 struct ReaderWindowRootView: View {
-    let seed: ReaderWindowSeed?
+    let seed: WindowSeed?
     var settingsStore: ReaderSettingsStore
-    let multiFileDisplayMode: ReaderMultiFileDisplayMode
+    let multiFileDisplayMode: MultiFileDisplayMode
 
     @Environment(\.openWindow) private var openWindow
     @State var sidebarDocumentController: ReaderSidebarDocumentController
@@ -17,9 +17,9 @@ struct ReaderWindowRootView: View {
     @State var uiTestLaunchCoordinator = UITestLaunchCoordinator()
 
     init(
-        seed: ReaderWindowSeed?,
+        seed: WindowSeed?,
         settingsStore: ReaderSettingsStore,
-        multiFileDisplayMode: ReaderMultiFileDisplayMode
+        multiFileDisplayMode: MultiFileDisplayMode
     ) {
         self.seed = seed
         self.settingsStore = settingsStore
@@ -46,7 +46,7 @@ struct ReaderWindowRootView: View {
         )
     }
 
-    private var sidebarPlacement: ReaderMultiFileDisplayMode.SidebarPlacement {
+    private var sidebarPlacement: MultiFileDisplayMode.SidebarPlacement {
         let effectiveMode = favoriteWorkspaceController.activeFavoriteWorkspaceState?.sidebarPosition ?? multiFileDisplayMode
         return effectiveMode.sidebarPlacement
     }
@@ -99,7 +99,7 @@ struct ReaderWindowRootView: View {
     }
 
     private var windowShell: some View {
-        let theme = ReaderTheme.theme(for: settingsStore.currentSettings.readerTheme)
+        let theme = Theme.theme(for: settingsStore.currentSettings.readerTheme)
         return ZStack {
             Rectangle()
                 .fill(Color(hex: theme.backgroundHex) ?? .clear)

--- a/minimark/Views/ThemeCardView.swift
+++ b/minimark/Views/ThemeCardView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ReaderThemeCard: View {
-    let kind: ReaderThemeKind
+    let kind: ThemeKind
     let isSelected: Bool
     let action: () -> Void
 

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -9,7 +9,7 @@ struct ThemeSelectorColumnWidths {
 struct ThemeSelectorView: View {
     private let settingsStore: ReaderSettingsStore
 
-    @State private var stagedReaderTheme: ReaderThemeKind
+    @State private var stagedReaderTheme: ThemeKind
     @State private var stagedSyntaxTheme: SyntaxThemeKind
     @State private var selectedBackgroundTab: BackgroundTab = .light
 
@@ -188,8 +188,8 @@ struct ThemeSelectorView: View {
         .padding(.top, 12)
     }
 
-    private var filteredReaderThemes: [ReaderThemeKind] {
-        ReaderThemeKind.allCases.filter {
+    private var filteredReaderThemes: [ThemeKind] {
+        ThemeKind.allCases.filter {
             selectedBackgroundTab == .light ? !$0.isDark : $0.isDark
         }
     }
@@ -202,7 +202,7 @@ struct ThemeSelectorView: View {
         stagedReaderTheme != appliedReaderTheme || stagedSyntaxTheme != appliedSyntaxTheme
     }
 
-    private var appliedReaderTheme: ReaderThemeKind {
+    private var appliedReaderTheme: ThemeKind {
         settingsStore.currentSettings.readerTheme
     }
 

--- a/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
+++ b/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
@@ -20,7 +20,7 @@ final class ContentViewActionRouter {
     private let applyTitlePresentation: () -> Void
     private let confirmFolderWatch: (FolderWatchOptions) -> Void
     private let stopFolderWatch: () -> Void
-    private let startFavoriteWatch: (ReaderFavoriteWatchedFolder) -> Void
+    private let startFavoriteWatch: (FavoriteWatchedFolder) -> Void
     private let setEditingSubfolders: (Bool) -> Void
     private let setEditingFavorites: (Bool) -> Void
 
@@ -37,7 +37,7 @@ final class ContentViewActionRouter {
         applyTitlePresentation: @escaping () -> Void,
         confirmFolderWatch: @escaping (FolderWatchOptions) -> Void,
         stopFolderWatch: @escaping () -> Void,
-        startFavoriteWatch: @escaping (ReaderFavoriteWatchedFolder) -> Void,
+        startFavoriteWatch: @escaping (FavoriteWatchedFolder) -> Void,
         setEditingSubfolders: @escaping (Bool) -> Void,
         setEditingFavorites: @escaping (Bool) -> Void
     ) {

--- a/minimark/Views/Window/Coordination/SidebarDocumentActionRouter.swift
+++ b/minimark/Views/Window/Coordination/SidebarDocumentActionRouter.swift
@@ -50,7 +50,7 @@ final class SidebarDocumentActionRouter {
         sidebarDocumentController.openDocumentsInApplication(nil, documentIDs: documentIDs)
     }
 
-    func openDocumentsInApplication(_ application: ReaderExternalApplication, _ documentIDs: Set<UUID>) {
+    func openDocumentsInApplication(_ application: ExternalApplication, _ documentIDs: Set<UUID>) {
         sidebarDocumentController.openDocumentsInApplication(application, documentIDs: documentIDs)
     }
 
@@ -64,7 +64,7 @@ final class SidebarDocumentActionRouter {
         }
     }
 
-    func toggleSidebarPlacement(currentMultiFileDisplayMode: ReaderMultiFileDisplayMode) {
+    func toggleSidebarPlacement(currentMultiFileDisplayMode: MultiFileDisplayMode) {
         if let favoriteController = favoriteWorkspaceControllerProvider(),
            let current = favoriteController.activeFavoriteWorkspaceState?.sidebarPosition {
             favoriteController.updateSidebarPosition(current.toggledSidebarPlacementMode)

--- a/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
@@ -6,7 +6,7 @@ import Foundation
 @MainActor
 private struct WindowStoreCallbackConfigurator {
     let lockedAppearanceProvider: @MainActor () -> LockedAppearance?
-    let onOpenAdditionalDocument: (URL, FolderWatchSession?, ReaderOpenOrigin, String?) -> Void
+    let onOpenAdditionalDocument: (URL, FolderWatchSession?, OpenOrigin, String?) -> Void
 
     func configure(_ store: ReaderStore) {
         if let lockedAppearance = lockedAppearanceProvider() {
@@ -114,7 +114,7 @@ final class WindowDocumentOpenCoordinator {
 
     func openDocumentInSelectedSlot(
         at fileURL: URL,
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         folderWatchSession: FolderWatchSession? = nil,
         initialDiffBaselineMarkdown: String? = nil
     ) {
@@ -132,7 +132,7 @@ final class WindowDocumentOpenCoordinator {
     func openAdditionalDocument(
         _ fileURL: URL,
         folderWatchSession: FolderWatchSession? = nil,
-        origin: ReaderOpenOrigin = .manual,
+        origin: OpenOrigin = .manual,
         initialDiffBaselineMarkdown: String? = nil
     ) {
         let normalizedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
@@ -152,7 +152,7 @@ final class WindowDocumentOpenCoordinator {
     func openAdditionalDocumentInCurrentWindow(
         _ fileURL: URL,
         folderWatchSession: FolderWatchSession? = nil,
-        origin: ReaderOpenOrigin = .manual,
+        origin: OpenOrigin = .manual,
         initialDiffBaselineMarkdown: String? = nil
     ) {
         let normalizedFileURL = ReaderFileRouting.normalizedFileURL(fileURL)
@@ -176,7 +176,7 @@ final class WindowDocumentOpenCoordinator {
         applyTitlePresentation()
     }
 
-    func applyInitialSeedIfNeeded(seed: ReaderWindowSeed?) {
+    func applyInitialSeedIfNeeded(seed: WindowSeed?) {
         ReaderWindowOpenAndWatchFlowSupport.applyInitialSeedIfNeeded(
             seed: seed,
             openDocumentInCurrentWindow: { [weak self] fileURL in

--- a/minimark/Views/Window/Coordination/WindowEventBridge.swift
+++ b/minimark/Views/Window/Coordination/WindowEventBridge.swift
@@ -85,7 +85,7 @@ final class WindowEventBridge {
         openDocumentPathTracker.update(from: sidebarDocumentController.documents)
     }
 
-    func handleFavoriteWorkspaceStateChange(_ newState: ReaderFavoriteWorkspaceState?) {
+    func handleFavoriteWorkspaceStateChange(_ newState: FavoriteWorkspaceState?) {
         guard let favoriteID = favoriteWorkspaceControllerProvider()?.activeFavoriteID,
               var state = newState else { return }
         state.lockedAppearance = appearanceControllerProvider()?.lockedAppearance

--- a/minimark/Views/Window/Coordination/WindowFolderWatchOpenController.swift
+++ b/minimark/Views/Window/Coordination/WindowFolderWatchOpenController.swift
@@ -32,7 +32,7 @@ final class WindowFolderWatchOpenController {
     func enqueue(
         _ event: FolderWatchChangeEvent,
         folderWatchSession: FolderWatchSession?,
-        origin: ReaderOpenOrigin
+        origin: OpenOrigin
     ) {
         batcher.enqueue(
             event,

--- a/minimark/Views/Window/Coordination/WindowFolderWatchSessionFlow.swift
+++ b/minimark/Views/Window/Coordination/WindowFolderWatchSessionFlow.swift
@@ -32,7 +32,7 @@ final class WindowFolderWatchSessionFlow {
         self.refreshWindowPresentation = refreshWindowPresentation
     }
 
-    func startFavoriteWatch(_ entry: ReaderFavoriteWatchedFolder) {
+    func startFavoriteWatch(_ entry: FavoriteWatchedFolder) {
         guard let favoriteWorkspaceController = favoriteWorkspaceControllerProvider() else { return }
         sidebarMetrics.width = favoriteWorkspaceController.startFavoriteWatch(entry)
         refreshWindowPresentation()

--- a/minimark/Views/Window/Flow/ReaderWindowOpenAndWatchFlowSupport.swift
+++ b/minimark/Views/Window/Flow/ReaderWindowOpenAndWatchFlowSupport.swift
@@ -6,11 +6,11 @@ enum ReaderWindowOpenAndWatchFlowSupport {
     }
 
     static func applyInitialSeedIfNeeded(
-        seed: ReaderWindowSeed?,
+        seed: WindowSeed?,
         openDocumentInCurrentWindow: (URL) -> Void,
-        openDocumentInSelectedSlot: (URL, ReaderOpenOrigin, FolderWatchSession?, String?) -> Void,
-        resolveRecentOpenedFileURL: (ReaderRecentOpenedFile) -> URL,
-        resolveRecentWatchedFolderURL: (ReaderRecentWatchedFolder) -> URL,
+        openDocumentInSelectedSlot: (URL, OpenOrigin, FolderWatchSession?, String?) -> Void,
+        resolveRecentOpenedFileURL: (RecentOpenedFile) -> URL,
+        resolveRecentWatchedFolderURL: (RecentWatchedFolder) -> URL,
         prepareRecentFolderWatch: (URL, FolderWatchOptions) -> Void
     ) {
         if let recentOpenedFile = seed?.recentOpenedFile {

--- a/minimark/Views/Window/SidebarSplitView.swift
+++ b/minimark/Views/Window/SidebarSplitView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// No per-pixel updates occur — width is only reported on mouse-up.
 struct SidebarDividerPositionSetter: NSViewRepresentable {
     let targetWidth: CGFloat
-    let placement: ReaderMultiFileDisplayMode.SidebarPlacement
+    let placement: MultiFileDisplayMode.SidebarPlacement
     let onDividerDragged: (CGFloat) -> Void
     let onDividerDragActive: (Bool) -> Void
 
@@ -38,11 +38,11 @@ final class SidebarPositionHelperView: NSView {
     private static let dividerHitZone: CGFloat = 6
 
     var targetWidth: CGFloat = 0
-    var placement: ReaderMultiFileDisplayMode.SidebarPlacement = .left
+    var placement: MultiFileDisplayMode.SidebarPlacement = .left
     var onDividerDragged: ((CGFloat) -> Void)?
     var onDividerDragActive: ((Bool) -> Void)?
     private var lastAppliedWidth: CGFloat = 0
-    private var lastAppliedPlacement: ReaderMultiFileDisplayMode.SidebarPlacement?
+    private var lastAppliedPlacement: MultiFileDisplayMode.SidebarPlacement?
     private var mouseDownMonitor: Any?
     private var mouseUpMonitor: Any?
     private var isDraggingDivider = false
@@ -71,7 +71,7 @@ final class SidebarPositionHelperView: NSView {
         onDividerDragActive?(false)
     }
 
-    func updateIfNeeded(targetWidth newWidth: CGFloat, placement newPlacement: ReaderMultiFileDisplayMode.SidebarPlacement) {
+    func updateIfNeeded(targetWidth newWidth: CGFloat, placement newPlacement: MultiFileDisplayMode.SidebarPlacement) {
         let widthChanged = abs(targetWidth - newWidth) > Self.widthEpsilon
         let placementChanged = placement != newPlacement
         if widthChanged { targetWidth = newWidth }

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -25,7 +25,7 @@ struct MarkdownObserverApp: App {
         let activeMultiFileDisplayMode = settingsStore.currentSettings.multiFileDisplayMode
         let appAppearance = settingsStore.currentSettings.appAppearance
 
-        WindowGroup("MarkdownObserver", for: ReaderWindowSeed.self) { seed in
+        WindowGroup("MarkdownObserver", for: WindowSeed.self) { seed in
             ReaderWindowRootView(
                 seed: seed.wrappedValue,
                 settingsStore: settingsStore,

--- a/minimarkShared/ReaderAccessibilityID.swift
+++ b/minimarkShared/ReaderAccessibilityID.swift
@@ -1,7 +1,8 @@
-import SwiftUI
+import Foundation
 
 /// Every accessibility identifier used by production views and `minimarkUITests`
-/// goes through this enum. UI tests reach the raw values via `@testable import minimark`.
+/// goes through this enum. UI tests access the raw values because `minimarkShared`
+/// is compiled into the UI-test target as well as the app target.
 enum ReaderAccessibilityID: String {
     case readerPreviewSummary = "reader-preview-summary"
     case tocButton = "toc-button"
@@ -23,11 +24,5 @@ enum ReaderAccessibilityID: String {
 
     static func sidebarDocument(title: String) -> String {
         "sidebar-document-\(title)"
-    }
-}
-
-extension View {
-    func accessibilityIdentifier(_ id: ReaderAccessibilityID) -> some View {
-        accessibilityIdentifier(id.rawValue)
     }
 }

--- a/minimarkShared/ReaderPreviewAccessibilitySummary.swift
+++ b/minimarkShared/ReaderPreviewAccessibilitySummary.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Typed representation of the accessibility value carried by the reader
-/// preview surface. Producer and consumer both round-trip through this type so
-/// a change in one side is a build-time error on the other.
+/// preview surface. Producer and consumer both round-trip through this shared
+/// type, making it the single source of truth for the payload format.
 struct ReaderPreviewAccessibilitySummary: Equatable, CustomStringConvertible {
     enum Surface: String {
         case preview

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -13,12 +13,12 @@ private func makeTestViewModel(
         settingsStore: settingsStore,
         requestWatchedFolderReauthorization: { _ in nil }
     )
-    let fileDeps = ReaderFileDependencies(
+    let fileDeps = FileDependencies(
         watcher: FileChangeWatcher(),
         io: ReaderDocumentIOService(),
         actions: ReaderFileActionService()
     )
-    let renderingDeps = ReaderRenderingDependencies(
+    let renderingDeps = RenderingDependencies(
         renderer: MarkdownRenderingService(),
         differ: ChangedRegionDiffer()
     )
@@ -245,12 +245,12 @@ struct ContentAreaViewModelDropRoutingTests {
             settingsStore: settingsStore,
             requestWatchedFolderReauthorization: { _ in nil }
         )
-        let fileDeps = ReaderFileDependencies(
+        let fileDeps = FileDependencies(
             watcher: FileChangeWatcher(),
             io: ReaderDocumentIOService(),
             actions: ReaderFileActionService()
         )
-        let renderingDeps = ReaderRenderingDependencies(
+        let renderingDeps = RenderingDependencies(
             renderer: MarkdownRenderingService(),
             differ: ChangedRegionDiffer()
         )

--- a/minimarkTests/Core/ContentViewActionRouterTests.swift
+++ b/minimarkTests/Core/ContentViewActionRouterTests.swift
@@ -14,7 +14,7 @@ struct ContentViewActionRouterTests {
         let folderWatchOpen: WindowFolderWatchOpenController
         var confirmFolderWatchCalls: [FolderWatchOptions] = []
         var stopFolderWatchCalls = 0
-        var startFavoriteWatchCalls: [ReaderFavoriteWatchedFolder] = []
+        var startFavoriteWatchCalls: [FavoriteWatchedFolder] = []
         var setEditingSubfoldersCalls: [Bool] = []
         var setEditingFavoritesCalls: [Bool] = []
         var applyTitleCalls = 0
@@ -73,7 +73,7 @@ struct ContentViewActionRouterTests {
         final class MutableState {
             var confirmFolderWatchCalls: [FolderWatchOptions] = []
             var stopFolderWatchCalls = 0
-            var startFavoriteWatchCalls: [ReaderFavoriteWatchedFolder] = []
+            var startFavoriteWatchCalls: [FavoriteWatchedFolder] = []
             var setEditingSubfoldersCalls: [Bool] = []
             var setEditingFavoritesCalls: [Bool] = []
             var applyTitleCalls = 0

--- a/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
+++ b/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
@@ -19,7 +19,7 @@ struct FavoriteWorkspaceControllerTests {
     @Test @MainActor func activateSetsIDAndWorkspaceState() {
         let controller = makeController()
         let id = UUID()
-        let state = ReaderFavoriteWorkspaceState.from(
+        let state = FavoriteWorkspaceState.from(
             settings: .default, pinnedGroupIDs: ["pinned"], collapsedGroupIDs: [], sidebarWidth: 300
         )
         controller.activate(id: id, workspaceState: state)
@@ -103,7 +103,7 @@ struct FavoriteWorkspaceControllerTests {
         let options = FolderWatchOptions(
             openMode: .watchChangesOnly, scope: .selectedFolderOnly, excludedSubdirectoryPaths: []
         )
-        let favorite = ReaderFavoriteWatchedFolder(
+        let favorite = FavoriteWatchedFolder(
             name: "Test", folderPath: normalizedPath, options: options, bookmarkData: nil, createdAt: .now
         )
         let result = controller.matchingFavorite(folderURL: folderURL, options: options, in: [favorite])
@@ -123,7 +123,7 @@ struct FavoriteWorkspaceControllerTests {
         let controller = FavoriteWorkspaceController(settingsStore: store)
         store.addFavoriteWatchedFolder(name: "Persist", folderURL: URL(fileURLWithPath: "/tmp/persist"), options: .default)
         let favoriteID = store.currentSettings.favoriteWatchedFolders.first!.id
-        var workspaceState = ReaderFavoriteWorkspaceState.from(
+        var workspaceState = FavoriteWorkspaceState.from(
             settings: .default, pinnedGroupIDs: ["pinned1"], collapsedGroupIDs: [], sidebarWidth: 350
         )
         workspaceState.fileSortMode = .nameAscending
@@ -141,9 +141,9 @@ struct FavoriteWorkspaceControllerTests {
         store.addFavoriteWatchedFolder(name: "NoOp", folderURL: URL(fileURLWithPath: "/tmp/no-persist"), options: .default)
         controller.persistFinalState(to: store)
         let persisted = store.currentSettings.favoriteWatchedFolders.first!
-        #expect(persisted.workspaceState == ReaderFavoriteWorkspaceState.from(
+        #expect(persisted.workspaceState == FavoriteWorkspaceState.from(
             settings: .default, pinnedGroupIDs: [], collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         ))
     }
 }

--- a/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
+++ b/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
@@ -18,10 +18,10 @@ struct OpenDocumentPathTrackerTests {
         settingsStore: ReaderSettingsStore
     ) -> ReaderSidebarDocumentController.Document {
         let store = ReaderStore(
-            rendering: ReaderRenderingDependencies(
+            rendering: RenderingDependencies(
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
-            file: ReaderFileDependencies(
+            file: FileDependencies(
                 watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Core/ReaderDocumentControllerTests.swift
+++ b/minimarkTests/Core/ReaderDocumentControllerTests.swift
@@ -12,7 +12,7 @@ struct ReaderDocumentControllerTests {
     ) -> ReaderDocumentController {
         let settings = TestReaderSettingsStore(autoRefreshOnExternalChange: true)
         return ReaderDocumentController(
-            fileDependencies: ReaderFileDependencies(watcher: watcher, io: io, actions: fileActions),
+            fileDependencies: FileDependencies(watcher: watcher, io: io, actions: fileActions),
             settingsStore: settings,
             settler: ReaderAutoOpenSettler(settlingInterval: 1.0)
         )

--- a/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
@@ -7,7 +7,7 @@ struct ReaderFavoriteWatchedFolderTests {
     // MARK: - Model
 
     @Test func matchesReturnsTrueForSameFolderPathAndOptions() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: "/tmp/docs",
             options: .default,
@@ -19,7 +19,7 @@ struct ReaderFavoriteWatchedFolderTests {
     }
 
     @Test func matchesReturnsFalseForDifferentPath() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: "/tmp/docs",
             options: .default,
@@ -31,7 +31,7 @@ struct ReaderFavoriteWatchedFolderTests {
     }
 
     @Test func matchesReturnsFalseForDifferentOptions() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: "/tmp/docs",
             options: .default,
@@ -71,7 +71,7 @@ struct ReaderFavoriteWatchedFolderTests {
             excludedSubdirectoryPaths: ["/tmp/docs/excluded"]
         )
 
-        let result = ReaderFavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
+        let result = FavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
             from: [
                 folderURL.appendingPathComponent("a.md"),
                 folderURL.appendingPathComponent("nested/b.md"),
@@ -88,7 +88,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     @Test func resolvedOpenDocumentFileURLsIgnoresInvalidRelativePaths() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: folderURL.path,
             options: FolderWatchOptions(openMode: .watchChangesOnly, scope: .includeSubfolders),
@@ -110,7 +110,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     @Test func insertingDuplicateFavoriteDoesNotAdd() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs")
-        let existing = [ReaderFavoriteWatchedFolder(
+        let existing = [FavoriteWatchedFolder(
             name: "Docs",
             folderURL: folderURL,
             options: .default
@@ -129,7 +129,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     @Test func insertingSameFolderWithDifferentOptionsAddsNewEntry() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs")
-        let existing = [ReaderFavoriteWatchedFolder(
+        let existing = [FavoriteWatchedFolder(
             name: "Docs",
             folderURL: folderURL,
             options: .default
@@ -155,7 +155,7 @@ struct ReaderFavoriteWatchedFolderTests {
     @Test func removingFavoriteByIDRemovesCorrectEntry() {
         let id = UUID()
         let entries = [
-            ReaderFavoriteWatchedFolder(
+            FavoriteWatchedFolder(
                 id: id,
                 name: "A",
                 folderPath: "/tmp/a",
@@ -163,7 +163,7 @@ struct ReaderFavoriteWatchedFolderTests {
                 bookmarkData: nil,
                 createdAt: .now
             ),
-            ReaderFavoriteWatchedFolder(
+            FavoriteWatchedFolder(
                 id: UUID(),
                 name: "B",
                 folderPath: "/tmp/b",
@@ -184,7 +184,7 @@ struct ReaderFavoriteWatchedFolderTests {
     @Test func renamingFavoriteUpdatesName() {
         let id = UUID()
         let entries = [
-            ReaderFavoriteWatchedFolder(
+            FavoriteWatchedFolder(
                 id: id,
                 name: "Old Name",
                 folderPath: "/tmp/docs",
@@ -311,7 +311,7 @@ struct ReaderFavoriteWatchedFolderTests {
             minimumPersistInterval: 0
         )
 
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Test",
             folderPath: "/tmp/docs",
             options: .default,
@@ -328,7 +328,7 @@ struct ReaderFavoriteWatchedFolderTests {
         let storage = TestSettingsKeyValueStorage()
         let store = ReaderSettingsStore(storage: storage, minimumPersistInterval: 0)
 
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Test",
             folderPath: "/tmp/docs",
             options: .default,
@@ -505,7 +505,7 @@ struct ReaderFavoriteWatchedFolderTests {
         }
         """
 
-        let favorite = try JSONDecoder().decode(ReaderFavoriteWatchedFolder.self, from: Data(json.utf8))
+        let favorite = try JSONDecoder().decode(FavoriteWatchedFolder.self, from: Data(json.utf8))
         #expect(favorite.allKnownRelativePaths.isEmpty)
     }
 
@@ -523,7 +523,7 @@ struct ReaderFavoriteWatchedFolderTests {
         }
         """
 
-        let favorite = try JSONDecoder().decode(ReaderFavoriteWatchedFolder.self, from: Data(json.utf8))
+        let favorite = try JSONDecoder().decode(FavoriteWatchedFolder.self, from: Data(json.utf8))
         #expect(favorite.openDocumentRelativePaths.isEmpty)
     }
 
@@ -659,7 +659,7 @@ struct ReaderFavoriteWatchedFolderTests {
     // MARK: - Excluded Subdirectory Relative Paths (Favorite)
 
     @Test func excludedSubdirectoryRelativePathsForFavorite() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Test",
             folderPath: "/tmp/project",
             options: FolderWatchOptions(
@@ -675,7 +675,7 @@ struct ReaderFavoriteWatchedFolderTests {
     }
 
     @Test func excludedSubdirectoryRelativePathsEmptyForSelectedFolderOnly() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Test",
             folderPath: "/tmp/project",
             options: FolderWatchOptions(
@@ -799,7 +799,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     @Test func newFilesAreThoseNotInKnownSet() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: folderURL.path,
             options: FolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly),
@@ -823,7 +823,7 @@ struct ReaderFavoriteWatchedFolderTests {
 
     @Test func emptyKnownSetTreatsAllScannedFilesAsNew() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: folderURL.path,
             options: FolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .selectedFolderOnly),
@@ -843,7 +843,7 @@ struct ReaderFavoriteWatchedFolderTests {
     }
 
     @Test func watchChangesOnlyFavoriteDoesNotDiscoverNewFiles() {
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Docs",
             folderPath: "/tmp/docs",
             options: FolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
@@ -875,25 +875,25 @@ struct ReaderFavoriteWatchedFolderTests {
         }
         """
 
-        let favorite = try JSONDecoder().decode(ReaderFavoriteWatchedFolder.self, from: Data(json.utf8))
+        let favorite = try JSONDecoder().decode(FavoriteWatchedFolder.self, from: Data(json.utf8))
 
         #expect(favorite.name == "Legacy Favorite")
         #expect(favorite.openDocumentRelativePaths == ["readme.md"])
 
-        let expectedDefault = ReaderFavoriteWorkspaceState.from(
+        let expectedDefault = FavoriteWorkspaceState.from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
         #expect(favorite.workspaceState == expectedDefault)
         #expect(favorite.workspaceState.pinnedGroupIDs.isEmpty)
         #expect(favorite.workspaceState.collapsedGroupIDs.isEmpty)
-        #expect(favorite.workspaceState.sidebarWidth == ReaderFavoriteWorkspaceState.defaultSidebarWidth)
+        #expect(favorite.workspaceState.sidebarWidth == FavoriteWorkspaceState.defaultSidebarWidth)
     }
 
     @Test func encodingAndDecodingPreservesWorkspaceState() throws {
-        let customState = ReaderFavoriteWorkspaceState(
+        let customState = FavoriteWorkspaceState(
             fileSortMode: .nameAscending,
             groupSortMode: .lastChangedNewestFirst,
             sidebarPosition: .sidebarRight,
@@ -902,7 +902,7 @@ struct ReaderFavoriteWatchedFolderTests {
             collapsedGroupIDs: ["group-3"]
         )
 
-        let original = ReaderFavoriteWatchedFolder(
+        let original = FavoriteWatchedFolder(
             name: "Workspace Test",
             folderPath: "/tmp/workspace",
             options: .default,
@@ -912,7 +912,7 @@ struct ReaderFavoriteWatchedFolderTests {
         )
 
         let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(ReaderFavoriteWatchedFolder.self, from: data)
+        let decoded = try JSONDecoder().decode(FavoriteWatchedFolder.self, from: data)
 
         #expect(decoded.workspaceState == customState)
         #expect(decoded.workspaceState.fileSortMode == .nameAscending)
@@ -934,7 +934,7 @@ struct ReaderFavoriteWatchedFolderTests {
         let existingFile = tempDir.appendingPathComponent("exists.md")
         try Data("# Exists".utf8).write(to: existingFile)
 
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             name: "Test",
             folderPath: tempDir.path,
             options: FolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
@@ -953,8 +953,8 @@ struct ReaderFavoriteWatchedFolderTests {
 
     // MARK: - Helpers
 
-    private func makeFavorite(name: String, folderPath: String) -> ReaderFavoriteWatchedFolder {
-        ReaderFavoriteWatchedFolder(
+    private func makeFavorite(name: String, folderPath: String) -> FavoriteWatchedFolder {
+        FavoriteWatchedFolder(
             name: name,
             folderPath: folderPath,
             options: .default,

--- a/minimarkTests/Core/ReaderFavoriteWorkspaceStateLockTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWorkspaceStateLockTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ReaderFavoriteWorkspaceStateLockTests: XCTestCase {
     func testWorkspaceStateDefaultsToNilLockedAppearance() {
-        let state = ReaderFavoriteWorkspaceState(
+        let state = FavoriteWorkspaceState(
             fileSortMode: .openOrder,
             groupSortMode: .lastChangedNewestFirst,
             sidebarPosition: .sidebarLeft,
@@ -16,7 +16,7 @@ final class ReaderFavoriteWorkspaceStateLockTests: XCTestCase {
     }
 
     func testWorkspaceStateStoresLockedAppearance() {
-        var state = ReaderFavoriteWorkspaceState(
+        var state = FavoriteWorkspaceState(
             fileSortMode: .openOrder,
             groupSortMode: .lastChangedNewestFirst,
             sidebarPosition: .sidebarLeft,
@@ -43,12 +43,12 @@ final class ReaderFavoriteWorkspaceStateLockTests: XCTestCase {
         }
         """.data(using: .utf8)!
 
-        let state = try JSONDecoder().decode(ReaderFavoriteWorkspaceState.self, from: legacyJSON)
+        let state = try JSONDecoder().decode(FavoriteWorkspaceState.self, from: legacyJSON)
         XCTAssertNil(state.lockedAppearance)
     }
 
     func testWorkspaceStateWithLockedAppearanceRoundTrips() throws {
-        var state = ReaderFavoriteWorkspaceState(
+        var state = FavoriteWorkspaceState(
             fileSortMode: .openOrder,
             groupSortMode: .lastChangedNewestFirst,
             sidebarPosition: .sidebarLeft,
@@ -63,7 +63,7 @@ final class ReaderFavoriteWorkspaceStateLockTests: XCTestCase {
         )
 
         let data = try JSONEncoder().encode(state)
-        let decoded = try JSONDecoder().decode(ReaderFavoriteWorkspaceState.self, from: data)
+        let decoded = try JSONDecoder().decode(FavoriteWorkspaceState.self, from: data)
 
         XCTAssertEqual(decoded.lockedAppearance?.readerTheme, .commodore64)
         XCTAssertEqual(decoded.lockedAppearance?.baseFontSize, 16)

--- a/minimarkTests/Core/ReaderFavoriteWorkspaceStateTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWorkspaceStateTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite
 struct ReaderFavoriteWorkspaceStateTests {
     @Test func codableRoundTripPreservesAllFields() throws {
-        let state = ReaderFavoriteWorkspaceState(
+        let state = FavoriteWorkspaceState(
             fileSortMode: .nameAscending,
             groupSortMode: .lastChangedNewestFirst,
             sidebarPosition: .sidebarRight,
@@ -15,7 +15,7 @@ struct ReaderFavoriteWorkspaceStateTests {
         )
 
         let data = try JSONEncoder().encode(state)
-        let decoded = try JSONDecoder().decode(ReaderFavoriteWorkspaceState.self, from: data)
+        let decoded = try JSONDecoder().decode(FavoriteWorkspaceState.self, from: data)
 
         #expect(decoded == state)
         #expect(decoded.fileSortMode == .nameAscending)
@@ -28,7 +28,7 @@ struct ReaderFavoriteWorkspaceStateTests {
     }
 
     @Test func codableRoundTripPreservesManualGroupOrder() throws {
-        let state = ReaderFavoriteWorkspaceState(
+        let state = FavoriteWorkspaceState(
             fileSortMode: .nameAscending,
             groupSortMode: .manualOrder,
             sidebarPosition: .sidebarRight,
@@ -39,7 +39,7 @@ struct ReaderFavoriteWorkspaceStateTests {
         )
 
         let data = try JSONEncoder().encode(state)
-        let decoded = try JSONDecoder().decode(ReaderFavoriteWorkspaceState.self, from: data)
+        let decoded = try JSONDecoder().decode(FavoriteWorkspaceState.self, from: data)
 
         #expect(decoded.manualGroupOrder == ["/path/gamma", "/path/alpha"])
         #expect(decoded.groupSortMode == .manualOrder)
@@ -48,23 +48,23 @@ struct ReaderFavoriteWorkspaceStateTests {
     @Test func defaultFactoryUsesGlobalSettingsAndEmptySets() {
         let settings = ReaderSettings.default
 
-        let state = ReaderFavoriteWorkspaceState.from(
+        let state = FavoriteWorkspaceState.from(
             settings: settings,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
 
         #expect(state.fileSortMode == settings.sidebarSortMode)
         #expect(state.groupSortMode == settings.sidebarGroupSortMode)
         #expect(state.sidebarPosition == settings.multiFileDisplayMode)
-        #expect(state.sidebarWidth == ReaderFavoriteWorkspaceState.defaultSidebarWidth)
+        #expect(state.sidebarWidth == FavoriteWorkspaceState.defaultSidebarWidth)
         #expect(state.pinnedGroupIDs.isEmpty)
         #expect(state.collapsedGroupIDs.isEmpty)
     }
 
     @Test func snapshotCapturesCurrentValues() {
-        let state = ReaderFavoriteWorkspaceState.from(
+        let state = FavoriteWorkspaceState.from(
             settings: ReaderSettings.default,
             pinnedGroupIDs: ["pinned1"],
             collapsedGroupIDs: ["collapsed1", "collapsed2"],
@@ -77,7 +77,7 @@ struct ReaderFavoriteWorkspaceStateTests {
     }
 
     @Test func favoriteWithWorkspaceStateRoundTripsViaReaderSettings() throws {
-        let workspaceState = ReaderFavoriteWorkspaceState(
+        let workspaceState = FavoriteWorkspaceState(
             fileSortMode: .lastChangedOldestFirst,
             groupSortMode: .nameDescending,
             sidebarPosition: .sidebarRight,
@@ -86,7 +86,7 @@ struct ReaderFavoriteWorkspaceStateTests {
             collapsedGroupIDs: ["dir3"]
         )
 
-        let favorite = ReaderFavoriteWatchedFolder(
+        let favorite = FavoriteWatchedFolder(
             name: "Integration Test",
             folderPath: "/tmp/integration",
             options: FolderWatchOptions(
@@ -131,7 +131,7 @@ struct ReaderFavoriteWorkspaceStateTests {
                 settings: .default,
                 pinnedGroupIDs: [],
                 collapsedGroupIDs: [],
-                sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+                sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
             )
         )
 
@@ -165,7 +165,7 @@ struct ReaderFavoriteWorkspaceStateTests {
         settings.sidebarGroupSortMode = .nameDescending
         settings.multiFileDisplayMode = .sidebarRight
 
-        let favorite = ReaderFavoriteWatchedFolder(
+        let favorite = FavoriteWatchedFolder(
             name: "Legacy",
             folderPath: "/tmp/legacy",
             options: FolderWatchOptions(

--- a/minimarkTests/Core/ReaderPresentableErrorTests.swift
+++ b/minimarkTests/Core/ReaderPresentableErrorTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct ReaderPresentableErrorTests {
     @Test func fileReadErrorClassifiesCorrectly() {
-        let error = ReaderPresentableError(from: ReaderError.fileReadFailed(
+        let error = PresentableError(from: ReaderError.fileReadFailed(
             URL(fileURLWithPath: "/test.md"),
             underlying: NSError(domain: "test", code: 1)
         ))
@@ -13,7 +13,7 @@ struct ReaderPresentableErrorTests {
     }
 
     @Test func fileWriteErrorClassifiesCorrectly() {
-        let error = ReaderPresentableError(from: ReaderError.fileWriteFailed(
+        let error = PresentableError(from: ReaderError.fileWriteFailed(
             URL(fileURLWithPath: "/test.md"),
             underlying: NSError(domain: "test", code: 1)
         ))
@@ -21,21 +21,21 @@ struct ReaderPresentableErrorTests {
     }
 
     @Test func renderingErrorClassifiesCorrectly() {
-        let error = ReaderPresentableError(from: ReaderError.renderingFailed(
+        let error = PresentableError(from: ReaderError.renderingFailed(
             underlying: NSError(domain: "test", code: 1)
         ))
         #expect(error.kind == .rendering)
     }
 
     @Test func applicationErrorClassifiesCorrectly() {
-        let error = ReaderPresentableError(from: ReaderError.noRegisteredApplications(
+        let error = PresentableError(from: ReaderError.noRegisteredApplications(
             URL(fileURLWithPath: "/test.md")
         ))
         #expect(error.kind == .application)
     }
 
     @Test func genericNSErrorClassifiesAsGeneral() {
-        let error = ReaderPresentableError(from: NSError(domain: "test", code: 42, userInfo: [
+        let error = PresentableError(from: NSError(domain: "test", code: 42, userInfo: [
             NSLocalizedDescriptionKey: "Something went wrong"
         ]))
         #expect(error.kind == .general)
@@ -43,15 +43,15 @@ struct ReaderPresentableErrorTests {
     }
 
     @Test func equalityBasedOnKindAndMessage() {
-        let a = ReaderPresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/a.md")))
-        let b = ReaderPresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/a.md")))
-        let c = ReaderPresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/b.md")))
+        let a = PresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/a.md")))
+        let b = PresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/a.md")))
+        let c = PresentableError(from: ReaderError.fileNotReachable(URL(fileURLWithPath: "/b.md")))
         #expect(a == b)
         #expect(a != c)
     }
 
     @Test func fileMissingKindFromFileNotReachable() {
-        let error = ReaderPresentableError(from: ReaderError.fileNotReachable(
+        let error = PresentableError(from: ReaderError.fileNotReachable(
             URL(fileURLWithPath: "/missing.md")
         ))
         #expect(error.kind == .fileMissing)

--- a/minimarkTests/Core/ReaderRenderingControllerTests.swift
+++ b/minimarkTests/Core/ReaderRenderingControllerTests.swift
@@ -15,7 +15,7 @@ struct ReaderRenderingControllerTests {
             requestWatchedFolderReauthorization: { _ in nil }
         )
         return ReaderRenderingController(
-            renderingDependencies: ReaderRenderingDependencies(renderer: renderer, differ: differ),
+            renderingDependencies: RenderingDependencies(renderer: renderer, differ: differ),
             settingsStore: settings,
             securityScopeResolver: securityScope
         )

--- a/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
+++ b/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
@@ -19,7 +19,7 @@ struct ReaderSettingsAndModelsTests {
             options: FolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .includeSubfolders),
             startedAt: Date(timeIntervalSince1970: 12345)
         )
-        let seed = ReaderWindowSeed(
+        let seed = WindowSeed(
             id: id,
             fileURL: fileURL,
             folderWatchSession: watchSession,
@@ -28,7 +28,7 @@ struct ReaderSettingsAndModelsTests {
         )
 
         let data = try JSONEncoder().encode(seed)
-        let decoded = try JSONDecoder().decode(ReaderWindowSeed.self, from: data)
+        let decoded = try JSONDecoder().decode(WindowSeed.self, from: data)
 
         #expect(decoded.id == id)
         #expect(decoded.filePath == fileURL.path)
@@ -39,31 +39,31 @@ struct ReaderSettingsAndModelsTests {
     }
 
     @Test @MainActor func readerWindowSeedCodableRoundTripPreservesRecentWatchedFolderRequest() throws {
-        let entry = ReaderRecentWatchedFolder(
+        let entry = RecentWatchedFolder(
             folderURL: URL(fileURLWithPath: "/tmp/docs"),
             options: FolderWatchOptions(openMode: .openAllMarkdownFiles, scope: .includeSubfolders)
         )
-        let seed = ReaderWindowSeed(recentWatchedFolder: entry)
+        let seed = WindowSeed(recentWatchedFolder: entry)
 
         let data = try JSONEncoder().encode(seed)
-        let decoded = try JSONDecoder().decode(ReaderWindowSeed.self, from: data)
+        let decoded = try JSONDecoder().decode(WindowSeed.self, from: data)
 
         #expect(decoded.recentWatchedFolder?.folderPath == entry.folderPath)
         #expect(decoded.recentWatchedFolder?.options == entry.options)
     }
 
     @Test @MainActor func readerWindowSeedCodableRoundTripPreservesRecentOpenedFileRequest() throws {
-        let entry = ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/tmp/recent.md"))
-        let seed = ReaderWindowSeed(recentOpenedFile: entry)
+        let entry = RecentOpenedFile(fileURL: URL(fileURLWithPath: "/tmp/recent.md"))
+        let seed = WindowSeed(recentOpenedFile: entry)
 
         let data = try JSONEncoder().encode(seed)
-        let decoded = try JSONDecoder().decode(ReaderWindowSeed.self, from: data)
+        let decoded = try JSONDecoder().decode(WindowSeed.self, from: data)
 
         #expect(decoded.recentOpenedFile?.filePath == entry.filePath)
     }
 
     @Test @MainActor func readerWindowSeedDefaultOriginIsManual() {
-        let seed = ReaderWindowSeed(fileURL: URL(fileURLWithPath: "/tmp/default-origin.md"))
+        let seed = WindowSeed(fileURL: URL(fileURLWithPath: "/tmp/default-origin.md"))
 
         #expect(seed.openOrigin == .manual)
     }
@@ -244,7 +244,7 @@ struct ReaderSettingsAndModelsTests {
             sidebarSortMode: .openOrder,
             recentWatchedFolders: [],
             recentManuallyOpenedFiles: [
-                ReaderRecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x00, 0x01, 0x02]))
+                RecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x00, 0x01, 0x02]))
             ]
         )
         storage.set(try JSONEncoder().encode(seededSettings), forKey: storageKey)
@@ -270,7 +270,7 @@ struct ReaderSettingsAndModelsTests {
             multiFileDisplayMode: .sidebarLeft,
             sidebarSortMode: .openOrder,
             recentWatchedFolders: [
-                ReaderRecentWatchedFolder(
+                RecentWatchedFolder(
                     folderPath: folderURL.path,
                     options: .default,
                     bookmarkData: Data([0xAA, 0xBB, 0xCC])
@@ -303,7 +303,7 @@ struct ReaderSettingsAndModelsTests {
             multiFileDisplayMode: .sidebarLeft,
             sidebarSortMode: .openOrder,
             recentWatchedFolders: [
-                ReaderRecentWatchedFolder(
+                RecentWatchedFolder(
                     folderPath: folderURL.path,
                     options: .default,
                     bookmarkData: originalBookmarkData
@@ -346,7 +346,7 @@ struct ReaderSettingsAndModelsTests {
             try? FileManager.default.removeItem(at: fileURL)
         }
 
-        let entry = ReaderRecentOpenedFile(fileURL: fileURL)
+        let entry = RecentOpenedFile(fileURL: fileURL)
         let seededSettings = ReaderSettings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
@@ -370,20 +370,20 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerRecentHistoryMenuTitleAddsParentContextOnlyWhenNeeded() {
         let fileEntries = [
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/ideas.md"))
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/ideas.md"))
         ]
         let folderEntries = [
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/alpha/docs"),
                 options: .default
             ),
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/beta/docs"),
                 options: .default
             ),
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/gamma/guides"),
                 options: .default
             )
@@ -397,7 +397,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerRecentHistoryMenuTitleAddsFilteredIndicatorForWatchedFolders() {
         let entries = [
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/alpha/docs"),
                 options: FolderWatchOptions(
                     openMode: .watchChangesOnly,
@@ -405,7 +405,7 @@ struct ReaderSettingsAndModelsTests {
                     excludedSubdirectoryPaths: ["/work/alpha/docs/build"]
                 )
             ),
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/beta/docs"),
                 options: .default
             )
@@ -421,7 +421,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerRecentHistoryMenuTitleOmitsFilteredIndicatorForSelectedFolderScope() {
         let entries = [
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/alpha/docs"),
                 options: FolderWatchOptions(
                     openMode: .watchChangesOnly,
@@ -429,7 +429,7 @@ struct ReaderSettingsAndModelsTests {
                     excludedSubdirectoryPaths: ["/work/alpha/docs/build"]
                 )
             ),
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/beta/docs"),
                 options: .default
             )
@@ -442,9 +442,9 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerRecentHistoryMenuTitlesDisambiguateMultipleDuplicateNames() {
         let entries = [
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/beta/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/gamma/tasks/todo.md"))
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/beta/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/gamma/tasks/todo.md"))
         ]
 
         let titlesByPath = ReaderRecentHistory.menuTitles(for: entries)
@@ -455,12 +455,12 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerRecentHistoryBulkMenuTitlesMatchPerEntryTitles() {
         let recentFiles = [
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/todo.md")),
-            ReaderRecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/ideas.md"))
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/work/alpha/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/todo.md")),
+            RecentOpenedFile(fileURL: URL(fileURLWithPath: "/archive/notes/ideas.md"))
         ]
         let recentFolders = [
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/alpha/docs"),
                 options: FolderWatchOptions(
                     openMode: .watchChangesOnly,
@@ -468,7 +468,7 @@ struct ReaderSettingsAndModelsTests {
                     excludedSubdirectoryPaths: ["/work/alpha/docs/build"]
                 )
             ),
-            ReaderRecentWatchedFolder(
+            RecentWatchedFolder(
                 folderURL: URL(fileURLWithPath: "/work/beta/docs"),
                 options: .default
             )
@@ -552,7 +552,7 @@ struct ReaderSettingsAndModelsTests {
             recentWatchedFolders: [],
             recentManuallyOpenedFiles: [],
             trustedImageFolders: [
-                ReaderTrustedImageFolder(folderPath: folderURL.path, bookmarkData: bookmarkData)
+                TrustedImageFolder(folderPath: folderURL.path, bookmarkData: bookmarkData)
             ]
         )
         storage.set(try JSONEncoder().encode(seededSettings), forKey: storageKey)
@@ -586,7 +586,7 @@ struct ReaderSettingsAndModelsTests {
             recentWatchedFolders: [],
             recentManuallyOpenedFiles: [],
             trustedImageFolders: [
-                ReaderTrustedImageFolder(folderPath: folderURL.path, bookmarkData: bookmarkData)
+                TrustedImageFolder(folderPath: folderURL.path, bookmarkData: bookmarkData)
             ]
         )
         storage.set(try JSONEncoder().encode(seededSettings), forKey: storageKey)
@@ -619,7 +619,7 @@ struct ReaderSettingsAndModelsTests {
             recentWatchedFolders: [],
             recentManuallyOpenedFiles: [],
             trustedImageFolders: [
-                ReaderTrustedImageFolder(folderPath: folderURL.path, bookmarkData: Data([0xAA, 0xBB]))
+                TrustedImageFolder(folderPath: folderURL.path, bookmarkData: Data([0xAA, 0xBB]))
             ]
         )
         storage.set(try JSONEncoder().encode(seededSettings), forKey: storageKey)
@@ -842,7 +842,7 @@ struct ReaderSettingsAndModelsTests {
             SidebarSortTestItem(id: "alpha", displayName: "alpha.md", lastChangedAt: nil)
         ]
 
-        let ordered = ReaderSidebarSortMode.nameAscending.sorted(items) { item in
+        let ordered = SidebarSortMode.nameAscending.sorted(items) { item in
             ReaderSidebarSortDescriptor(displayName: item.displayName, lastChangedAt: item.lastChangedAt)
         }
 
@@ -859,7 +859,7 @@ struct ReaderSettingsAndModelsTests {
             SidebarSortTestItem(id: "untitled", displayName: nil, lastChangedAt: nil)
         ]
 
-        let ordered = ReaderSidebarSortMode.lastChangedNewestFirst.sorted(items) { item in
+        let ordered = SidebarSortMode.lastChangedNewestFirst.sorted(items) { item in
             ReaderSidebarSortDescriptor(displayName: item.displayName, lastChangedAt: item.lastChangedAt)
         }
 
@@ -867,8 +867,8 @@ struct ReaderSettingsAndModelsTests {
     }
 
     @Test func readerMultiFileDisplayModeChangesNeverRequireRestartInSidebarOnlyMode() {
-        #expect(!ReaderMultiFileDisplayMode.sidebarLeft.requiresRestart(from: .sidebarRight))
-        #expect(!ReaderMultiFileDisplayMode.sidebarRight.requiresRestart(from: .sidebarLeft))
+        #expect(!MultiFileDisplayMode.sidebarLeft.requiresRestart(from: .sidebarRight))
+        #expect(!MultiFileDisplayMode.sidebarRight.requiresRestart(from: .sidebarLeft))
     }
 
     @Test func readerSettingsGuidanceExplainsImmediateSidebarLayoutChanges() {

--- a/minimarkTests/Core/ReaderSettingsStoreFavoritesTests.swift
+++ b/minimarkTests/Core/ReaderSettingsStoreFavoritesTests.swift
@@ -20,7 +20,7 @@ struct ReaderSettingsStoreFavoritesTests {
         )
 
         let favoriteID = store.currentSettings.favoriteWatchedFolders.first!.id
-        let newState = ReaderFavoriteWorkspaceState(
+        let newState = FavoriteWorkspaceState(
             fileSortMode: .nameDescending,
             groupSortMode: .nameAscending,
             sidebarPosition: .sidebarRight,
@@ -53,7 +53,7 @@ struct ReaderSettingsStoreFavoritesTests {
         let before = store.currentSettings.favoriteWatchedFolders
         store.updateFavoriteWorkspaceState(
             id: UUID(),
-            workspaceState: ReaderFavoriteWorkspaceState(
+            workspaceState: FavoriteWorkspaceState(
                 fileSortMode: .nameDescending,
                 groupSortMode: .nameAscending,
                 sidebarPosition: .sidebarRight,

--- a/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
+++ b/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
@@ -10,7 +10,7 @@ import Testing
 struct SourceHTMLDocumentCacheTests {
 
     private static func makeSettings(
-        readerTheme: ReaderThemeKind = .blackOnWhite,
+        readerTheme: ThemeKind = .blackOnWhite,
         baseFontSize: Double = 15
     ) -> ReaderSettings {
         ReaderSettings(

--- a/minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift
+++ b/minimarkTests/Core/ThemeSelectorLayoutAndPreviewTests.swift
@@ -12,7 +12,7 @@ struct ThemeSelectorLayoutAndPreviewTests {
 
     @Test
     func previewReaderTextExamplesIncludeKeyReaderColors() {
-        let readerSamples = ThemePreviewReaderTextExamples.reader(theme: ReaderTheme.theme(for: .monokai))
+        let readerSamples = ThemePreviewReaderTextExamples.reader(theme: Theme.theme(for: .monokai))
 
         #expect(readerSamples.count == 4)
         #expect(readerSamples.contains(where: { $0.role == .body && $0.hex == "#F8F8F2" }))

--- a/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
+++ b/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
@@ -171,10 +171,10 @@ struct EditFolderWatchExclusionsTests {
                     requestWatchedFolderReauthorization: { _ in nil }
                 )
                 return ReaderStore(
-                    rendering: ReaderRenderingDependencies(
+                    rendering: RenderingDependencies(
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
-                    file: ReaderFileDependencies(
+                    file: FileDependencies(
                         watcher: fw, io: ReaderDocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(

--- a/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
+++ b/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
@@ -446,8 +446,8 @@ struct FolderWatchCoordinationTests {
             FolderWatchChangeEvent(fileURL: URL(fileURLWithPath: "/tmp/watched/second.md"), kind: .added),
             FolderWatchChangeEvent(fileURL: URL(fileURLWithPath: "/tmp/watched/third.md"), kind: .added)
         ]
-        var primaryOpenCalls: [(FolderWatchChangeEvent, ReaderOpenOrigin)] = []
-        var additionalOpenCalls: [(FolderWatchChangeEvent, ReaderOpenOrigin)] = []
+        var primaryOpenCalls: [(FolderWatchChangeEvent, OpenOrigin)] = []
+        var additionalOpenCalls: [(FolderWatchChangeEvent, OpenOrigin)] = []
 
         let dispatcher = FolderWatchDispatcher(
             folderWatchDependencies: FolderWatchDependencies(

--- a/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
+++ b/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
@@ -10,7 +10,7 @@ import Testing
 @Suite
 struct CalloutBlockRenderingTests {
     private let service = MarkdownRenderingService()
-    private let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+    private let theme = ThemeKind.blackOnWhite.themeDefinition
 
     private func renderHTML(_ markdown: String) throws -> String {
         try service.render(

--- a/minimarkTests/Rendering/CheckboxCSSTests.swift
+++ b/minimarkTests/Rendering/CheckboxCSSTests.swift
@@ -9,7 +9,7 @@ import Testing
 @Suite
 struct CheckboxCSSTests {
     private let css = ReaderCSSFactory().makeCSS(
-        theme: ReaderThemeKind.blackOnWhite.themeDefinition,
+        theme: ThemeKind.blackOnWhite.themeDefinition,
         syntaxTheme: .default,
         baseFontSize: 16.0
     )

--- a/minimarkTests/Rendering/MarkdownRenderingServiceTests.swift
+++ b/minimarkTests/Rendering/MarkdownRenderingServiceTests.swift
@@ -10,7 +10,7 @@ import Testing
 @Suite
 struct MarkdownRenderingServiceTests {
     private let service = MarkdownRenderingService()
-    private let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+    private let theme = ThemeKind.blackOnWhite.themeDefinition
 
     @Test func renderProducesHTMLDocument() throws {
         let result = try service.render(

--- a/minimarkTests/Rendering/ReaderCSSFactoryCacheTests.swift
+++ b/minimarkTests/Rendering/ReaderCSSFactoryCacheTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ReaderCSSFactoryCacheTests: XCTestCase {
 
     func testSameInputsReturnIdenticalCSS() {
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css1 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
         let css2 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
 
@@ -12,8 +12,8 @@ final class ReaderCSSFactoryCacheTests: XCTestCase {
     }
 
     func testDifferentThemeProducesDifferentCSS() {
-        let theme1 = ReaderThemeKind.blackOnWhite.themeDefinition
-        let theme2 = ReaderThemeKind.newspaper.themeDefinition
+        let theme1 = ThemeKind.blackOnWhite.themeDefinition
+        let theme2 = ThemeKind.newspaper.themeDefinition
         let css1 = ReaderCSSThemeGenerator.makeCSS(theme: theme1, syntaxTheme: .monokai, baseFontSize: 15)
         let css2 = ReaderCSSThemeGenerator.makeCSS(theme: theme2, syntaxTheme: .monokai, baseFontSize: 15)
 
@@ -21,7 +21,7 @@ final class ReaderCSSFactoryCacheTests: XCTestCase {
     }
 
     func testDifferentFontSizeProducesDifferentCSS() {
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css1 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
         let css2 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 20)
 
@@ -29,7 +29,7 @@ final class ReaderCSSFactoryCacheTests: XCTestCase {
     }
 
     func testDifferentSyntaxThemeProducesDifferentCSS() {
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css1 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
         let css2 = ReaderCSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .dracula, baseFontSize: 15)
 

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -417,7 +417,7 @@ struct RenderingAndDiffTests {
     @Test func readerCSSUsesFullAvailableDocumentWidth() {
         let factory = ReaderCSSFactory()
 
-        let css = factory.makeCSS(theme: ReaderThemeKind.blackOnWhite.themeDefinition, syntaxTheme: .default, baseFontSize: 16)
+        let css = factory.makeCSS(theme: ThemeKind.blackOnWhite.themeDefinition, syntaxTheme: .default, baseFontSize: 16)
 
         #expect(css.contains("width: 100%;"))
         #expect(css.contains("margin: 0;"))

--- a/minimarkTests/Rendering/SyntaxBackgroundAdjusterTests.swift
+++ b/minimarkTests/Rendering/SyntaxBackgroundAdjusterTests.swift
@@ -72,7 +72,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     // MARK: - Real theme pairings
 
     func testGruvboxDarkReaderWithGruvboxDarkSyntax() {
-        let reader = ReaderTheme.theme(for: .gruvboxDark)
+        let reader = Theme.theme(for: .gruvboxDark)
         let syntax = SyntaxThemeKind.gruvboxDark.previewPalette
         let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
             readerBackgroundHex: reader.backgroundHex,
@@ -83,7 +83,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     }
 
     func testMonokaiReaderWithMonokaiSyntax() {
-        let reader = ReaderTheme.theme(for: .monokai)
+        let reader = Theme.theme(for: .monokai)
         let syntax = SyntaxThemeKind.monokai.previewPalette
         let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
             readerBackgroundHex: reader.backgroundHex,
@@ -94,7 +94,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     }
 
     func testDraculaReaderWithDraculaSyntax() {
-        let reader = ReaderTheme.theme(for: .dracula)
+        let reader = Theme.theme(for: .dracula)
         let syntax = SyntaxThemeKind.dracula.previewPalette
         let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
             readerBackgroundHex: reader.backgroundHex,
@@ -105,7 +105,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     }
 
     func testGruvboxDarkReaderWithOneDarkSyntaxNoAdjustment() {
-        let reader = ReaderTheme.theme(for: .gruvboxDark)
+        let reader = Theme.theme(for: .gruvboxDark)
         let syntax = SyntaxThemeKind.oneDark.previewPalette
         let result = SyntaxBackgroundAdjuster.adjustedBlockBackground(
             readerBackgroundHex: reader.backgroundHex,
@@ -119,7 +119,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     // MARK: - effectiveBlockBackgroundHex
 
     func testEffectiveHexReturnsThemePaletteForProvidesSyntaxHighlighting() {
-        let theme = ReaderThemeKind.amberTerminal.themeDefinition
+        let theme = ThemeKind.amberTerminal.themeDefinition
         let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
             theme: theme,
             syntaxTheme: .monokai
@@ -128,7 +128,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     }
 
     func testEffectiveHexAdjustsForMatchingNonProvidesSyntaxTheme() {
-        let theme = ReaderThemeKind.gruvboxDark.themeDefinition
+        let theme = ThemeKind.gruvboxDark.themeDefinition
         let original = SyntaxThemeKind.gruvboxDark.previewPalette.blockBackgroundHex
         let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
             theme: theme,
@@ -138,7 +138,7 @@ final class SyntaxBackgroundAdjusterTests: XCTestCase {
     }
 
     func testEffectiveHexReturnsOriginalWhenBackgroundsDiffer() {
-        let theme = ReaderThemeKind.gruvboxDark.themeDefinition
+        let theme = ThemeKind.gruvboxDark.themeDefinition
         let original = SyntaxThemeKind.monokai.previewPalette.blockBackgroundHex
         let result = SyntaxBackgroundAdjuster.effectiveBlockBackgroundHex(
             theme: theme,

--- a/minimarkTests/Rendering/ThemeDefinitionTests.swift
+++ b/minimarkTests/Rendering/ThemeDefinitionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ThemeDefinitionTests: XCTestCase {
 
     func testSimpleThemeDefinitionHasNilCustomCSS() {
-        let definition = ReaderThemeKind.blackOnWhite.themeDefinition
+        let definition = ThemeKind.blackOnWhite.themeDefinition
         XCTAssertNil(definition.customCSS)
         XCTAssertNil(definition.customJavaScript)
         XCTAssertNil(definition.syntaxCSS)
@@ -13,22 +13,22 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testSimpleThemeDefinitionHasCorrectColors() {
-        let definition = ReaderThemeKind.blackOnWhite.themeDefinition
-        let expectedColors = ReaderTheme.theme(for: .blackOnWhite)
+        let definition = ThemeKind.blackOnWhite.themeDefinition
+        let expectedColors = Theme.theme(for: .blackOnWhite)
         XCTAssertEqual(definition.colors, expectedColors)
         XCTAssertEqual(definition.kind, .blackOnWhite)
-        XCTAssertEqual(definition.displayName, ReaderThemeKind.blackOnWhite.displayName)
+        XCTAssertEqual(definition.displayName, ThemeKind.blackOnWhite.displayName)
     }
 
     func testAllExistingThemesProduceValidDefinitions() {
-        let simpleKinds: [ReaderThemeKind] = [
+        let simpleKinds: [ThemeKind] = [
             .blackOnWhite, .whiteOnBlack, .darkGreyOnLightGrey, .lightGreyOnDarkGrey
         ]
         for kind in simpleKinds {
             let definition = kind.themeDefinition
             XCTAssertEqual(definition.kind, kind, "Kind mismatch for \(kind)")
             XCTAssertEqual(definition.displayName, kind.displayName, "Display name mismatch for \(kind)")
-            XCTAssertEqual(definition.colors, ReaderTheme.theme(for: kind), "Colors mismatch for \(kind)")
+            XCTAssertEqual(definition.colors, Theme.theme(for: kind), "Colors mismatch for \(kind)")
             XCTAssertNil(definition.customCSS, "Simple theme \(kind) should not have custom CSS")
             XCTAssertNil(definition.customJavaScript, "Simple theme \(kind) should not have custom JS")
             XCTAssertNil(definition.syntaxCSS, "Simple theme \(kind) should not have syntax CSS")
@@ -40,13 +40,13 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Amber Terminal Theme
 
     func testAmberTerminalHasCorrectDisplayName() {
-        let kind = ReaderThemeKind.amberTerminal
+        let kind = ThemeKind.amberTerminal
         XCTAssertEqual(kind.displayName, "Amber Terminal")
         XCTAssertTrue(kind.isDark)
     }
 
     func testAmberTerminalDefinitionProvidesCustomCSS() {
-        let definition = ReaderThemeKind.amberTerminal.themeDefinition
+        let definition = ThemeKind.amberTerminal.themeDefinition
         XCTAssertNotNil(definition.customCSS)
         XCTAssertTrue(definition.providesSyntaxHighlighting)
         XCTAssertNotNil(definition.syntaxCSS)
@@ -55,14 +55,14 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testAmberTerminalColorsAreAmberPalette() {
-        let definition = ReaderThemeKind.amberTerminal.themeDefinition
+        let definition = ThemeKind.amberTerminal.themeDefinition
         XCTAssertFalse(definition.colors.hasLightBackground)
         XCTAssertEqual(definition.colors.backgroundHex, "#1A1200")
         XCTAssertEqual(definition.colors.foregroundHex, "#FFB000")
     }
 
     func testAmberTerminalCSSContainsCRTEffects() {
-        let definition = ReaderThemeKind.amberTerminal.themeDefinition
+        let definition = ThemeKind.amberTerminal.themeDefinition
         let css = definition.customCSS!
         XCTAssertTrue(css.contains("repeating-linear-gradient"), "Should have scanlines")
         XCTAssertTrue(css.contains("radial-gradient"), "Should have vignette")
@@ -71,7 +71,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testAmberTerminalSyntaxCSSCoversAllTokenTypes() {
-        let definition = ReaderThemeKind.amberTerminal.themeDefinition
+        let definition = ThemeKind.amberTerminal.themeDefinition
         let css = definition.syntaxCSS!
         XCTAssertTrue(css.contains(".hljs-comment"))
         XCTAssertTrue(css.contains(".hljs-keyword"))
@@ -85,7 +85,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testSimpleThemeCSSDoesNotContainCustomCSS() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
         XCTAssertTrue(css.contains("--reader-bg:"))
         XCTAssertTrue(css.contains(".hljs-keyword"), "Should contain syntax theme CSS from SyntaxThemeKind")
@@ -94,7 +94,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testAmberTerminalCSSIncludesCustomCSSAfterStructural() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.amberTerminal.themeDefinition
+        let theme = ThemeKind.amberTerminal.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
 
         XCTAssertTrue(css.contains("--reader-bg:"), "Should contain CSS variables")
@@ -110,7 +110,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testAmberTerminalUsesSyntaxCSSInsteadOfSyntaxTheme() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.amberTerminal.themeDefinition
+        let theme = ThemeKind.amberTerminal.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
 
         // Should contain amber syntax tokens, not Monokai ones
@@ -120,7 +120,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testSimpleThemeUsesSelectedSyntaxTheme() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
 
         XCTAssertTrue(css.contains("#F92672"), "Should contain Monokai keyword color")
@@ -129,7 +129,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Green Terminal Static Theme
 
     func testGreenTerminalStaticHasNoJavaScript() {
-        let definition = ReaderThemeKind.greenTerminalStatic.themeDefinition
+        let definition = ThemeKind.greenTerminalStatic.themeDefinition
         XCTAssertNil(definition.customJavaScript)
         XCTAssertNotNil(definition.customCSS)
         XCTAssertTrue(definition.providesSyntaxHighlighting)
@@ -184,13 +184,13 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Green Terminal Theme
 
     func testGreenTerminalHasCorrectDisplayName() {
-        let kind = ReaderThemeKind.greenTerminal
+        let kind = ThemeKind.greenTerminal
         XCTAssertEqual(kind.displayName, "Green Terminal")
         XCTAssertTrue(kind.isDark)
     }
 
     func testGreenTerminalDefinitionProvidesAllCustomFields() {
-        let definition = ReaderThemeKind.greenTerminal.themeDefinition
+        let definition = ThemeKind.greenTerminal.themeDefinition
         XCTAssertNotNil(definition.customCSS)
         XCTAssertNotNil(definition.customJavaScript, "Green Terminal should have digital rain JS")
         XCTAssertTrue(definition.providesSyntaxHighlighting)
@@ -199,14 +199,14 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGreenTerminalColorsAreGreenPalette() {
-        let definition = ReaderThemeKind.greenTerminal.themeDefinition
+        let definition = ThemeKind.greenTerminal.themeDefinition
         XCTAssertFalse(definition.colors.hasLightBackground)
         XCTAssertEqual(definition.colors.backgroundHex, "#0D0208")
         XCTAssertEqual(definition.colors.foregroundHex, "#00FF41")
     }
 
     func testGreenTerminalCSSContainsCRTEffects() {
-        let definition = ReaderThemeKind.greenTerminal.themeDefinition
+        let definition = ThemeKind.greenTerminal.themeDefinition
         let css = definition.customCSS!
         XCTAssertTrue(css.contains("repeating-linear-gradient"), "Should have scanlines")
         XCTAssertTrue(css.contains("radial-gradient"), "Should have vignette")
@@ -216,7 +216,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGreenTerminalSyntaxCSSCoversAllTokenTypes() {
-        let definition = ReaderThemeKind.greenTerminal.themeDefinition
+        let definition = ThemeKind.greenTerminal.themeDefinition
         let css = definition.syntaxCSS!
         XCTAssertTrue(css.contains(".hljs-comment"))
         XCTAssertTrue(css.contains(".hljs-keyword"))
@@ -227,7 +227,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGreenTerminalJSContainsDigitalRain() {
-        let definition = ReaderThemeKind.greenTerminal.themeDefinition
+        let definition = ThemeKind.greenTerminal.themeDefinition
         let js = definition.customJavaScript!
         XCTAssertTrue(js.contains("canvas"), "Should create a canvas element")
         XCTAssertTrue(js.contains("__minimarkThemeCleanup"), "Should register cleanup hook")
@@ -237,7 +237,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testGreenTerminalUsesSyntaxCSSInsteadOfSyntaxTheme() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.greenTerminal.themeDefinition
+        let theme = ThemeKind.greenTerminal.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
 
         XCTAssertTrue(css.contains("color: #00FF41"), "Should contain green syntax CSS")
@@ -247,7 +247,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Newspaper Theme
 
     func testNewspaperThemeDefinition() {
-        let definition = ReaderThemeKind.newspaper.themeDefinition
+        let definition = ThemeKind.newspaper.themeDefinition
         XCTAssertEqual(definition.displayName, "Newspaper")
         XCTAssertFalse(definition.kind.isDark)
         XCTAssertNotNil(definition.customCSS)
@@ -257,7 +257,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testNewspaperCSSContainsSerifTypography() {
-        let css = ReaderThemeKind.newspaper.themeDefinition.customCSS!
+        let css = ThemeKind.newspaper.themeDefinition.customCSS!
         XCTAssertTrue(css.contains("Charter"))
         XCTAssertTrue(css.contains("Georgia"))
         XCTAssertTrue(css.contains("serif"))
@@ -267,7 +267,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Focus Theme
 
     func testFocusThemeDefinition() {
-        let definition = ReaderThemeKind.focus.themeDefinition
+        let definition = ThemeKind.focus.themeDefinition
         XCTAssertEqual(definition.displayName, "Focus")
         XCTAssertFalse(definition.kind.isDark)
         XCTAssertNotNil(definition.customCSS)
@@ -276,7 +276,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testFocusCSSContainsGenerousLineHeight() {
-        let css = ReaderThemeKind.focus.themeDefinition.customCSS!
+        let css = ThemeKind.focus.themeDefinition.customCSS!
         XCTAssertTrue(css.contains("line-height: 1.8"))
         XCTAssertTrue(css.contains("text-decoration: underline"))
     }
@@ -284,7 +284,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Commodore 64 Theme
 
     func testCommodore64ThemeDefinition() {
-        let definition = ReaderThemeKind.commodore64.themeDefinition
+        let definition = ThemeKind.commodore64.themeDefinition
         XCTAssertEqual(definition.displayName, "Commodore 64")
         XCTAssertTrue(definition.kind.isDark)
         XCTAssertNotNil(definition.customCSS)
@@ -295,13 +295,13 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testCommodore64ColorsAreC64Palette() {
-        let definition = ReaderThemeKind.commodore64.themeDefinition
+        let definition = ThemeKind.commodore64.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#40318D")
         XCTAssertEqual(definition.colors.linkHex, "#FFFFFF")
     }
 
     func testCommodore64SyntaxCSSCoversAllTokenTypes() {
-        let css = ReaderThemeKind.commodore64.themeDefinition.syntaxCSS!
+        let css = ThemeKind.commodore64.themeDefinition.syntaxCSS!
         XCTAssertTrue(css.contains(".hljs-comment"))
         XCTAssertTrue(css.contains(".hljs-keyword"))
         XCTAssertTrue(css.contains(".hljs-string"))
@@ -313,7 +313,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Game Boy Theme
 
     func testGameBoyThemeDefinition() {
-        let definition = ReaderThemeKind.gameBoy.themeDefinition
+        let definition = ThemeKind.gameBoy.themeDefinition
         XCTAssertEqual(definition.displayName, "Game Boy")
         XCTAssertFalse(definition.kind.isDark)
         XCTAssertNotNil(definition.customCSS)
@@ -324,19 +324,19 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGameBoyUsesAuthenticDMGPalette() {
-        let definition = ReaderThemeKind.gameBoy.themeDefinition
+        let definition = ThemeKind.gameBoy.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#9BBC0F")
         XCTAssertEqual(definition.colors.foregroundHex, "#0F380F")
     }
 
     func testGameBoyCSSContainsPixelGrid() {
-        let css = ReaderThemeKind.gameBoy.themeDefinition.customCSS!
+        let css = ThemeKind.gameBoy.themeDefinition.customCSS!
         XCTAssertTrue(css.contains("background-image"), "Should have pixel grid overlay")
         XCTAssertTrue(css.contains("monospace"))
     }
 
     func testGameBoySyntaxUsesOnly4Shades() {
-        let css = ReaderThemeKind.gameBoy.themeDefinition.syntaxCSS!
+        let css = ThemeKind.gameBoy.themeDefinition.syntaxCSS!
         XCTAssertTrue(css.contains("#0F380F"), "Should use darkest shade")
         XCTAssertTrue(css.contains("#306230"), "Should use dark shade")
         XCTAssertTrue(css.contains("font-weight: bold"), "Should use weight to differentiate")
@@ -345,8 +345,8 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - Theme Color Scheme Consistency
 
     func testIsDarkAndHasLightBackgroundAreConsistentForAllThemes() {
-        for kind in ReaderThemeKind.allCases {
-            let theme = ReaderTheme.theme(for: kind)
+        for kind in ThemeKind.allCases {
+            let theme = Theme.theme(for: kind)
             XCTAssertEqual(
                 kind.isDark, !theme.hasLightBackground,
                 "\(kind): isDark (\(kind.isDark)) must be opposite of hasLightBackground (\(theme.hasLightBackground))"
@@ -358,10 +358,10 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testSimpleThemesCSSOutputContainsExpectedVariables() {
         let factory = ReaderCSSFactory()
-        for kind in [ReaderThemeKind.blackOnWhite, .whiteOnBlack, .darkGreyOnLightGrey, .lightGreyOnDarkGrey] {
+        for kind in [ThemeKind.blackOnWhite, .whiteOnBlack, .darkGreyOnLightGrey, .lightGreyOnDarkGrey] {
             let theme = kind.themeDefinition
             let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16)
-            let expectedColors = ReaderTheme.theme(for: kind)
+            let expectedColors = Theme.theme(for: kind)
             XCTAssertTrue(css.contains(expectedColors.backgroundHex), "CSS should contain background hex for \(kind)")
             XCTAssertTrue(css.contains(expectedColors.foregroundHex), "CSS should contain foreground hex for \(kind)")
         }
@@ -370,7 +370,7 @@ final class ThemeDefinitionTests: XCTestCase {
     // MARK: - New Content Themes
 
     func testGruvboxDarkThemeDefinition() {
-        let definition = ReaderThemeKind.gruvboxDark.themeDefinition
+        let definition = ThemeKind.gruvboxDark.themeDefinition
         XCTAssertEqual(definition.displayName, "Gruvbox Dark")
         XCTAssertTrue(definition.kind.isDark)
         XCTAssertNil(definition.customCSS)
@@ -381,7 +381,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGruvboxDarkColors() {
-        let definition = ReaderThemeKind.gruvboxDark.themeDefinition
+        let definition = ThemeKind.gruvboxDark.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#282828")
         XCTAssertEqual(definition.colors.foregroundHex, "#EBDBB2")
         XCTAssertEqual(definition.colors.linkHex, "#FE8019")
@@ -391,7 +391,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGruvboxLightThemeDefinition() {
-        let definition = ReaderThemeKind.gruvboxLight.themeDefinition
+        let definition = ThemeKind.gruvboxLight.themeDefinition
         XCTAssertEqual(definition.displayName, "Gruvbox Light")
         XCTAssertFalse(definition.kind.isDark)
         XCTAssertNil(definition.customCSS)
@@ -402,7 +402,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testGruvboxLightColors() {
-        let definition = ReaderThemeKind.gruvboxLight.themeDefinition
+        let definition = ThemeKind.gruvboxLight.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#FBF1C7")
         XCTAssertEqual(definition.colors.foregroundHex, "#3C3836")
         XCTAssertEqual(definition.colors.linkHex, "#076678")
@@ -412,7 +412,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testDraculaThemeDefinition() {
-        let definition = ReaderThemeKind.dracula.themeDefinition
+        let definition = ThemeKind.dracula.themeDefinition
         XCTAssertEqual(definition.displayName, "Dracula")
         XCTAssertTrue(definition.kind.isDark)
         XCTAssertNil(definition.customCSS)
@@ -423,7 +423,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testDraculaColors() {
-        let definition = ReaderThemeKind.dracula.themeDefinition
+        let definition = ThemeKind.dracula.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#282A36")
         XCTAssertEqual(definition.colors.foregroundHex, "#F8F8F2")
         XCTAssertEqual(definition.colors.linkHex, "#8BE9FD")
@@ -433,7 +433,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testMonokaiThemeDefinition() {
-        let definition = ReaderThemeKind.monokai.themeDefinition
+        let definition = ThemeKind.monokai.themeDefinition
         XCTAssertEqual(definition.displayName, "Monokai")
         XCTAssertTrue(definition.kind.isDark)
         XCTAssertNil(definition.customCSS)
@@ -444,7 +444,7 @@ final class ThemeDefinitionTests: XCTestCase {
     }
 
     func testMonokaiColors() {
-        let definition = ReaderThemeKind.monokai.themeDefinition
+        let definition = ThemeKind.monokai.themeDefinition
         XCTAssertEqual(definition.colors.backgroundHex, "#272822")
         XCTAssertEqual(definition.colors.foregroundHex, "#F8F8F2")
         XCTAssertEqual(definition.colors.linkHex, "#A6E22E")
@@ -455,7 +455,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testNewThemesCSSContainsHeaderVariables() {
         let factory = ReaderCSSFactory()
-        let newThemes: [ReaderThemeKind] = [.gruvboxDark, .gruvboxLight, .dracula, .monokai]
+        let newThemes: [ThemeKind] = [.gruvboxDark, .gruvboxLight, .dracula, .monokai]
         for kind in newThemes {
             let theme = kind.themeDefinition
             let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
@@ -468,14 +468,14 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testNewThemesUseSelectedSyntaxTheme() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.gruvboxDark.themeDefinition
+        let theme = ThemeKind.gruvboxDark.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16)
         XCTAssertTrue(css.contains("#D73A49"), "Should contain GitHub keyword color from selected syntax theme")
     }
 
     func testSimpleThemesDoNotEmitHeaderVariables() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
         XCTAssertFalse(css.contains("--reader-h1:"), "Simple themes should not emit h1 variable")
         XCTAssertFalse(css.contains("--reader-h2:"), "Simple themes should not emit h2 variable")
@@ -484,7 +484,7 @@ final class ThemeDefinitionTests: XCTestCase {
 
     func testHeaderColorFallbackInCSS() {
         let factory = ReaderCSSFactory()
-        let theme = ReaderThemeKind.blackOnWhite.themeDefinition
+        let theme = ThemeKind.blackOnWhite.themeDefinition
         let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
         XCTAssertTrue(css.contains("color: var(--reader-h1, var(--reader-fg))"), "h1 should fall back to foreground")
         XCTAssertTrue(css.contains("color: var(--reader-h2, var(--reader-fg))"), "h2 should fall back to foreground")

--- a/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
@@ -39,10 +39,10 @@ struct DocumentCloseCoordinatorTests {
             requestWatchedFolderReauthorization: { _ in nil }
         )
         return ReaderStore(
-            rendering: ReaderRenderingDependencies(
+            rendering: RenderingDependencies(
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
-            file: ReaderFileDependencies(
+            file: FileDependencies(
                 watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
+++ b/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
@@ -54,10 +54,10 @@ struct FileOpenPlanExecutorTests {
             requestWatchedFolderReauthorization: { _ in nil }
         )
         return ReaderStore(
-            rendering: ReaderRenderingDependencies(
+            rendering: RenderingDependencies(
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
-            file: ReaderFileDependencies(
+            file: FileDependencies(
                 watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -269,10 +269,10 @@ struct ReaderSidebarDocumentControllerTests {
                         requestWatchedFolderReauthorization: { _ in nil }
                     )
                     return ReaderStore(
-                        rendering: ReaderRenderingDependencies(
+                        rendering: RenderingDependencies(
                             renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                         ),
-                        file: ReaderFileDependencies(
+                        file: FileDependencies(
                             watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
                         ),
                         folderWatch: FolderWatchDependencies(
@@ -329,7 +329,7 @@ struct ReaderSidebarDocumentControllerTests {
         let nestedFileURL = nestedDirectoryURL.appendingPathComponent("nested.md")
         try "# Nested".write(to: nestedFileURL, atomically: true, encoding: .utf8)
 
-        let favoriteEntry = ReaderFavoriteWatchedFolder(
+        let favoriteEntry = FavoriteWatchedFolder(
             name: "Docs",
             folderURL: harness.temporaryDirectoryURL,
             options: FolderWatchOptions(openMode: .watchChangesOnly, scope: .selectedFolderOnly),
@@ -1265,10 +1265,10 @@ struct ReaderSidebarDocumentControllerTests {
                     requestWatchedFolderReauthorization: { _ in nil }
                 )
                 return ReaderStore(
-                    rendering: ReaderRenderingDependencies(
+                    rendering: RenderingDependencies(
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
-                    file: ReaderFileDependencies(
+                    file: FileDependencies(
                         watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Sidebar/ReaderSidebarGroupingTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarGroupingTests.swift
@@ -14,7 +14,7 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents)
+        let grouping = SidebarGrouping.group(harness.documents)
 
         guard case .flat(let documents) = grouping else {
             Issue.record("Expected flat grouping for single directory")
@@ -30,7 +30,7 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents)
+        let grouping = SidebarGrouping.group(harness.documents)
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result for multiple directories")
@@ -53,7 +53,7 @@ struct ReaderSidebarGroupingTests {
         olderDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         newerDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents)
+        let grouping = SidebarGrouping.group(harness.documents)
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result")
@@ -71,7 +71,7 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             harness.documents,
             sortMode: .nameAscending
         )
@@ -94,7 +94,7 @@ struct ReaderSidebarGroupingTests {
         let alphaDoc = try #require(harness.documentsInSubdirectory("alpha").first)
         let reorderedDocuments = [betaDoc, alphaDoc]
 
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             reorderedDocuments,
             sortMode: .openOrder
         )
@@ -120,7 +120,7 @@ struct ReaderSidebarGroupingTests {
         let fileSortedDocuments = [alphaDoc, betaDoc]
         let openOrderSourceDocuments = [betaDoc, alphaDoc]
 
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             fileSortedDocuments,
             sortMode: .openOrder,
             directoryOrderSourceDocuments: openOrderSourceDocuments
@@ -149,7 +149,7 @@ struct ReaderSidebarGroupingTests {
         let alphaDoc = try #require(harness.documentsInSubdirectory("alpha").first)
 
         // Intentionally reverse incoming order to ensure tie-break is deterministic by display name.
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             [zetaDoc, alphaDoc],
             sortMode: .lastChangedNewestFirst
         )
@@ -175,7 +175,7 @@ struct ReaderSidebarGroupingTests {
         alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         betaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
-        let grouping1 = ReaderSidebarGrouping.group(harness.documents)
+        let grouping1 = SidebarGrouping.group(harness.documents)
         guard case .grouped(let groups1) = grouping1 else {
             Issue.record("Expected grouped result")
             return
@@ -185,7 +185,7 @@ struct ReaderSidebarGroupingTests {
         // Now alpha gets modified more recently
         alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 3000))
 
-        let grouping2 = ReaderSidebarGrouping.group(harness.documents)
+        let grouping2 = SidebarGrouping.group(harness.documents)
         guard case .grouped(let groups2) = grouping2 else {
             Issue.record("Expected grouped result")
             return
@@ -202,7 +202,7 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        let states = ReaderSidebarGrouping.indicators(for: harness.documents)
+        let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states.isEmpty)
     }
 
@@ -216,7 +216,7 @@ struct ReaderSidebarGroupingTests {
         harness.documents[0].readerStore.testSetHasUnacknowledgedExternalChange(true)
         harness.documents[0].readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
 
-        let states = ReaderSidebarGrouping.indicators(for: harness.documents)
+        let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states == [.externalChange])
     }
 
@@ -231,7 +231,7 @@ struct ReaderSidebarGroupingTests {
         harness.documents[0].readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
         harness.documents[0].readerStore.testSetIsCurrentFileMissing(true)
 
-        let states = ReaderSidebarGrouping.indicators(for: harness.documents)
+        let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states == [.deletedExternalChange])
     }
 
@@ -250,7 +250,7 @@ struct ReaderSidebarGroupingTests {
         }
 
         let gammaPath = harness.directoryPath(for: "gamma")
-        let grouping = ReaderSidebarGrouping.group(harness.documents, pinnedGroupIDs: [gammaPath])
+        let grouping = SidebarGrouping.group(harness.documents, pinnedGroupIDs: [gammaPath])
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result")
@@ -280,7 +280,7 @@ struct ReaderSidebarGroupingTests {
         let alphaPath = harness.directoryPath(for: "alpha")
         let gammaPath = harness.directoryPath(for: "gamma")
 
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             harness.documents,
             pinnedGroupIDs: [alphaPath, gammaPath]
         )
@@ -311,7 +311,7 @@ struct ReaderSidebarGroupingTests {
         alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         betaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents, pinnedGroupIDs: [])
+        let grouping = SidebarGrouping.group(harness.documents, pinnedGroupIDs: [])
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result")
@@ -345,49 +345,49 @@ struct ReaderSidebarGroupingTests {
         #expect(documentStates.contains(.externalChange))
         #expect(documentStates.contains(.deletedExternalChange))
 
-        let states = ReaderSidebarGrouping.indicators(for: harness.documents)
+        let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states == [.externalChange, .deletedExternalChange])
     }
 
     // MARK: - Indicator Aggregation from Pre-Computed States
 
     @Test @MainActor func indicatorsFromStatesReturnsEmptyWhenAllNone() {
-        let result = ReaderSidebarGrouping.indicators(
+        let result = SidebarGrouping.indicators(
             from: [.none, .none, .none]
         )
         #expect(result.isEmpty)
     }
 
     @Test @MainActor func indicatorsFromStatesReturnsExternalChangeWhenPresent() {
-        let result = ReaderSidebarGrouping.indicators(
+        let result = SidebarGrouping.indicators(
             from: [.none, .externalChange, .none]
         )
         #expect(result == [.externalChange])
     }
 
     @Test @MainActor func indicatorsFromStatesKeepsAddedAndModifiedDistinct() {
-        let result = ReaderSidebarGrouping.indicators(
+        let result = SidebarGrouping.indicators(
             from: [.none, .addedExternalChange, .none]
         )
         #expect(result == [.addedExternalChange])
     }
 
     @Test @MainActor func indicatorsFromStatesReturnsDeletedWhenPresent() {
-        let result = ReaderSidebarGrouping.indicators(
+        let result = SidebarGrouping.indicators(
             from: [.none, .deletedExternalChange]
         )
         #expect(result == [.deletedExternalChange])
     }
 
     @Test @MainActor func indicatorsFromStatesReturnsAllKindsInStableOrder() {
-        let result = ReaderSidebarGrouping.indicators(
+        let result = SidebarGrouping.indicators(
             from: [.externalChange, .deletedExternalChange, .addedExternalChange, .none]
         )
         #expect(result == [.addedExternalChange, .externalChange, .deletedExternalChange])
     }
 
     @Test @MainActor func indicatorsFromStatesHandlesEmptyArray() {
-        let result = ReaderSidebarGrouping.indicators(from: [])
+        let result = SidebarGrouping.indicators(from: [])
         #expect(result.isEmpty)
     }
 
@@ -410,7 +410,7 @@ struct ReaderSidebarGroupingTests {
             testsPath: 0
         ]
 
-        let grouping = ReaderSidebarGrouping.group(
+        let grouping = SidebarGrouping.group(
             harness.documents,
             precomputedIndicatorStates: precomputed,
             precomputedIndicatorPulseTokens: pulseTokens
@@ -440,7 +440,7 @@ struct ReaderSidebarGroupingTests {
             .testSetHasUnacknowledgedExternalChange(true)
         harness.documentsInSubdirectory("src").first!.readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents)
+        let grouping = SidebarGrouping.group(harness.documents)
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result")
@@ -464,7 +464,7 @@ struct ReaderSidebarGroupingTests {
             .testSetHasUnacknowledgedExternalChange(true)
         harness.documentsInSubdirectory("src").first!.readerStore.externalChange.unacknowledgedExternalChangeKind = .added
 
-        let grouping = ReaderSidebarGrouping.group(harness.documents)
+        let grouping = SidebarGrouping.group(harness.documents)
 
         guard case .grouped(let groups) = grouping else {
             Issue.record("Expected grouped result")

--- a/minimarkTests/Sidebar/SidebarDocumentListTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentListTests.swift
@@ -19,10 +19,10 @@ struct SidebarDocumentListTests {
         settingsStore: ReaderSettingsStore
     ) -> ReaderSidebarDocumentController.Document {
         let store = ReaderStore(
-            rendering: ReaderRenderingDependencies(
+            rendering: RenderingDependencies(
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
-            file: ReaderFileDependencies(
+            file: FileDependencies(
                 watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
+++ b/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
@@ -218,7 +218,7 @@ struct SidebarGroupStateControllerTests {
     @Test @MainActor func applyWorkspaceStateRestoresAllGroupState() throws {
         let controller = SidebarGroupStateController()
 
-        let state = ReaderFavoriteWorkspaceState(
+        let state = FavoriteWorkspaceState(
             fileSortMode: .nameAscending,
             groupSortMode: .nameDescending,
             sidebarPosition: .sidebarLeft,

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -18,10 +18,10 @@ struct SidebarRowStateComputerTests {
         settingsStore: ReaderSettingsStore
     ) -> ReaderSidebarDocumentController.Document {
         let store = ReaderStore(
-            rendering: ReaderRenderingDependencies(
+            rendering: RenderingDependencies(
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
-            file: ReaderFileDependencies(
+            file: FileDependencies(
                 watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(

--- a/minimarkTests/Stores/Settings/FavoriteWatchedFoldersStoreTests.swift
+++ b/minimarkTests/Stores/Settings/FavoriteWatchedFoldersStoreTests.swift
@@ -14,7 +14,7 @@ struct FavoriteWatchedFoldersStoreTests {
     }
 
     @MainActor private func makeStore(
-        initial: [ReaderFavoriteWatchedFolder] = [],
+        initial: [FavoriteWatchedFolder] = [],
         resolver: @escaping BookmarkRefreshing.Resolver = { _ in (URL(fileURLWithPath: "/ignored"), false) },
         creator: @escaping BookmarkRefreshing.Creator = { _ in Data() }
     ) -> (FavoriteWatchedFoldersStore, RecordingCoordinator) {
@@ -104,7 +104,7 @@ struct FavoriteWatchedFoldersStoreTests {
         let id = store.currentFavorites[0].id
         coordinator.coalescingCalls.removeAll()
 
-        let newState = ReaderFavoriteWorkspaceState(
+        let newState = FavoriteWorkspaceState(
             fileSortMode: .nameAscending,
             groupSortMode: .nameAscending,
             sidebarPosition: .sidebarRight,
@@ -135,7 +135,7 @@ struct FavoriteWatchedFoldersStoreTests {
 
     @Test @MainActor func resolvedFavoriteWatchedFolderURLReturnsFolderURLWhenNoBookmark() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
-        let entry = ReaderFavoriteWatchedFolder(name: "Docs", folderURL: folderURL, options: .default)
+        let entry = FavoriteWatchedFolder(name: "Docs", folderURL: folderURL, options: .default)
         let (store, _) = makeStore(initial: [entry])
 
         let resolved = store.resolvedFavoriteWatchedFolderURL(for: entry)
@@ -148,7 +148,7 @@ struct FavoriteWatchedFoldersStoreTests {
         let resolvedURL = URL(fileURLWithPath: "/tmp/docs-moved", isDirectory: true)
         let originalBookmark = Data([0x01])
         let refreshedBookmark = Data([0x02, 0x03])
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             id: UUID(),
             name: "Docs",
             folderPath: folderURL.path,
@@ -160,7 +160,7 @@ struct FavoriteWatchedFoldersStoreTests {
                 settings: .default,
                 pinnedGroupIDs: [],
                 collapsedGroupIDs: [],
-                sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+                sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
             ),
             createdAt: Date()
         )
@@ -179,7 +179,7 @@ struct FavoriteWatchedFoldersStoreTests {
 
     @Test @MainActor func resolvedFavoriteWatchedFolderURLClearsInvalidBookmark() {
         let folderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
-        let entry = ReaderFavoriteWatchedFolder(
+        let entry = FavoriteWatchedFolder(
             id: UUID(),
             name: "Docs",
             folderPath: folderURL.path,
@@ -191,7 +191,7 @@ struct FavoriteWatchedFoldersStoreTests {
                 settings: .default,
                 pinnedGroupIDs: [],
                 collapsedGroupIDs: [],
-                sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+                sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
             ),
             createdAt: Date()
         )

--- a/minimarkTests/Stores/Settings/RecentOpenedFilesStoreTests.swift
+++ b/minimarkTests/Stores/Settings/RecentOpenedFilesStoreTests.swift
@@ -14,7 +14,7 @@ struct RecentOpenedFilesStoreTests {
     }
 
     @MainActor private func makeStore(
-        initial: [ReaderRecentOpenedFile] = [],
+        initial: [RecentOpenedFile] = [],
         resolver: @escaping BookmarkRefreshing.Resolver = { _ in (URL(fileURLWithPath: "/ignored"), false) },
         creator: @escaping BookmarkRefreshing.Creator = { _ in Data() }
     ) -> (RecentOpenedFilesStore, RecordingCoordinator) {
@@ -37,11 +37,11 @@ struct RecentOpenedFilesStoreTests {
 
     @Test @MainActor func addRespectsMaximumCount() {
         let (store, _) = makeStore()
-        for i in 0..<(ReaderRecentOpenedFile.maximumCount + 3) {
+        for i in 0..<(RecentOpenedFile.maximumCount + 3) {
             store.addRecentManuallyOpenedFile(URL(fileURLWithPath: "/tmp/f-\(i).md"))
         }
 
-        #expect(store.currentRecentOpenedFiles.count == ReaderRecentOpenedFile.maximumCount)
+        #expect(store.currentRecentOpenedFiles.count == RecentOpenedFile.maximumCount)
     }
 
     @Test @MainActor func clearEmptiesCollection() {
@@ -63,7 +63,7 @@ struct RecentOpenedFilesStoreTests {
 
     @Test @MainActor func resolvedURLRefreshesStaleBookmark() {
         let fileURL = URL(fileURLWithPath: "/tmp/stale.md")
-        let entry = ReaderRecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x01]))
+        let entry = RecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x01]))
         let refreshed = Data([0xBB])
         let (store, _) = makeStore(
             initial: [entry],
@@ -79,7 +79,7 @@ struct RecentOpenedFilesStoreTests {
 
     @Test @MainActor func resolvedURLClearsInvalidBookmark() {
         let fileURL = URL(fileURLWithPath: "/tmp/broken.md")
-        let entry = ReaderRecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x01]))
+        let entry = RecentOpenedFile(filePath: fileURL.path, bookmarkData: Data([0x01]))
         let (store, _) = makeStore(
             initial: [entry],
             resolver: { _ in throw NSError(domain: "test", code: 1) }

--- a/minimarkTests/Stores/Settings/RecentWatchedFoldersStoreTests.swift
+++ b/minimarkTests/Stores/Settings/RecentWatchedFoldersStoreTests.swift
@@ -14,7 +14,7 @@ struct RecentWatchedFoldersStoreTests {
     }
 
     @MainActor private func makeStore(
-        initial: [ReaderRecentWatchedFolder] = [],
+        initial: [RecentWatchedFolder] = [],
         resolver: @escaping BookmarkRefreshing.Resolver = { _ in (URL(fileURLWithPath: "/ignored"), false) },
         creator: @escaping BookmarkRefreshing.Creator = { _ in Data() }
     ) -> (RecentWatchedFoldersStore, RecordingCoordinator) {
@@ -37,14 +37,14 @@ struct RecentWatchedFoldersStoreTests {
 
     @Test @MainActor func addRespectsMaximumCount() {
         let (store, _) = makeStore()
-        for i in 0..<(ReaderRecentWatchedFolder.maximumCount + 5) {
+        for i in 0..<(RecentWatchedFolder.maximumCount + 5) {
             store.addRecentWatchedFolder(
                 URL(fileURLWithPath: "/tmp/f-\(i)", isDirectory: true),
                 options: .default
             )
         }
 
-        #expect(store.currentRecentWatchedFolders.count == ReaderRecentWatchedFolder.maximumCount)
+        #expect(store.currentRecentWatchedFolders.count == RecentWatchedFolder.maximumCount)
     }
 
     @Test @MainActor func clearEmptiesCollection() {
@@ -66,7 +66,7 @@ struct RecentWatchedFoldersStoreTests {
 
     @Test @MainActor func resolvedURLRefreshesStaleBookmark() {
         let folderURL = URL(fileURLWithPath: "/tmp/stale", isDirectory: true)
-        let entry = ReaderRecentWatchedFolder(
+        let entry = RecentWatchedFolder(
             folderPath: folderURL.path,
             options: .default,
             bookmarkData: Data([0x01])
@@ -86,7 +86,7 @@ struct RecentWatchedFoldersStoreTests {
 
     @Test @MainActor func resolvedURLClearsInvalidBookmark() {
         let folderURL = URL(fileURLWithPath: "/tmp/broken", isDirectory: true)
-        let entry = ReaderRecentWatchedFolder(
+        let entry = RecentWatchedFolder(
             folderPath: folderURL.path,
             options: .default,
             bookmarkData: Data([0x01])

--- a/minimarkTests/Stores/Settings/TrustedImageFoldersStoreTests.swift
+++ b/minimarkTests/Stores/Settings/TrustedImageFoldersStoreTests.swift
@@ -14,7 +14,7 @@ struct TrustedImageFoldersStoreTests {
     }
 
     @MainActor private func makeStore(
-        initial: [ReaderTrustedImageFolder] = [],
+        initial: [TrustedImageFolder] = [],
         resolver: @escaping BookmarkRefreshing.Resolver = { _ in (URL(fileURLWithPath: "/ignored"), false) },
         creator: @escaping BookmarkRefreshing.Creator = { _ in Data() }
     ) -> (TrustedImageFoldersStore, RecordingCoordinator) {
@@ -35,7 +35,7 @@ struct TrustedImageFoldersStoreTests {
     }
 
     @Test @MainActor func resolvedURLReturnsNilWhenNoFolderContainsFile() {
-        let entry = ReaderTrustedImageFolder(
+        let entry = TrustedImageFolder(
             folderPath: "/tmp/images",
             bookmarkData: Data([0x01])
         )
@@ -47,7 +47,7 @@ struct TrustedImageFoldersStoreTests {
     }
 
     @Test @MainActor func resolvedURLReturnsNilWhenEntryHasNoBookmark() {
-        let entry = ReaderTrustedImageFolder(folderPath: "/tmp/images", bookmarkData: nil)
+        let entry = TrustedImageFolder(folderPath: "/tmp/images", bookmarkData: nil)
         let (store, _) = makeStore(initial: [entry])
 
         let result = store.resolvedTrustedImageFolderURL(containing: URL(fileURLWithPath: "/tmp/images/a.png"))
@@ -58,7 +58,7 @@ struct TrustedImageFoldersStoreTests {
     @Test @MainActor func resolvedURLRefreshesStaleBookmark() {
         let folderURL = URL(fileURLWithPath: "/tmp/images", isDirectory: true)
         let refreshed = Data([0xCC])
-        let entry = ReaderTrustedImageFolder(folderPath: folderURL.path, bookmarkData: Data([0x01]))
+        let entry = TrustedImageFolder(folderPath: folderURL.path, bookmarkData: Data([0x01]))
         let (store, _) = makeStore(
             initial: [entry],
             resolver: { _ in (folderURL, true) },
@@ -72,7 +72,7 @@ struct TrustedImageFoldersStoreTests {
     }
 
     @Test @MainActor func resolvedURLClearsInvalidBookmarkAndReturnsNil() {
-        let entry = ReaderTrustedImageFolder(folderPath: "/tmp/images", bookmarkData: Data([0x01]))
+        let entry = TrustedImageFolder(folderPath: "/tmp/images", bookmarkData: Data([0x01]))
         let (store, _) = makeStore(
             initial: [entry],
             resolver: { _ in throw NSError(domain: "test", code: 1) }

--- a/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
+++ b/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
@@ -34,10 +34,10 @@ struct ReaderSidebarGroupingTestHarness {
                     requestWatchedFolderReauthorization: { _ in nil }
                 )
                 let store = ReaderStore(
-                    rendering: ReaderRenderingDependencies(
+                    rendering: RenderingDependencies(
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
-                    file: ReaderFileDependencies(
+                    file: FileDependencies(
                         watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -104,9 +104,9 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         subject.value
     }
 
-    private(set) var recordedFavoriteWatchedFolders: [ReaderFavoriteWatchedFolder] = []
-    private(set) var recordedRecentWatchedFolders: [ReaderRecentWatchedFolder] = []
-    private(set) var recordedRecentManuallyOpenedFiles: [ReaderRecentOpenedFile] = []
+    private(set) var recordedFavoriteWatchedFolders: [FavoriteWatchedFolder] = []
+    private(set) var recordedRecentWatchedFolders: [RecentWatchedFolder] = []
+    private(set) var recordedRecentManuallyOpenedFiles: [RecentOpenedFile] = []
 
     private let subject: CurrentValueSubject<ReaderSettings, Never>
 
@@ -139,7 +139,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         subject.send(next)
     }
 
-    func updateTheme(_ kind: ReaderThemeKind) {
+    func updateTheme(_ kind: ThemeKind) {
         var next = subject.value
         next.readerTheme = kind
         subject.send(next)
@@ -175,19 +175,19 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         subject.send(next)
     }
 
-    func updateMultiFileDisplayMode(_ mode: ReaderMultiFileDisplayMode) {
+    func updateMultiFileDisplayMode(_ mode: MultiFileDisplayMode) {
         var next = subject.value
         next.multiFileDisplayMode = mode
         subject.send(next)
     }
 
-    func updateSidebarSortMode(_ mode: ReaderSidebarSortMode) {
+    func updateSidebarSortMode(_ mode: SidebarSortMode) {
         var next = subject.value
         next.sidebarSortMode = mode
         subject.send(next)
     }
 
-    func updateSidebarGroupSortMode(_ mode: ReaderSidebarSortMode) {
+    func updateSidebarGroupSortMode(_ mode: SidebarSortMode) {
         var next = subject.value
         next.sidebarGroupSortMode = mode
         subject.send(next)
@@ -198,11 +198,11 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         folderURL: URL,
         options: FolderWatchOptions,
         openDocumentFileURLs: [URL] = [],
-        workspaceState: ReaderFavoriteWorkspaceState = .from(
+        workspaceState: FavoriteWorkspaceState = .from(
             settings: .default,
             pinnedGroupIDs: [],
             collapsedGroupIDs: [],
-            sidebarWidth: ReaderFavoriteWorkspaceState.defaultSidebarWidth
+            sidebarWidth: FavoriteWorkspaceState.defaultSidebarWidth
         )
     ) {
         var next = subject.value
@@ -250,7 +250,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         }
 
         let existing = next.favoriteWatchedFolders[index]
-        let scopedRelativePaths = ReaderFavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
+        let scopedRelativePaths = FavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
             from: openDocumentFileURLs,
             relativeTo: folderURL,
             options: existing.options
@@ -258,7 +258,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         let updatedKnownPaths = Array(
             Set(existing.allKnownRelativePaths).union(scopedRelativePaths)
         ).sorted()
-        next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
+        next.favoriteWatchedFolders[index] = FavoriteWatchedFolder(
             id: existing.id,
             name: existing.name,
             folderPath: existing.folderPath,
@@ -285,7 +285,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         }
 
         let existing = next.favoriteWatchedFolders[index]
-        let scopedRelativePaths = ReaderFavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
+        let scopedRelativePaths = FavoriteWatchedFolder.scopedOpenDocumentRelativePaths(
             from: knownDocumentFileURLs,
             relativeTo: folderURL,
             options: existing.options
@@ -293,7 +293,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         let updatedKnownPaths = Array(
             Set(existing.allKnownRelativePaths).union(scopedRelativePaths)
         ).sorted()
-        next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
+        next.favoriteWatchedFolders[index] = FavoriteWatchedFolder(
             id: existing.id,
             name: existing.name,
             folderPath: existing.folderPath,
@@ -309,17 +309,17 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         subject.send(next)
     }
 
-    func resolvedFavoriteWatchedFolderURL(for entry: ReaderFavoriteWatchedFolder) -> URL {
+    func resolvedFavoriteWatchedFolderURL(for entry: FavoriteWatchedFolder) -> URL {
         entry.folderURL
     }
 
-    func updateFavoriteWorkspaceState(id: UUID, workspaceState: ReaderFavoriteWorkspaceState) {
+    func updateFavoriteWorkspaceState(id: UUID, workspaceState: FavoriteWorkspaceState) {
         var next = subject.value
         guard let index = next.favoriteWatchedFolders.firstIndex(where: { $0.id == id }) else {
             return
         }
         let existing = next.favoriteWatchedFolders[index]
-        next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
+        next.favoriteWatchedFolders[index] = FavoriteWatchedFolder(
             id: existing.id,
             name: existing.name,
             folderPath: existing.folderPath,
@@ -390,7 +390,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         subject.send(next)
     }
 
-    private(set) var recordedTrustedImageFolders: [ReaderTrustedImageFolder] = []
+    private(set) var recordedTrustedImageFolders: [TrustedImageFolder] = []
 
     func addTrustedImageFolder(_ folderURL: URL) {
         var next = subject.value
@@ -461,7 +461,7 @@ final class TestReaderSettingsStore: ReaderSettingsStoring {
         guard existing.options != normalizedOptions else {
             return
         }
-        next.favoriteWatchedFolders[index] = ReaderFavoriteWatchedFolder(
+        next.favoriteWatchedFolders[index] = FavoriteWatchedFolder(
             id: existing.id,
             name: existing.name,
             folderPath: existing.folderPath,
@@ -596,7 +596,7 @@ final class TestReaderAutoOpenSettler: ReaderAutoOpenSettling {
     var handleChangeIfNeededResult = false
 
     func makePendingContext(
-        origin: ReaderOpenOrigin,
+        origin: OpenOrigin,
         initialDiffBaselineMarkdown: String?,
         loadedMarkdown: String,
         now: Date
@@ -640,11 +640,11 @@ final class TestReaderDocumentIO: ReaderDocumentIO {
 }
 
 final class TestReaderFileActions: ReaderFileActionHandling {
-    func registeredApplications(for fileURL: URL) throws -> [ReaderExternalApplication] {
+    func registeredApplications(for fileURL: URL) throws -> [ExternalApplication] {
         []
     }
 
-    func open(fileURL: URL, in application: ReaderExternalApplication?) throws {}
+    func open(fileURL: URL, in application: ExternalApplication?) throws {}
     func revealInFinder(fileURL: URL) throws {}
 }
 
@@ -805,7 +805,7 @@ final class TestFolderWatchControllerDelegate: FolderWatchControllerDelegate {
         _ controller: FolderWatchController,
         handleEvents events: [FolderWatchChangeEvent],
         in session: FolderWatchSession,
-        origin: ReaderOpenOrigin
+        origin: OpenOrigin
     ) {
         handledEvents.append(contentsOf: events)
     }
@@ -878,8 +878,8 @@ struct ReaderStoreTestFixture {
         )
         let settler = ReaderAutoOpenSettler(settlingInterval: autoOpenSettlingInterval)
         store = ReaderStore(
-            rendering: ReaderRenderingDependencies(renderer: renderer, differ: differ),
-            file: ReaderFileDependencies(watcher: watcher, io: ReaderDocumentIOService(), actions: fileActions),
+            rendering: RenderingDependencies(renderer: renderer, differ: differ),
+            file: FileDependencies(watcher: watcher, io: ReaderDocumentIOService(), actions: fileActions),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),
                 settler: settler,
@@ -952,10 +952,10 @@ struct ReaderSidebarControllerTestHarness {
                     requestWatchedFolderReauthorization: { _ in nil }
                 )
                 let store = ReaderStore(
-                    rendering: ReaderRenderingDependencies(
+                    rendering: RenderingDependencies(
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
-                    file: ReaderFileDependencies(
+                    file: FileDependencies(
                         watcher: fileWatcher, io: ReaderDocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(


### PR DESCRIPTION
Batch 1 of 6 for #355 — renames in `minimark/Models/`.

## Types renamed

- `ReaderRenderingDependencies` → `RenderingDependencies`
- `ReaderFileDependencies` → `FileDependencies`
- `ReaderExternalApplication` → `ExternalApplication`
- `ReaderFavoriteWatchedFolder` → `FavoriteWatchedFolder`
- `ReaderFavoriteWorkspaceState` → `FavoriteWorkspaceState`
- `ReaderMultiFileDisplayMode` → `MultiFileDisplayMode`
- `ReaderPresentableError` → `PresentableError`
- `ReaderRecentOpenedFile` → `RecentOpenedFile`
- `ReaderRecentWatchedFolder` → `RecentWatchedFolder`
- `ReaderSidebarGrouping` → `SidebarGrouping`
- `ReaderSidebarSortMode` → `SidebarSortMode`
- `ReaderTheme` → `Theme`, `ReaderThemeKind` → `ThemeKind`
- `ReaderTrustedImageFolder` → `TrustedImageFolder`
- `ReaderWindowSeed` → `WindowSeed`, `ReaderOpenOrigin` → `OpenOrigin`

Files renamed to match. `ReaderDependencies.swift` → `Dependencies.swift` (no `ReaderDependencies` type existed).

No behavior changes. Part of the #355 series; subsequent batches (`Support/`, `Services/`, `Stores/`, `Views/+Commands/`, `minimarkShared/+tests`) follow in their own PRs.

## Note on bundled prior commit

This PR is based on a local `develop` that was 1 commit ahead of `origin/develop` when batch 1 branched off. The bundled prior commit — `20c8d90` "Refactor: move SwiftUI View extension out of minimarkShared (follow-up #352)" — is a legitimate earlier change that addresses Copilot feedback on #352. It's an intentional part of the merge into `develop`, just not part of the Models/ rename work.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:minimarkTests` → ** TEST SUCCEEDED **
- [x] CI green (expected)