### PR TITLE
Refactor: drop Reader prefix from Services/ (batch 3 of #355)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -182,8 +182,8 @@ struct ContentView: View {
     )
     let fileDeps = FileDependencies(
         watcher: FileChangeWatcher(),
-        io: ReaderDocumentIOService(),
-        actions: ReaderFileActionService()
+        io: DocumentIOService(),
+        actions: FileActionService()
     )
     let renderingDeps = RenderingDependencies(
         renderer: MarkdownRenderingService(),

--- a/minimark/Models/Dependencies.swift
+++ b/minimark/Models/Dependencies.swift
@@ -7,12 +7,12 @@ struct RenderingDependencies {
 
 struct FileDependencies {
     let watcher: FileChangeWatching
-    let io: ReaderDocumentIO
-    let actions: ReaderFileActionHandling
+    let io: DocumentIO
+    let actions: FileActionHandling
 }
 
 struct FolderWatchDependencies {
     let autoOpenPlanner: FolderWatchAutoOpenPlanning
     let settler: ReaderAutoOpenSettling
-    let systemNotifier: ReaderSystemNotifying
+    let systemNotifier: SystemNotifying
 }

--- a/minimark/Services/DefaultMarkdownAssociationService.swift
+++ b/minimark/Services/DefaultMarkdownAssociationService.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreServices
 import UniformTypeIdentifiers
 
-protocol ReaderDefaultMarkdownAssociationHandling {
+protocol DefaultMarkdownAssociationHandling {
     func setCurrentAppAsDefaultForMarkdown() throws -> MarkdownAssociationUpdateResult
 }
 
@@ -74,7 +74,7 @@ enum MarkdownAssociationError: LocalizedError, Equatable {
     }
 }
 
-final class ReaderDefaultMarkdownAssociationService: ReaderDefaultMarkdownAssociationHandling {
+final class DefaultMarkdownAssociationService: DefaultMarkdownAssociationHandling {
     private let launchServices: LaunchServicesControlling
     private let typeResolver: MarkdownContentTypeResolving
     private let appBundle: Bundle

--- a/minimark/Services/DocumentIOService.swift
+++ b/minimark/Services/DocumentIOService.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-protocol ReaderDocumentIO: AnyObject {
+protocol DocumentIO: AnyObject {
     func load(at accessibleURL: URL) throws -> (markdown: String, modificationDate: Date)
     func write(_ markdown: String, to accessibleURL: URL) throws
     func modificationDate(for url: URL) -> Date
 }
 
-final class ReaderDocumentIOService: ReaderDocumentIO {
+final class DocumentIOService: DocumentIO {
     func load(at accessibleURL: URL) throws -> (markdown: String, modificationDate: Date) {
         guard accessibleURL.isFileURL else {
             throw AppError.invalidFileURL

--- a/minimark/Services/FileActionService.swift
+++ b/minimark/Services/FileActionService.swift
@@ -1,13 +1,13 @@
 import AppKit
 import Foundation
 
-protocol ReaderFileActionHandling {
+protocol FileActionHandling {
     func registeredApplications(for fileURL: URL) throws -> [ExternalApplication]
     func open(fileURL: URL, in application: ExternalApplication?) throws
     func revealInFinder(fileURL: URL) throws
 }
 
-final class ReaderFileActionService: ReaderFileActionHandling {
+final class FileActionService: FileActionHandling {
     private let workspace: WorkspaceControlling
 
     init(workspace: WorkspaceControlling = NSWorkspace.shared) {

--- a/minimark/Services/SystemNotificationService.swift
+++ b/minimark/Services/SystemNotificationService.swift
@@ -3,14 +3,14 @@ import Combine
 import Foundation
 import UserNotifications
 
-struct ReaderUserNotificationSettings: Equatable, Sendable {
+struct UserNotificationSettings: Equatable, Sendable {
     let authorizationStatus: UNAuthorizationStatus
     let alertSetting: UNNotificationSetting
     let soundSetting: UNNotificationSetting
     let notificationCenterSetting: UNNotificationSetting
 }
 
-protocol ReaderUserNotificationCentering: AnyObject {
+protocol UserNotificationCentering: AnyObject {
     var delegate: UNUserNotificationCenterDelegate? { get set }
 
     func requestAuthorization(
@@ -19,7 +19,7 @@ protocol ReaderUserNotificationCentering: AnyObject {
     )
 
     func notificationSettings(
-        completionHandler: @escaping @Sendable (ReaderUserNotificationSettings) -> Void
+        completionHandler: @escaping @Sendable (UserNotificationSettings) -> Void
     )
 
     func add(
@@ -28,13 +28,13 @@ protocol ReaderUserNotificationCentering: AnyObject {
     )
 }
 
-extension UNUserNotificationCenter: ReaderUserNotificationCentering {
+extension UNUserNotificationCenter: UserNotificationCentering {
     func notificationSettings(
-        completionHandler: @escaping @Sendable (ReaderUserNotificationSettings) -> Void
+        completionHandler: @escaping @Sendable (UserNotificationSettings) -> Void
     ) {
         getNotificationSettings { settings in
             completionHandler(
-                ReaderUserNotificationSettings(
+                UserNotificationSettings(
                     authorizationStatus: settings.authorizationStatus,
                     alertSetting: settings.alertSetting,
                     soundSetting: settings.soundSetting,
@@ -45,11 +45,11 @@ extension UNUserNotificationCenter: ReaderUserNotificationCentering {
     }
 }
 
-protocol ReaderNotificationSettingsOpening {
+protocol NotificationSettingsOpening {
     func openNotificationSettings()
 }
 
-struct ReaderSystemNotificationSettingsOpener: ReaderNotificationSettingsOpening {
+struct SystemNotificationSettingsOpener: NotificationSettingsOpening {
     private static let notificationSettingsURL = URL(
         string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
     )
@@ -62,7 +62,7 @@ struct ReaderSystemNotificationSettingsOpener: ReaderNotificationSettingsOpening
     }
 }
 
-enum ReaderNotificationAuthorizationState: Equatable {
+enum NotificationAuthorizationState: Equatable {
     case notDetermined
     case denied
     case authorized
@@ -82,14 +82,14 @@ enum ReaderNotificationAuthorizationState: Equatable {
     }
 }
 
-struct ReaderNotificationStatus: Equatable {
-    let authorizationState: ReaderNotificationAuthorizationState
+struct NotificationStatus: Equatable {
+    let authorizationState: NotificationAuthorizationState
     let alertsEnabled: Bool
     let soundsEnabled: Bool
     let notificationCenterEnabled: Bool
 
     init(
-        authorizationState: ReaderNotificationAuthorizationState,
+        authorizationState: NotificationAuthorizationState,
         alertsEnabled: Bool,
         soundsEnabled: Bool,
         notificationCenterEnabled: Bool
@@ -100,15 +100,15 @@ struct ReaderNotificationStatus: Equatable {
         self.notificationCenterEnabled = notificationCenterEnabled
     }
 
-    static let unknown = ReaderNotificationStatus(
+    static let unknown = NotificationStatus(
         authorizationState: .unknown,
         alertsEnabled: false,
         soundsEnabled: false,
         notificationCenterEnabled: false
     )
 
-    init(settings: ReaderUserNotificationSettings) {
-        authorizationState = ReaderNotificationAuthorizationState(settings.authorizationStatus)
+    init(settings: UserNotificationSettings) {
+        authorizationState = NotificationAuthorizationState(settings.authorizationStatus)
         alertsEnabled = settings.alertSetting == .enabled
         soundsEnabled = settings.soundSetting == .enabled
         notificationCenterEnabled = settings.notificationCenterSetting == .enabled
@@ -155,7 +155,7 @@ struct ReaderNotificationStatus: Equatable {
     }
 }
 
-protocol ReaderSystemNotifying {
+protocol SystemNotifying {
     func notifyFileChanged(
         _ fileURL: URL,
         changeKind: FolderWatchChangeKind,
@@ -163,12 +163,12 @@ protocol ReaderSystemNotifying {
     )
 }
 
-private enum ReaderSystemNotificationUserInfoKey {
+private enum SystemNotificationUserInfoKey {
     static let filePath = "filePath"
     static let watchedFolderPath = "watchedFolderPath"
 }
 
-private enum ReaderSystemNotificationEvent {
+private enum SystemNotificationEvent {
     case fileChanged(changeKind: FolderWatchChangeKind)
 
     var titleText: String {
@@ -183,7 +183,7 @@ private enum ReaderSystemNotificationEvent {
     }
 }
 
-private struct ReaderSystemNotificationDescriptor {
+private struct SystemNotificationDescriptor {
     let title: String
     let subtitle: String
     let body: String
@@ -201,7 +201,7 @@ private struct ReaderSystemNotificationDescriptor {
         self.userInfo = userInfo
     }
 
-    init(fileURL: URL, watchedFolderURL: URL?, event: ReaderSystemNotificationEvent) {
+    init(fileURL: URL, watchedFolderURL: URL?, event: SystemNotificationEvent) {
         let normalizedFileURL = FileRouting.normalizedFileURL(fileURL)
         let normalizedWatchedFolderURL = watchedFolderURL.map(FileRouting.normalizedFileURL)
         let fileName = normalizedFileURL.lastPathComponent
@@ -211,21 +211,21 @@ private struct ReaderSystemNotificationDescriptor {
         body = ""
 
         var userInfo: [AnyHashable: Any] = [
-            ReaderSystemNotificationUserInfoKey.filePath: normalizedFileURL.path
+            SystemNotificationUserInfoKey.filePath: normalizedFileURL.path
         ]
         if let normalizedWatchedFolderURL {
-            userInfo[ReaderSystemNotificationUserInfoKey.watchedFolderPath] = normalizedWatchedFolderURL.path
+            userInfo[SystemNotificationUserInfoKey.watchedFolderPath] = normalizedWatchedFolderURL.path
         }
         self.userInfo = userInfo
     }
 }
 
-protocol ReaderNotificationTargetFocusing {
+protocol NotificationTargetFocusing {
     @discardableResult
     func focusNotificationTarget(fileURL: URL?, watchedFolderURL: URL?) -> Bool
 }
 
-struct ReaderNotificationTargetFocusCoordinator: ReaderNotificationTargetFocusing {
+struct NotificationTargetFocusCoordinator: NotificationTargetFocusing {
     @discardableResult
     func focusNotificationTarget(fileURL: URL?, watchedFolderURL: URL?) -> Bool {
         if Thread.isMainThread {
@@ -248,19 +248,19 @@ struct ReaderNotificationTargetFocusCoordinator: ReaderNotificationTargetFocusin
     }
 }
 
-final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotifying, UNUserNotificationCenterDelegate {
-    static let shared = ReaderSystemNotifier()
+final class SystemNotifier: NSObject, ObservableObject, SystemNotifying, UNUserNotificationCenterDelegate {
+    static let shared = SystemNotifier()
 
-    @Published private(set) var notificationStatus: ReaderNotificationStatus = .unknown
+    @Published private(set) var notificationStatus: NotificationStatus = .unknown
 
-    private let notificationCenter: ReaderUserNotificationCentering
-    private let settingsOpener: ReaderNotificationSettingsOpening
-    private let notificationTargetFocuser: ReaderNotificationTargetFocusing
+    private let notificationCenter: UserNotificationCentering
+    private let settingsOpener: NotificationSettingsOpening
+    private let notificationTargetFocuser: NotificationTargetFocusing
 
     init(
-        notificationCenter: ReaderUserNotificationCentering = UNUserNotificationCenter.current(),
-        settingsOpener: ReaderNotificationSettingsOpening = ReaderSystemNotificationSettingsOpener(),
-        notificationTargetFocuser: ReaderNotificationTargetFocusing = ReaderNotificationTargetFocusCoordinator()
+        notificationCenter: UserNotificationCentering = UNUserNotificationCenter.current(),
+        settingsOpener: NotificationSettingsOpening = SystemNotificationSettingsOpener(),
+        notificationTargetFocuser: NotificationTargetFocusing = NotificationTargetFocusCoordinator()
     ) {
         self.notificationCenter = notificationCenter
         self.settingsOpener = settingsOpener
@@ -290,7 +290,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
     func sendTestNotification(after delay: TimeInterval = 5) {
         let roundedDelay = max(delay.rounded(.up), 1)
         postNotification(
-            ReaderSystemNotificationDescriptor(
+            SystemNotificationDescriptor(
                 title: "Test notification",
                 subtitle: "Background delivery check",
                 body: "This test was scheduled by MarkdownObserver. Switch away from the app before it fires to verify background delivery.",
@@ -306,7 +306,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
         watchedFolderURL: URL?
     ) {
         postNotification(
-            ReaderSystemNotificationDescriptor(
+            SystemNotificationDescriptor(
                 fileURL: fileURL,
                 watchedFolderURL: watchedFolderURL,
                 event: .fileChanged(changeKind: changeKind)
@@ -332,8 +332,8 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
     }
 
     func handleNotificationResponseUserInfo(_ userInfo: [AnyHashable: Any]) {
-        let fileURL = Self.url(from: userInfo[ReaderSystemNotificationUserInfoKey.filePath])
-        let watchedFolderURL = Self.url(from: userInfo[ReaderSystemNotificationUserInfoKey.watchedFolderPath])
+        let fileURL = Self.url(from: userInfo[SystemNotificationUserInfoKey.filePath])
+        let watchedFolderURL = Self.url(from: userInfo[SystemNotificationUserInfoKey.watchedFolderPath])
 
         _ = notificationTargetFocuser.focusNotificationTarget(
             fileURL: fileURL,
@@ -342,7 +342,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
     }
 
     private func postNotification(
-        _ descriptor: ReaderSystemNotificationDescriptor,
+        _ descriptor: SystemNotificationDescriptor,
         timeInterval: TimeInterval? = nil
     ) {
         ensureAuthorizationIfNeeded { [weak self] isAuthorized in
@@ -358,7 +358,7 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
     }
 
     private func addNotificationRequest(
-        _ descriptor: ReaderSystemNotificationDescriptor,
+        _ descriptor: SystemNotificationDescriptor,
         timeInterval: TimeInterval?
     ) {
         let trigger = timeInterval.map {
@@ -391,12 +391,12 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
     }
 
     private func handleAuthorizationState(
-        _ settings: ReaderUserNotificationSettings,
+        _ settings: UserNotificationSettings,
         completion: @escaping @Sendable (Bool) -> Void
     ) {
         updateNotificationStatus(with: settings)
 
-        switch ReaderNotificationAuthorizationState(settings.authorizationStatus) {
+        switch NotificationAuthorizationState(settings.authorizationStatus) {
         case .authorized:
             completion(true)
         case .denied, .unknown:
@@ -409,8 +409,8 @@ final class ReaderSystemNotifier: NSObject, ObservableObject, ReaderSystemNotify
         }
     }
 
-    private func updateNotificationStatus(with settings: ReaderUserNotificationSettings) {
-        let status = ReaderNotificationStatus(settings: settings)
+    private func updateNotificationStatus(with settings: UserNotificationSettings) {
+        let status = NotificationStatus(settings: settings)
         DispatchQueue.main.async { [weak self] in
             guard let self else {
                 return

--- a/minimark/Stores/Reader/MarkdownFileLoader.swift
+++ b/minimark/Stores/Reader/MarkdownFileLoader.swift
@@ -3,9 +3,9 @@ import Foundation
 @MainActor
 final class MarkdownFileLoader {
     private let securityScopeResolver: SecurityScopeResolver
-    private let fileIO: ReaderDocumentIO
+    private let fileIO: DocumentIO
 
-    init(securityScopeResolver: SecurityScopeResolver, fileIO: ReaderDocumentIO) {
+    init(securityScopeResolver: SecurityScopeResolver, fileIO: DocumentIO) {
         self.securityScopeResolver = securityScopeResolver
         self.fileIO = fileIO
     }

--- a/minimark/Stores/Reader/SourceDraftPersister.swift
+++ b/minimark/Stores/Reader/SourceDraftPersister.swift
@@ -14,7 +14,7 @@ final class SourceDraftPersister {
     private let renderingController: ReaderRenderingController
     private let folderWatchDispatcher: FolderWatchDispatcher
     private let securityScopeResolver: SecurityScopeResolver
-    private let fileIO: ReaderDocumentIO
+    private let fileIO: DocumentIO
     private let saveLogFormatter: SaveLogFormatter
 
     init(
@@ -24,7 +24,7 @@ final class SourceDraftPersister {
         renderingController: ReaderRenderingController,
         folderWatchDispatcher: FolderWatchDispatcher,
         securityScopeResolver: SecurityScopeResolver,
-        fileIO: ReaderDocumentIO,
+        fileIO: DocumentIO,
         saveLogFormatter: SaveLogFormatter
     ) {
         self.document = document

--- a/minimark/Stores/ReaderSidebarDocumentController.swift
+++ b/minimark/Stores/ReaderSidebarDocumentController.swift
@@ -87,15 +87,15 @@ final class ReaderSidebarDocumentController {
                 ),
                 file: FileDependencies(
                     watcher: FileChangeWatcher(),
-                    io: ReaderDocumentIOService(),
-                    actions: ReaderFileActionService()
+                    io: DocumentIOService(),
+                    actions: FileActionService()
                 ),
                 folderWatch: FolderWatchDependencies(
                     autoOpenPlanner: FolderWatchAutoOpenPlanner(
                         minimumDiffBaselineAge: settingsStore.currentSettings.diffBaselineLookback.timeInterval
                     ),
                     settler: settler,
-                    systemNotifier: ReaderSystemNotifier.shared
+                    systemNotifier: SystemNotifier.shared
                 ),
                 settingsStore: settingsStore,
                 securityScopeResolver: securityScopeResolver
@@ -108,7 +108,7 @@ final class ReaderSidebarDocumentController {
                 folderWatcher: FolderChangeWatcher(),
                 settingsStore: settingsStore,
                 securityScope: SecurityScopedResourceAccess(),
-                systemNotifier: ReaderSystemNotifier.shared,
+                systemNotifier: SystemNotifier.shared,
                 folderWatchAutoOpenPlanner: FolderWatchAutoOpenPlanner(
                     minimumDiffBaselineAge: settingsStore.currentSettings.diffBaselineLookback.timeInterval
                 )

--- a/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
+++ b/minimark/Stores/ReaderSidebarFolderWatchOwnership.swift
@@ -18,7 +18,7 @@ final class FolderWatchController {
     private let folderWatcher: FolderChangeWatching
     private let settingsStore: ReaderSettingsReading & ReaderRecentWriting
     private let securityScope: SecurityScopedResourceAccessing
-    private let systemNotifier: ReaderSystemNotifying
+    private let systemNotifier: SystemNotifying
     private let folderWatchAutoOpenPlanner: FolderWatchAutoOpenPlanning
 
     private var folderSecurityScopeToken: SecurityScopedAccessToken?
@@ -63,7 +63,7 @@ final class FolderWatchController {
         folderWatcher: FolderChangeWatching,
         settingsStore: ReaderSettingsReading & ReaderRecentWriting,
         securityScope: SecurityScopedResourceAccessing,
-        systemNotifier: ReaderSystemNotifying,
+        systemNotifier: SystemNotifying,
         folderWatchAutoOpenPlanner: FolderWatchAutoOpenPlanning
     ) {
         self.folderWatcher = folderWatcher

--- a/minimark/Views/ReaderSettingsView.swift
+++ b/minimark/Views/ReaderSettingsView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 struct ReaderSettingsView: View {
     private var settingsStore: ReaderSettingsStore
-    @ObservedObject private var notificationNotifier: ReaderSystemNotifier
+    @ObservedObject private var notificationNotifier: SystemNotifier
 
     init(
         settingsStore: ReaderSettingsStore,
-        notificationNotifier: ReaderSystemNotifier = .shared
+        notificationNotifier: SystemNotifier = .shared
     ) {
         self.settingsStore = settingsStore
         self.notificationNotifier = notificationNotifier
@@ -243,7 +243,7 @@ private struct SettingsSectionContainer<Content: View>: View {
 }
 
 private struct NotificationStatusCard: View {
-    let status: ReaderNotificationStatus
+    let status: NotificationStatus
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -11,7 +11,7 @@ struct MarkdownObserverApp: App {
         _settingsStore = State(wrappedValue: settingsStore)
         ReaderUITestWindowBootstrapper.shared.configure(settingsStore: settingsStore)
 
-        ReaderSystemNotifier.shared.configure()
+        SystemNotifier.shared.configure()
 
         NSWindow.allowsAutomaticWindowTabbing = false
         applyAppAppearanceIfAvailable(settingsStore.currentSettings.appAppearance)
@@ -66,7 +66,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        ReaderSystemNotifier.shared.refreshNotificationStatus()
+        SystemNotifier.shared.refreshNotificationStatus()
     }
 }
 

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -15,8 +15,8 @@ private func makeTestViewModel(
     )
     let fileDeps = FileDependencies(
         watcher: FileChangeWatcher(),
-        io: ReaderDocumentIOService(),
-        actions: ReaderFileActionService()
+        io: DocumentIOService(),
+        actions: FileActionService()
     )
     let renderingDeps = RenderingDependencies(
         renderer: MarkdownRenderingService(),
@@ -247,8 +247,8 @@ struct ContentAreaViewModelDropRoutingTests {
         )
         let fileDeps = FileDependencies(
             watcher: FileChangeWatcher(),
-            io: ReaderDocumentIOService(),
-            actions: ReaderFileActionService()
+            io: DocumentIOService(),
+            actions: FileActionService()
         )
         let renderingDeps = RenderingDependencies(
             renderer: MarkdownRenderingService(),

--- a/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
+++ b/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
@@ -22,7 +22,7 @@ struct OpenDocumentPathTrackerTests {
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
             file: FileDependencies(
-                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Core/ReaderDocumentControllerTests.swift
+++ b/minimarkTests/Core/ReaderDocumentControllerTests.swift
@@ -6,9 +6,9 @@ import Foundation
 @Suite("ReaderDocumentController")
 struct ReaderDocumentControllerTests {
     private func makeSUT(
-        io: ReaderDocumentIO = ReaderDocumentIOService(),
+        io: DocumentIO = DocumentIOService(),
         watcher: FileChangeWatching = TestFileWatcher(),
-        fileActions: ReaderFileActionHandling = TestReaderFileActions()
+        fileActions: FileActionHandling = TestReaderFileActions()
     ) -> ReaderDocumentController {
         let settings = TestReaderSettingsStore(autoRefreshOnExternalChange: true)
         return ReaderDocumentController(

--- a/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
+++ b/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
@@ -647,7 +647,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierConfigureDoesNotRequestAuthorization() {
         let notificationCenter = TestUserNotificationCenter()
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
 
         notifier.configure()
 
@@ -657,13 +657,13 @@ struct ReaderSettingsAndModelsTests {
 
     @Test @MainActor func readerSystemNotifierConfigureRefreshesNotificationStatus() async {
         let notificationCenter = TestUserNotificationCenter()
-        notificationCenter.currentNotificationSettings = ReaderUserNotificationSettings(
+        notificationCenter.currentNotificationSettings = UserNotificationSettings(
             authorizationStatus: .denied,
             alertSetting: .disabled,
             soundSetting: .disabled,
             notificationCenterSetting: .enabled
         )
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
 
         notifier.configure()
 
@@ -676,7 +676,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierRequestsAuthorizationBeforePostingFirstNotification() throws {
         let notificationCenter = TestUserNotificationCenter()
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
         let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
         let fileURL = watchedFolderURL.appendingPathComponent("roadmap.md")
 
@@ -705,7 +705,7 @@ struct ReaderSettingsAndModelsTests {
     @Test func readerSystemNotifierRoutesNotificationClicksToTargetFocuser() {
         let notificationCenter = TestUserNotificationCenter()
         let focuser = TestNotificationTargetFocuser()
-        let notifier = ReaderSystemNotifier(
+        let notifier = SystemNotifier(
             notificationCenter: notificationCenter,
             notificationTargetFocuser: focuser
         )
@@ -722,13 +722,13 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierSchedulesDelayedTestNotification() throws {
         let notificationCenter = TestUserNotificationCenter()
-        notificationCenter.currentNotificationSettings = ReaderUserNotificationSettings(
+        notificationCenter.currentNotificationSettings = UserNotificationSettings(
             authorizationStatus: .authorized,
             alertSetting: .enabled,
             soundSetting: .disabled,
             notificationCenterSetting: .enabled
         )
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
 
         notifier.sendTestNotification()
 
@@ -741,7 +741,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierPostsAddedNotificationWithCorrectContent() throws {
         let notificationCenter = TestUserNotificationCenter()
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
         let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
         let fileURL = watchedFolderURL.appendingPathComponent("new-file.md")
 
@@ -760,7 +760,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierPostsModifiedNotificationWithCorrectContent() throws {
         let notificationCenter = TestUserNotificationCenter()
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
         let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
         let fileURL = watchedFolderURL.appendingPathComponent("edited.md")
 
@@ -779,7 +779,7 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSystemNotifierPostsDeletedNotificationWithCorrectContent() throws {
         let notificationCenter = TestUserNotificationCenter()
-        let notifier = ReaderSystemNotifier(notificationCenter: notificationCenter)
+        let notifier = SystemNotifier(notificationCenter: notificationCenter)
         let watchedFolderURL = URL(fileURLWithPath: "/tmp/docs", isDirectory: true)
         let fileURL = watchedFolderURL.appendingPathComponent("removed.md")
 

--- a/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
+++ b/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
@@ -175,7 +175,7 @@ struct EditFolderWatchExclusionsTests {
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
                     file: FileDependencies(
-                        watcher: fw, io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                        watcher: fw, io: DocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(
                         autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
+++ b/minimarkTests/Infrastructure/FileRoutingAndWatcherTests.swift
@@ -1201,7 +1201,7 @@ struct FileRoutingAndWatcherTests {
         let workspace = TestWorkspace(
             applicationURLsToReturn: [duplicateReleaseAppURL, textEditAppURL, duplicateDebugAppURL]
         )
-        let service = ReaderFileActionService(workspace: workspace)
+        let service = FileActionService(workspace: workspace)
 
         let applications = try service.registeredApplications(for: markdownFileURL)
 
@@ -1224,7 +1224,7 @@ struct FileRoutingAndWatcherTests {
         )
         let bundle = try #require(Bundle(url: appURL))
         let launchServices = TestLaunchServices()
-        let service = ReaderDefaultMarkdownAssociationService(
+        let service = DefaultMarkdownAssociationService(
             launchServices: launchServices,
             typeResolver: TestMarkdownContentTypeResolver(identifiers: ["net.daringfireball.markdown"]),
             appBundle: bundle
@@ -1254,7 +1254,7 @@ struct FileRoutingAndWatcherTests {
         )
         let bundle = try #require(Bundle(url: appURL))
         let launchServices = TestLaunchServices(registerStatus: -10814)
-        let service = ReaderDefaultMarkdownAssociationService(
+        let service = DefaultMarkdownAssociationService(
             launchServices: launchServices,
             typeResolver: TestMarkdownContentTypeResolver(identifiers: ["net.daringfireball.markdown"]),
             appBundle: bundle

--- a/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
+++ b/minimarkTests/Infrastructure/SystemNotificationEndToEndTests.swift
@@ -18,7 +18,7 @@ import UserNotifications
 struct SystemNotificationEndToEndTests {
 
     @Test func notificationPostedForCreatedFile() async throws {
-        let notifier = ReaderSystemNotifier(
+        let notifier = SystemNotifier(
             notificationCenter: UNUserNotificationCenter.current()
         )
         notifier.configure()
@@ -37,7 +37,7 @@ struct SystemNotificationEndToEndTests {
     }
 
     @Test func notificationPostedForModifiedFile() async throws {
-        let notifier = ReaderSystemNotifier(
+        let notifier = SystemNotifier(
             notificationCenter: UNUserNotificationCenter.current()
         )
         notifier.configure()
@@ -55,7 +55,7 @@ struct SystemNotificationEndToEndTests {
     }
 
     @Test func notificationPostedForDeletedFile() async throws {
-        let notifier = ReaderSystemNotifier(
+        let notifier = SystemNotifier(
             notificationCenter: UNUserNotificationCenter.current()
         )
         notifier.configure()

--- a/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
@@ -43,7 +43,7 @@ struct DocumentCloseCoordinatorTests {
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
             file: FileDependencies(
-                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
+++ b/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
@@ -58,7 +58,7 @@ struct FileOpenPlanExecutorTests {
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
             file: FileDependencies(
-                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -273,7 +273,7 @@ struct ReaderSidebarDocumentControllerTests {
                             renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                         ),
                         file: FileDependencies(
-                            watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                            watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
                         ),
                         folderWatch: FolderWatchDependencies(
                             autoOpenPlanner: FolderWatchAutoOpenPlanner(),
@@ -1269,7 +1269,7 @@ struct ReaderSidebarDocumentControllerTests {
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
                     file: FileDependencies(
-                        watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                        watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(
                         autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Sidebar/SidebarDocumentListTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentListTests.swift
@@ -23,7 +23,7 @@ struct SidebarDocumentListTests {
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
             file: FileDependencies(
-                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -22,7 +22,7 @@ struct SidebarRowStateComputerTests {
                 renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
             ),
             file: FileDependencies(
-                watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
             ),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
+++ b/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
@@ -38,7 +38,7 @@ struct ReaderSidebarGroupingTestHarness {
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
                     file: FileDependencies(
-                        watcher: TestFileWatcher(), io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                        watcher: TestFileWatcher(), io: DocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(
                         autoOpenPlanner: FolderWatchAutoOpenPlanner(),

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -623,8 +623,8 @@ final class TestReaderAutoOpenSettler: ReaderAutoOpenSettling {
     }
 }
 
-final class TestReaderDocumentIO: ReaderDocumentIO {
-    private let realIO = ReaderDocumentIOService()
+final class TestReaderDocumentIO: DocumentIO {
+    private let realIO = DocumentIOService()
 
     func load(at accessibleURL: URL) throws -> (markdown: String, modificationDate: Date) {
         try realIO.load(at: accessibleURL)
@@ -639,7 +639,7 @@ final class TestReaderDocumentIO: ReaderDocumentIO {
     }
 }
 
-final class TestReaderFileActions: ReaderFileActionHandling {
+final class TestReaderFileActions: FileActionHandling {
     func registeredApplications(for fileURL: URL) throws -> [ExternalApplication] {
         []
     }
@@ -668,7 +668,7 @@ final class TestWorkspace: WorkspaceControlling {
     func activateFileViewerSelecting(_ fileURLs: [URL]) {}
 }
 
-final class TestReaderSystemNotifier: ReaderSystemNotifying {
+final class TestReaderSystemNotifier: SystemNotifying {
     struct FileChangeNotification: Equatable {
         let fileURL: URL
         let changeKind: FolderWatchChangeKind
@@ -692,7 +692,7 @@ final class TestReaderSystemNotifier: ReaderSystemNotifying {
     }
 }
 
-final class TestNotificationTargetFocuser: ReaderNotificationTargetFocusing {
+final class TestNotificationTargetFocuser: NotificationTargetFocusing {
     private(set) var focusedTargets: [(fileURL: URL?, watchedFolderURL: URL?)] = []
     var focusResult = true
 
@@ -705,14 +705,14 @@ final class TestNotificationTargetFocuser: ReaderNotificationTargetFocusing {
     }
 }
 
-final class TestUserNotificationCenter: ReaderUserNotificationCentering {
+final class TestUserNotificationCenter: UserNotificationCentering {
     weak var delegate: UNUserNotificationCenterDelegate?
 
     private(set) var requestAuthorizationCallCount = 0
     private(set) var addedRequests: [UNNotificationRequest] = []
     private(set) var recordedEvents: [String] = []
     var authorizationRequestResult = true
-    var currentNotificationSettings = ReaderUserNotificationSettings(
+    var currentNotificationSettings = UserNotificationSettings(
         authorizationStatus: .notDetermined,
         alertSetting: .disabled,
         soundSetting: .disabled,
@@ -726,7 +726,7 @@ final class TestUserNotificationCenter: ReaderUserNotificationCentering {
         recordedEvents.append("requestAuthorization")
         requestAuthorizationCallCount += 1
         if authorizationRequestResult {
-            currentNotificationSettings = ReaderUserNotificationSettings(
+            currentNotificationSettings = UserNotificationSettings(
                 authorizationStatus: .authorized,
                 alertSetting: .enabled,
                 soundSetting: .disabled,
@@ -737,7 +737,7 @@ final class TestUserNotificationCenter: ReaderUserNotificationCentering {
     }
 
     func notificationSettings(
-        completionHandler: @escaping (ReaderUserNotificationSettings) -> Void
+        completionHandler: @escaping (UserNotificationSettings) -> Void
     ) {
         recordedEvents.append("notificationSettings")
         completionHandler(currentNotificationSettings)
@@ -879,7 +879,7 @@ struct ReaderStoreTestFixture {
         let settler = ReaderAutoOpenSettler(settlingInterval: autoOpenSettlingInterval)
         store = ReaderStore(
             rendering: RenderingDependencies(renderer: renderer, differ: differ),
-            file: FileDependencies(watcher: watcher, io: ReaderDocumentIOService(), actions: fileActions),
+            file: FileDependencies(watcher: watcher, io: DocumentIOService(), actions: fileActions),
             folderWatch: FolderWatchDependencies(
                 autoOpenPlanner: FolderWatchAutoOpenPlanner(),
                 settler: settler,
@@ -956,7 +956,7 @@ struct ReaderSidebarControllerTestHarness {
                         renderer: TestMarkdownRenderer(), differ: TestChangedRegionDiffer()
                     ),
                     file: FileDependencies(
-                        watcher: fileWatcher, io: ReaderDocumentIOService(), actions: TestReaderFileActions()
+                        watcher: fileWatcher, io: DocumentIOService(), actions: TestReaderFileActions()
                     ),
                     folderWatch: FolderWatchDependencies(
                         autoOpenPlanner: FolderWatchAutoOpenPlanner(),


### PR DESCRIPTION
Batch 3 of 6 for #355 — renames in `minimark/Services/`.

Re-opened PR after the original #358 was auto-closed when its base branch was deleted during batch 2 merge.

## Types renamed

- `ReaderDocumentIO` / `ReaderDocumentIOService` → `DocumentIO` / `DocumentIOService`
- `ReaderFileActionHandling` / `ReaderFileActionService` → `FileActionHandling` / `FileActionService`
- `ReaderDefaultMarkdownAssociationHandling` / `ReaderDefaultMarkdownAssociationService` → drop `Reader`
- All notification types: `ReaderSystemNotifier`, `ReaderSystemNotifying`, `ReaderUserNotificationSettings` / `Centering`, `ReaderNotificationAuthorizationState`, `ReaderNotificationStatus`, `ReaderNotificationSettingsOpening`, `ReaderSystemNotificationSettingsOpener`, `ReaderNotificationTargetFocusing` / `Coordinator`, plus private helper types — all drop `Reader`

Test-double naming cleanup (e.g. `TestReaderDocumentIO` → `TestDocumentIO`, `TestReaderSystemNotifier` → `TestSystemNotifier`) is addressed in the batch 6 cleanup commit per Copilot's feedback on the original #358.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:minimarkTests` → ** TEST SUCCEEDED **
- [ ] CI green