### PR TITLE
Refactor: drop Reader prefix from Views/ + Commands/ (batch 5 of #355)

### DIFF
--- a/minimark/Commands/AppCommands.swift
+++ b/minimark/Commands/AppCommands.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-struct ReaderCommands: Commands {
+struct AppCommands: Commands {
     var settingsStore: SettingsStore
     let multiFileDisplayMode: MultiFileDisplayMode
 

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
     }
 
     private var topBar: some View {
-        ReaderTopBar(
+        TopBar(
             document: viewModel.document,
             sourceEditing: viewModel.sourceEditing,
             statusBarTimestamp: viewModel.statusBarTimestamp,

--- a/minimark/Models/FavoriteWorkspaceState.swift
+++ b/minimark/Models/FavoriteWorkspaceState.swift
@@ -56,7 +56,7 @@ nonisolated struct FavoriteWorkspaceState: Equatable, Hashable, Codable, Sendabl
     }
 
     static func from(
-        settings: ReaderSettings,
+        settings: Settings,
         pinnedGroupIDs: Set<String>,
         collapsedGroupIDs: Set<String>,
         sidebarWidth: CGFloat

--- a/minimark/Models/SidebarGrouping.swift
+++ b/minimark/Models/SidebarGrouping.swift
@@ -96,9 +96,9 @@ enum SidebarGrouping: Equatable {
     ) -> [DocumentIndicatorState] {
         let states = documents.map { document in
             DocumentIndicatorState(
-                hasUnacknowledgedExternalChange: document.readerStore.externalChange.hasUnacknowledgedExternalChange,
-                isCurrentFileMissing: document.readerStore.document.isCurrentFileMissing,
-                unacknowledgedExternalChangeKind: document.readerStore.externalChange.unacknowledgedExternalChangeKind
+                hasUnacknowledgedExternalChange: document.documentStore.externalChange.hasUnacknowledgedExternalChange,
+                isCurrentFileMissing: document.documentStore.document.isCurrentFileMissing,
+                unacknowledgedExternalChangeKind: document.documentStore.externalChange.unacknowledgedExternalChangeKind
             )
         }
 
@@ -143,16 +143,16 @@ enum SidebarGrouping: Equatable {
     private static func directoryURL(
         for document: SidebarDocumentController.Document
     ) -> URL? {
-        document.readerStore.document.fileURL?.deletingLastPathComponent()
+        document.documentStore.document.fileURL?.deletingLastPathComponent()
     }
 
     private static func newestModificationDate(
         for documents: [SidebarDocumentController.Document]
     ) -> Date? {
         documents.compactMap { document in
-            document.readerStore.document.fileLastModifiedAt
-                ?? document.readerStore.externalChange.lastExternalChangeAt
-                ?? document.readerStore.renderingController.lastRefreshAt
+            document.documentStore.document.fileLastModifiedAt
+                ?? document.documentStore.externalChange.lastExternalChangeAt
+                ?? document.documentStore.renderingController.lastRefreshAt
         }.max()
     }
 

--- a/minimark/Services/FileOpenCoordinator.swift
+++ b/minimark/Services/FileOpenCoordinator.swift
@@ -173,7 +173,7 @@ final class FileOpenCoordinator {
 
     private var canReuseEmptySlot: Bool {
         guard let selectedDocument = controller.selectedDocument else { return false }
-        return selectedDocument.readerStore.document.fileURL == nil && controller.documents.count == 1
+        return selectedDocument.documentStore.document.fileURL == nil && controller.documents.count == 1
     }
 
     private nonisolated func loadMode(

--- a/minimark/Services/MarkdownRenderingService.swift
+++ b/minimark/Services/MarkdownRenderingService.swift
@@ -25,7 +25,7 @@ struct MarkdownRenderingService: MarkdownRendering {
     init(
         cssFactory: CSSFactory = CSSFactory(),
         payloadEncoder: MarkdownRuntimePayloadEncoding = JSONBase64MarkdownRuntimePayloadEncoder(),
-        runtimeAssetResolver: RuntimeAssetResolving = BundledReaderRuntimeAssetResolver()
+        runtimeAssetResolver: RuntimeAssetResolving = BundledRuntimeAssetResolver()
     ) {
         self.cssFactory = cssFactory
         self.payloadEncoder = payloadEncoder

--- a/minimark/Stores/DocumentCloseCoordinator.swift
+++ b/minimark/Stores/DocumentCloseCoordinator.swift
@@ -41,7 +41,7 @@ final class DocumentCloseCoordinator {
             let replacement = delegate.makeDocument()
             documentList.replaceAll(with: [replacement])
             if let storeConfigurator = delegate.storeConfigurator {
-                storeConfigurator(replacement.readerStore)
+                storeConfigurator(replacement.documentStore)
             }
             delegate.selectedDocumentID = replacement.id
             synchronizeAndRebuild()
@@ -110,7 +110,7 @@ final class DocumentCloseCoordinator {
         guard let delegate else { return }
         let replacement = delegate.makeDocument()
         if let storeConfigurator = delegate.storeConfigurator {
-            storeConfigurator(replacement.readerStore)
+            storeConfigurator(replacement.documentStore)
         }
 
         documentList.replaceAll(with: [replacement])

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -98,7 +98,7 @@ final class FavoriteWorkspaceController {
     // MARK: - Open Document URLs
 
     func openDocumentFileURLs() -> [URL] {
-        sidebarDocumentController?.documents.compactMap { $0.readerStore.document.fileURL } ?? []
+        sidebarDocumentController?.documents.compactMap { $0.documentStore.document.fileURL } ?? []
     }
 
     // MARK: - Persistence

--- a/minimark/Stores/FileOpenPlanExecutor.swift
+++ b/minimark/Stores/FileOpenPlanExecutor.swift
@@ -5,7 +5,7 @@ protocol FileOpenPlanExecutorDelegate: AnyObject {
     typealias Document = SidebarDocumentController.Document
 
     var selectedDocumentID: UUID { get set }
-    var selectedReaderStore: DocumentStore { get }
+    var selectedDocumentStore: DocumentStore { get }
     var storeConfigurator: ((DocumentStore) -> Void)? { get }
     func makeDocument() -> Document
     func selectDocument(_ documentID: UUID?)
@@ -52,8 +52,8 @@ final class FileOpenPlanExecutor {
             let fileURL = assignment.fileURL
 
             if let existingDocument = documentList.document(for: fileURL) {
-                if existingDocument.readerStore.document.isDeferredDocument, assignment.loadMode == .loadFully {
-                    let store = existingDocument.readerStore
+                if existingDocument.documentStore.document.isDeferredDocument, assignment.loadMode == .loadFully {
+                    let store = existingDocument.documentStore
                     let effectiveSession = delegate.resolvedFolderWatchSession(
                         for: fileURL,
                         requestedSession: plan.folderWatchSession
@@ -86,7 +86,7 @@ final class FileOpenPlanExecutor {
                 } else {
                     let document = delegate.makeDocument()
                     if let storeConfigurator = delegate.storeConfigurator {
-                        storeConfigurator(document.readerStore)
+                        storeConfigurator(document.documentStore)
                     }
                     targetDocument = document
                     shouldAppendDocument = true
@@ -95,7 +95,7 @@ final class FileOpenPlanExecutor {
             case .createNew:
                 let document = delegate.makeDocument()
                 if let storeConfigurator = delegate.storeConfigurator {
-                    storeConfigurator(document.readerStore)
+                    storeConfigurator(document.documentStore)
                 }
                 targetDocument = document
                 shouldAppendDocument = true
@@ -103,13 +103,13 @@ final class FileOpenPlanExecutor {
 
             switch assignment.loadMode {
             case .deferOnly:
-                targetDocument.readerStore.opener.deferFile(
+                targetDocument.documentStore.opener.deferFile(
                     at: fileURL,
                     origin: plan.origin,
                     folderWatchSession: effectiveFolderWatchSession
                 )
             case .loadFully:
-                targetDocument.readerStore.opener.open(
+                targetDocument.documentStore.opener.open(
                     at: fileURL,
                     origin: plan.origin,
                     folderWatchSession: effectiveFolderWatchSession,
@@ -117,7 +117,7 @@ final class FileOpenPlanExecutor {
                 )
             }
 
-            guard targetDocument.readerStore.document.fileURL != nil else {
+            guard targetDocument.documentStore.document.fileURL != nil else {
                 continue
             }
 
@@ -139,7 +139,7 @@ final class FileOpenPlanExecutor {
 
         // In screenshot mode, override selection to a specific document by filename
         if let targetFile = ProcessInfo.processInfo.environment["MINIMARK_SCREENSHOT_SELECT_FILE"],
-           let match = documentList.documents.first(where: { $0.readerStore.document.fileURL?.lastPathComponent == targetFile }) {
+           let match = documentList.documents.first(where: { $0.documentStore.document.fileURL?.lastPathComponent == targetFile }) {
             delegate.selectedDocumentID = match.id
         }
 
@@ -149,9 +149,9 @@ final class FileOpenPlanExecutor {
 
     func selectDocumentWithNewestModificationDate() {
         let newest = documentList.documents
-            .filter { $0.readerStore.document.fileURL != nil }
+            .filter { $0.documentStore.document.fileURL != nil }
             .max(by: {
-                ($0.readerStore.document.fileLastModifiedAt ?? .distantPast) < ($1.readerStore.document.fileLastModifiedAt ?? .distantPast)
+                ($0.documentStore.document.fileLastModifiedAt ?? .distantPast) < ($1.documentStore.document.fileLastModifiedAt ?? .distantPast)
             })
         if let newest {
             delegate?.selectDocument(newest.id)
@@ -162,13 +162,13 @@ final class FileOpenPlanExecutor {
         count: Int = FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount
     ) {
         let deferredDocs = documentList.documents
-            .filter { $0.readerStore.document.isDeferredDocument }
+            .filter { $0.documentStore.document.isDeferredDocument }
             .sorted {
-                ($0.readerStore.document.fileLastModifiedAt ?? .distantPast) > ($1.readerStore.document.fileLastModifiedAt ?? .distantPast)
+                ($0.documentStore.document.fileLastModifiedAt ?? .distantPast) > ($1.documentStore.document.fileLastModifiedAt ?? .distantPast)
             }
 
         for document in deferredDocs.prefix(count) {
-            document.readerStore.opener.materializeDeferred()
+            document.documentStore.opener.materializeDeferred()
         }
 
         selectDocumentWithNewestModificationDate()
@@ -184,8 +184,8 @@ final class FileOpenPlanExecutor {
         case .deferThenMaterializeNewest(let count):
             materializeNewestDeferredDocuments(count: count)
         case .deferThenMaterializeSelected:
-            if delegate.selectedReaderStore.document.isDeferredDocument {
-                let store = delegate.selectedReaderStore
+            if delegate.selectedDocumentStore.document.isDeferredDocument {
+                let store = delegate.selectedDocumentStore
                 scheduleLoadWithOverlay(on: store) {
                     store.opener.materializeDeferred()
                 }

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -165,7 +165,7 @@ final class FolderWatchFlowController {
                 performInitialAutoOpen: performInitialAutoOpen
             )
         } catch {
-            sidebarDocumentController.selectedReaderStore.document.handle(error)
+            sidebarDocumentController.selectedDocumentStore.document.handle(error)
         }
 
         return didDeactivateFavorite
@@ -220,7 +220,7 @@ final class FolderWatchFlowController {
         do {
             try sidebarDocumentController.folderWatchCoordinator.updateFolderWatchExcludedSubdirectories(newExcludedPaths)
         } catch {
-            sidebarDocumentController.selectedReaderStore.document.handle(error)
+            sidebarDocumentController.selectedDocumentStore.document.handle(error)
             return false
         }
 
@@ -256,14 +256,14 @@ final class FolderWatchFlowController {
         }
 
         let wasSelectedExcluded = sidebarDocumentController.selectedDocument.flatMap { doc in
-            doc.readerStore.document.fileURL.map { url in
+            doc.documentStore.document.fileURL.map { url in
                 let normalized = FileRouting.normalizedFileURL(url).path
                 return excludedPrefixes.contains { normalized.hasPrefix($0) }
             }
         } ?? false
 
         let documentsToClose = sidebarDocumentController.documents.filter { doc in
-            guard let fileURL = doc.readerStore.document.fileURL else { return false }
+            guard let fileURL = doc.documentStore.document.fileURL else { return false }
             let normalized = FileRouting.normalizedFileURL(fileURL).path
             return excludedPrefixes.contains { normalized.hasPrefix($0) }
         }
@@ -293,7 +293,7 @@ final class FolderWatchFlowController {
 
             let alreadyOpenPaths = Set(
                 sidebarDocumentController.documents.compactMap {
-                    $0.readerStore.document.fileURL.map { FileRouting.normalizedFileURL($0).path }
+                    $0.documentStore.document.fileURL.map { FileRouting.normalizedFileURL($0).path }
                 }
             )
 

--- a/minimark/Stores/FolderWatchSessionCoordinator.swift
+++ b/minimark/Stores/FolderWatchSessionCoordinator.swift
@@ -6,7 +6,7 @@ protocol FolderWatchSessionCoordinatorDelegate: AnyObject {
     typealias Document = SidebarDocumentController.Document
 
     var documents: [Document] { get }
-    var selectedReaderStore: DocumentStore { get }
+    var selectedDocumentStore: DocumentStore { get }
     func document(for fileURL: URL) -> Document?
     func selectDocumentWithNewestModificationDate()
     func handleFolderWatchOpenRequest(_ request: FileOpenRequest)
@@ -191,13 +191,13 @@ final class FolderWatchSessionCoordinator {
 
 extension FolderWatchSessionCoordinator: FolderWatchControllerDelegate {
     func folderWatchControllerCurrentDocumentFileURL(_ controller: FolderWatchController) -> URL? {
-        delegate?.selectedReaderStore.document.fileURL
+        delegate?.selectedDocumentStore.document.fileURL
     }
 
     func folderWatchControllerOpenDocumentFileURLs(_ controller: FolderWatchController) -> [URL] {
         guard let delegate else { return [] }
         return delegate.documents.compactMap { document in
-            document.readerStore.document.isDeferredDocument ? nil : document.readerStore.document.fileURL
+            document.documentStore.document.isDeferredDocument ? nil : document.documentStore.document.fileURL
         }
     }
 
@@ -233,7 +233,7 @@ extension FolderWatchSessionCoordinator: FolderWatchControllerDelegate {
         guard let delegate else { return }
         for url in urls {
             if let doc = delegate.document(for: url) {
-                doc.readerStore.opener.markAsLiveAutoOpened()
+                doc.documentStore.opener.markAsLiveAutoOpened()
             }
         }
     }

--- a/minimark/Stores/Settings/PreferencesStore.swift
+++ b/minimark/Stores/Settings/PreferencesStore.swift
@@ -70,7 +70,7 @@ nonisolated struct ReaderPreferencesSlice: Equatable, Sendable {
     }
 
     func resetFontSize() {
-        updateBaseFontSize(ReaderSettings.default.baseFontSize)
+        updateBaseFontSize(Settings.default.baseFontSize)
     }
 
     func updateNotificationsEnabled(_ isEnabled: Bool) {

--- a/minimark/Stores/SettingsStore.swift
+++ b/minimark/Stores/SettingsStore.swift
@@ -3,7 +3,7 @@ import Combine
 import Observation
 import OSLog
 
-nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
+nonisolated struct Settings: Equatable, Codable, Sendable {
     var appAppearance: AppAppearance
     var readerTheme: ThemeKind
     var syntaxTheme: SyntaxThemeKind
@@ -72,7 +72,7 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
         case dismissedHints
     }
 
-    static let `default` = ReaderSettings(
+    static let `default` = Settings(
         appAppearance: .system,
         readerTheme: .blackOnWhite,
         syntaxTheme: .monokai,
@@ -137,8 +137,8 @@ nonisolated struct ReaderSettings: Equatable, Codable, Sendable {
 }
 
 @MainActor protocol SettingsReading: AnyObject {
-    var settingsPublisher: AnyPublisher<ReaderSettings, Never> { get }
-    var currentSettings: ReaderSettings { get }
+    var settingsPublisher: AnyPublisher<Settings, Never> { get }
+    var currentSettings: Settings { get }
     func isHintDismissed(_ hint: FirstUseHint) -> Bool
 }
 
@@ -229,11 +229,11 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
     typealias BookmarkResolver = (Data) throws -> BookmarkResolution
     typealias BookmarkCreator = (URL) throws -> Data
 
-    var settingsPublisher: AnyPublisher<ReaderSettings, Never> {
+    var settingsPublisher: AnyPublisher<Settings, Never> {
         subject.eraseToAnyPublisher()
     }
 
-    private(set) var currentSettings: ReaderSettings
+    private(set) var currentSettings: Settings
 
     let preferences: PreferencesStore
     let favorites: FavoriteWatchedFoldersStore
@@ -243,7 +243,7 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
 
     @ObservationIgnored private let storage: SettingsKeyValueStoring
     @ObservationIgnored private let storageKey: String
-    @ObservationIgnored private let subject: CurrentValueSubject<ReaderSettings, Never>
+    @ObservationIgnored private let subject: CurrentValueSubject<Settings, Never>
     @ObservationIgnored private let encoder = JSONEncoder()
     @ObservationIgnored private let decoder = JSONDecoder()
     @ObservationIgnored private let minimumPersistInterval: TimeInterval
@@ -276,9 +276,9 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
         self.storageKey = storageKey
         self.minimumPersistInterval = max(0, minimumPersistInterval)
 
-        let initialSettings: ReaderSettings
+        let initialSettings: Settings
         if let data = storage.data(forKey: storageKey),
-           let decoded = try? decoder.decode(ReaderSettings.self, from: data) {
+           let decoded = try? decoder.decode(Settings.self, from: data) {
             initialSettings = decoded
         } else {
             initialSettings = .default
@@ -345,9 +345,9 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
         }
     }
 
-    private func reassembleSettings() -> ReaderSettings {
+    private func reassembleSettings() -> Settings {
         let prefs = preferences.currentPreferences
-        return ReaderSettings(
+        return Settings(
             appAppearance: prefs.appAppearance,
             readerTheme: prefs.readerTheme,
             syntaxTheme: prefs.syntaxTheme,

--- a/minimark/Stores/SidebarDocumentController.swift
+++ b/minimark/Stores/SidebarDocumentController.swift
@@ -6,7 +6,7 @@ import Observation
 final class SidebarDocumentController {
     struct Document: Identifiable, Equatable {
         let id: UUID
-        let readerStore: DocumentStore
+        let documentStore: DocumentStore
         var normalizedFileURL: URL?
 
         static func == (lhs: Document, rhs: Document) -> Bool {
@@ -32,7 +32,7 @@ final class SidebarDocumentController {
 
     // MARK: - Dependencies
 
-    private let makeReaderStore: () -> DocumentStore
+    private let makeDocumentStore: () -> DocumentStore
     @ObservationIgnored private(set) var storeConfigurator: ((DocumentStore) -> Void)?
     @ObservationIgnored lazy var fileOpenCoordinator = FileOpenCoordinator(controller: self)
 
@@ -63,10 +63,10 @@ final class SidebarDocumentController {
 
     init(
         settingsStore: SettingsStore,
-        makeReaderStore: (() -> DocumentStore)? = nil,
+        makeDocumentStore: (() -> DocumentStore)? = nil,
         makeFolderWatchController: (() -> FolderWatchController)? = nil
     ) {
-        let resolvedMakeReaderStore = makeReaderStore ?? {
+        let resolvedMakeDocumentStore = makeDocumentStore ?? {
             let settler = AutoOpenSettler(settlingInterval: 1.0)
             let securityScopeResolver = SecurityScopeResolver(
                 securityScope: SecurityScopedResourceAccess(),
@@ -102,7 +102,7 @@ final class SidebarDocumentController {
             )
             return store
         }
-        self.makeReaderStore = resolvedMakeReaderStore
+        self.makeDocumentStore = resolvedMakeDocumentStore
         let resolvedMakeFolderWatchController = makeFolderWatchController ?? {
             FolderWatchController(
                 folderWatcher: FolderChangeWatcher(),
@@ -118,7 +118,7 @@ final class SidebarDocumentController {
             makeFolderWatchController: resolvedMakeFolderWatchController
         )
 
-        let initialDocument = Document(id: UUID(), readerStore: resolvedMakeReaderStore(), normalizedFileURL: nil)
+        let initialDocument = Document(id: UUID(), documentStore: resolvedMakeDocumentStore(), normalizedFileURL: nil)
         documentList = SidebarDocumentList(initialDocument: initialDocument)
         fileOpenPlanExecutor = FileOpenPlanExecutor(
             documentList: documentList,
@@ -131,9 +131,9 @@ final class SidebarDocumentController {
             rowStateComputer: rowStateComputer
         )
         selectedDocumentID = initialDocument.id
-        selectedWindowTitle = initialDocument.readerStore.document.windowTitle
-        selectedFileURL = initialDocument.readerStore.document.fileURL
-        selectedHasUnacknowledgedExternalChange = initialDocument.readerStore.externalChange.hasUnacknowledgedExternalChange
+        selectedWindowTitle = initialDocument.documentStore.document.windowTitle
+        selectedFileURL = initialDocument.documentStore.document.fileURL
+        selectedHasUnacknowledgedExternalChange = initialDocument.documentStore.externalChange.hasUnacknowledgedExternalChange
         rowStateComputer.rebuildAllRowStates(from: documentList.documents)
         folderWatchCoordinator.delegate = self
         fileOpenPlanExecutor.delegate = self
@@ -146,14 +146,14 @@ final class SidebarDocumentController {
         documents.first(where: { $0.id == selectedDocumentID })
     }
 
-    var selectedReaderStore: DocumentStore {
-        selectedDocument?.readerStore ?? documents[0].readerStore
+    var selectedDocumentStore: DocumentStore {
+        selectedDocument?.documentStore ?? documents[0].documentStore
     }
 
     func setStoreConfigurator(_ configurator: @escaping (DocumentStore) -> Void) {
         storeConfigurator = configurator
         for document in documents {
-            configurator(document.readerStore)
+            configurator(document.documentStore)
         }
     }
 
@@ -172,7 +172,7 @@ final class SidebarDocumentController {
             // deferred — in that case we must materialize (see #345). Avoid
             // reassigning `selectedDocumentID` so Observation doesn't fire for a
             // ready-state reselect.
-            let store = selectedReaderStore
+            let store = selectedDocumentStore
             guard store.document.isDeferredDocument else { return }
             scheduleLoadWithOverlay(on: store) {
                 store.opener.materializeDeferred()
@@ -181,7 +181,7 @@ final class SidebarDocumentController {
         }
 
         selectedDocumentID = documentID
-        let store = selectedReaderStore
+        let store = selectedDocumentStore
 
         if store.document.isDeferredDocument {
             scheduleLoadWithOverlay(on: store) {
@@ -241,21 +241,21 @@ final class SidebarDocumentController {
     // MARK: - Document actions
 
     func openDocumentsInApplication(_ application: ExternalApplication?, documentIDs: Set<UUID>) {
-        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.readerStore.document.fileURL != nil {
-            tab.readerStore.document.openInApplication(application)
+        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.documentStore.document.fileURL != nil {
+            tab.documentStore.document.openInApplication(application)
         }
     }
 
     func revealDocumentsInFinder(_ documentIDs: Set<UUID>) {
-        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.readerStore.document.fileURL != nil {
-            tab.readerStore.document.revealInFinder()
+        for tab in documentList.orderedDocuments(matching: documentIDs) where tab.documentStore.document.fileURL != nil {
+            tab.documentStore.document.revealInFinder()
         }
     }
 
     // MARK: - Internal helpers
 
     func makeDocument() -> Document {
-        Document(id: UUID(), readerStore: makeReaderStore(), normalizedFileURL: nil)
+        Document(id: UUID(), documentStore: makeDocumentStore(), normalizedFileURL: nil)
     }
 
     private func scheduleLoadWithOverlay(on store: DocumentStore, load: @escaping @MainActor () -> Void) {
@@ -268,7 +268,7 @@ final class SidebarDocumentController {
     }
 
     func bindSelectedStore() {
-        let store = selectedReaderStore
+        let store = selectedDocumentStore
         selectedWindowTitle = store.document.windowTitle
         selectedFileURL = store.document.fileURL
         selectedHasUnacknowledgedExternalChange = store.externalChange.hasUnacknowledgedExternalChange

--- a/minimark/Stores/SidebarGroupStateController.swift
+++ b/minimark/Stores/SidebarGroupStateController.swift
@@ -179,10 +179,10 @@ final class SidebarGroupStateController {
     ) {
         let sortedDocuments = fileSortMode.sorted(documents) { document in
             ReaderSidebarSortDescriptor(
-                displayName: document.readerStore.document.fileDisplayName,
-                lastChangedAt: document.readerStore.document.fileLastModifiedAt
-                    ?? document.readerStore.externalChange.lastExternalChangeAt
-                    ?? document.readerStore.renderingController.lastRefreshAt
+                displayName: document.documentStore.document.fileDisplayName,
+                lastChangedAt: document.documentStore.document.fileLastModifiedAt
+                    ?? document.documentStore.externalChange.lastExternalChangeAt
+                    ?? document.documentStore.renderingController.lastRefreshAt
             )
         }
 
@@ -214,7 +214,7 @@ final class SidebarGroupStateController {
 
     private func rebuildGroupIndicatorStates() {
         let grouped = Dictionary(grouping: documents) { document in
-            document.readerStore.document.fileURL?.deletingLastPathComponent()
+            document.documentStore.document.fileURL?.deletingLastPathComponent()
                 .path(percentEncoded: false) ?? ""
         }
         var result: [String: [DocumentIndicatorState]] = [:]
@@ -236,7 +236,7 @@ final class SidebarGroupStateController {
 
     private func pruneStaleGroupIDs() {
         let activeGroupIDs = Set(documents.compactMap { document in
-            document.readerStore.document.fileURL?.deletingLastPathComponent()
+            document.documentStore.document.fileURL?.deletingLastPathComponent()
                 .path(percentEncoded: false)
         })
         collapsedGroupIDs.formIntersection(activeGroupIDs)

--- a/minimark/Stores/SidebarObservationManager.swift
+++ b/minimark/Stores/SidebarObservationManager.swift
@@ -37,11 +37,11 @@ final class SidebarObservationManager {
 
         for document in documents where documentObservationTasks[document.id] == nil {
             let documentID = document.id
-            document.readerStore.externalChange.onStateChanged = {
+            document.documentStore.externalChange.onStateChanged = {
                 onStoreChanged(documentID)
             }
             documentObservationTasks[document.id] = Task { [weak self] in
-                let store = document.readerStore
+                let store = document.documentStore
                 defer { store.externalChange.onStateChanged = nil }
                 while !Task.isCancelled {
                     let cancelled = await Self.awaitObservationChange {

--- a/minimark/Stores/SidebarRowStateComputer.swift
+++ b/minimark/Stores/SidebarRowStateComputer.swift
@@ -15,7 +15,7 @@ final class SidebarRowStateComputer {
         var states: [UUID: SidebarRowState] = [:]
         for document in documents {
             let previousIndicatorState = rowStates[document.id]?.indicatorState
-            let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
+            let currentIndicatorState = deriveIndicatorState(from: document.documentStore)
             if let previousIndicatorState,
                previousIndicatorState != currentIndicatorState,
                currentIndicatorState.showsIndicator {
@@ -33,7 +33,7 @@ final class SidebarRowStateComputer {
     func updateRowStateIfNeeded(for documentID: UUID, in documents: [Document]) {
         guard let document = documents.first(where: { $0.id == documentID }) else { return }
         let previousIndicatorState = rowStates[documentID]?.indicatorState
-        let currentIndicatorState = deriveIndicatorState(from: document.readerStore)
+        let currentIndicatorState = deriveIndicatorState(from: document.documentStore)
         if let previousIndicatorState,
            previousIndicatorState != currentIndicatorState,
            currentIndicatorState.showsIndicator {
@@ -48,7 +48,7 @@ final class SidebarRowStateComputer {
     }
 
     func deriveRowState(from document: Document) -> SidebarRowState {
-        let store = document.readerStore
+        let store = document.documentStore
         let indicatorState = deriveIndicatorState(from: store)
         return SidebarRowState(
             id: document.id,

--- a/minimark/Support/BundledAssets.swift
+++ b/minimark/Support/BundledAssets.swift
@@ -15,7 +15,7 @@ protocol RuntimeAssetResolving {
     func requiredRuntimeAssets() throws -> RuntimeAssets
 }
 
-struct BundledReaderRuntimeAssetResolver: RuntimeAssetResolving {
+struct BundledRuntimeAssetResolver: RuntimeAssetResolving {
     func requiredRuntimeAssets() throws -> RuntimeAssets {
         try BundledAssets.requiredRuntimeAssets()
     }

--- a/minimark/Support/HostedWindowController.swift
+++ b/minimark/Support/HostedWindowController.swift
@@ -5,7 +5,7 @@ import SwiftUI
 final class HostedWindowController: NSWindowController {
     init(settingsStore: SettingsStore) {
         let hostingController = NSHostingController(
-            rootView: ReaderWindowRootView(
+            rootView: WindowRootView(
                 seed: nil,
                 settingsStore: settingsStore,
                 multiFileDisplayMode: settingsStore.currentSettings.multiFileDisplayMode

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -24,7 +24,7 @@ enum MarkdownSourceHTMLRenderer {
         let isDark: Bool
     }
 
-    static func makeHTMLDocument(markdown: String, settings: ReaderSettings, isEditable: Bool) -> String {
+    static func makeHTMLDocument(markdown: String, settings: Settings, isEditable: Bool) -> String {
         let theme = Theme.theme(for: settings.readerTheme)
         let baseCSS = theme.cssVariables(baseFontSize: settings.baseFontSize)
         let codeMirrorScriptPath = BundledAssets.availableCodeMirrorSourceViewScriptPath()
@@ -257,7 +257,7 @@ enum MarkdownSourceHTMLRenderer {
     private static func makePayloadBase64(
         markdown: String,
         theme: Theme,
-        settings: ReaderSettings,
+        settings: Settings,
         isEditable: Bool
     ) -> String {
         let payload = Payload(

--- a/minimark/Support/WindowTitleSupport.swift
+++ b/minimark/Support/WindowTitleSupport.swift
@@ -34,7 +34,7 @@ enum DocumentIndicatorState: Equatable, Sendable {
         self != .none
     }
 
-    func color(for settings: ReaderSettings, colorScheme: ColorScheme) -> Color {
+    func color(for settings: Settings, colorScheme: ColorScheme) -> Color {
         switch self {
         case .deletedExternalChange:
             return Color(nsColor: .systemRed)

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -273,7 +273,7 @@ final class ContentAreaViewModel {
         )
     }
 
-    func dispatchTopBarAction(_ action: ReaderTopBarAction) {
+    func dispatchTopBarAction(_ action: TopBarAction) {
         switch action {
         case .openFiles(let urls):
             handlePickedFileURLs(urls)

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// controller, settings store, and appearance controller are tracked only for this view's
 /// body, not for the root or sidebar workspace view.
 struct ContentViewAdapter: View {
-    let readerStore: DocumentStore
+    let documentStore: DocumentStore
     let sidebarDocumentController: SidebarDocumentController
     let settingsStore: SettingsStore
     let appearanceController: WindowAppearanceController
@@ -43,7 +43,7 @@ struct ContentViewAdapter: View {
         )
 
         ContentAreaHost(
-            readerStore: readerStore,
+            documentStore: documentStore,
             settingsStore: settingsStore,
             folderWatchState: folderWatchState,
             onAction: onAction,
@@ -55,7 +55,7 @@ struct ContentViewAdapter: View {
         // Remount the host (and its @State viewModel) when the selected
         // DocumentStore changes; otherwise SwiftUI preserves @State across
         // document swaps and the VM keeps the prior store's controllers.
-        .id(ObjectIdentifier(readerStore))
+        .id(ObjectIdentifier(documentStore))
     }
 }
 
@@ -63,7 +63,7 @@ struct ContentViewAdapter: View {
 /// across host-body re-evaluations. Inputs that change per parent eval (`folderWatchState`,
 /// `onAction`) are pushed into the VM via `applyHostInputs` on each body.
 private struct ContentAreaHost: View {
-    let readerStore: DocumentStore
+    let documentStore: DocumentStore
     let settingsStore: SettingsStore
     let folderWatchState: ContentViewFolderWatchState
     let onAction: (ContentViewAction) -> Void
@@ -76,7 +76,7 @@ private struct ContentAreaHost: View {
     @State private var viewModel: ContentAreaViewModel
 
     init(
-        readerStore: DocumentStore,
+        documentStore: DocumentStore,
         settingsStore: SettingsStore,
         folderWatchState: ContentViewFolderWatchState,
         onAction: @escaping (ContentViewAction) -> Void,
@@ -85,7 +85,7 @@ private struct ContentAreaHost: View {
         pendingFolderWatchScope: Binding<FolderWatchScope>,
         pendingFolderWatchExcludedSubdirectoryPaths: Binding<[String]>
     ) {
-        self.readerStore = readerStore
+        self.documentStore = documentStore
         self.settingsStore = settingsStore
         self.folderWatchState = folderWatchState
         self.onAction = onAction
@@ -94,11 +94,11 @@ private struct ContentAreaHost: View {
         self._pendingFolderWatchScope = pendingFolderWatchScope
         self._pendingFolderWatchExcludedSubdirectoryPaths = pendingFolderWatchExcludedSubdirectoryPaths
         _viewModel = State(wrappedValue: ContentAreaViewModel(
-            document: readerStore.document,
-            rendering: readerStore.renderingController,
-            sourceEditing: readerStore.sourceEditingController,
-            externalChange: readerStore.externalChange,
-            toc: readerStore.toc,
+            document: documentStore.document,
+            rendering: documentStore.renderingController,
+            sourceEditing: documentStore.sourceEditingController,
+            externalChange: documentStore.externalChange,
+            toc: documentStore.toc,
             settingsStore: settingsStore,
             folderWatchState: folderWatchState,
             surfaceViewModel: DocumentSurfaceViewModel(),

--- a/minimark/Views/Content/DocumentSurfaceViewModel.swift
+++ b/minimark/Views/Content/DocumentSurfaceViewModel.swift
@@ -74,7 +74,7 @@ final class DocumentSurfaceViewModel {
 
     func refreshSourceHTML(
         markdown: String,
-        settings: ReaderSettings,
+        settings: Settings,
         isEditable: Bool
     ) {
         sourceHTMLCache.refreshIfNeeded(

--- a/minimark/Views/Content/OverlayLayoutModel.swift
+++ b/minimark/Views/Content/OverlayLayoutModel.swift
@@ -5,9 +5,9 @@ struct OverlayLayoutModel: Equatable, Sendable {
     let isStatusBannerVisible: Bool
 
     var topInset: CGFloat {
-        var height = ReaderTopBarMetrics.mainBarHeight
+        var height = TopBarMetrics.mainBarHeight
         if isSourceEditing {
-            height += ReaderTopBarMetrics.sourceEditingBarHeight
+            height += TopBarMetrics.sourceEditingBarHeight
         }
         return height
     }

--- a/minimark/Views/Content/ReaderTopBarComponents.swift
+++ b/minimark/Views/Content/ReaderTopBarComponents.swift
@@ -323,7 +323,7 @@ struct BreadcrumbTimestampLine: View {
             case let .updated(d), let .lastModified(d):
                 date = d
             }
-            let relative = ReaderStatusFormatting.relativeText(for: date, relativeTo: now)
+            let relative = StatusFormatting.relativeText(for: date, relativeTo: now)
             parts += " \u{00B7} \(relative)"
         }
         return parts

--- a/minimark/Views/Content/SourceHTMLDocumentCache.swift
+++ b/minimark/Views/Content/SourceHTMLDocumentCache.swift
@@ -3,14 +3,14 @@ import Foundation
 struct SourceHTMLDocumentCache {
     private struct Inputs: Equatable {
         let markdown: String
-        let settings: ReaderSettings
+        let settings: Settings
         let isEditable: Bool
     }
 
     private var lastInputs: Inputs?
     private(set) var document: String = ""
 
-    mutating func refreshIfNeeded(markdown: String, settings: ReaderSettings, isEditable: Bool) {
+    mutating func refreshIfNeeded(markdown: String, settings: Settings, isEditable: Bool) {
         let inputs = Inputs(markdown: markdown, settings: settings, isEditable: isEditable)
         guard lastInputs != inputs else { return }
         lastInputs = inputs

--- a/minimark/Views/Content/StatusFormatting.swift
+++ b/minimark/Views/Content/StatusFormatting.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ReaderStatusFormatting {
+enum StatusFormatting {
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .short

--- a/minimark/Views/Content/TopBar.swift
+++ b/minimark/Views/Content/TopBar.swift
@@ -24,12 +24,12 @@ struct PointingHandCursor: ViewModifier {
     }
 }
 
-enum ReaderTopBarMetrics {
+enum TopBarMetrics {
     static let mainBarHeight: CGFloat = 44
     static let sourceEditingBarHeight: CGFloat = 22
 }
 
-enum ReaderTopBarAction {
+enum TopBarAction {
     case openFiles([URL])
     case openInApp(ExternalApplication)
     case revealInFinder
@@ -65,7 +65,7 @@ enum ReaderTopBarAction {
     }
 }
 
-struct ReaderTopBar: View {
+struct TopBar: View {
     let document: DocumentController
     let sourceEditing: SourceEditingController
     let statusBarTimestamp: StatusBarTimestamp?
@@ -75,11 +75,11 @@ struct ReaderTopBar: View {
     let recentWatchedFolders: [RecentWatchedFolder]
     let recentManuallyOpenedFiles: [RecentOpenedFile]
     let iconProvider: (ExternalApplication) -> NSImage?
-    let onAction: (ReaderTopBarAction) -> Void
+    let onAction: (TopBarAction) -> Void
 
     private enum Metrics {
         static let barHorizontalPadding: CGFloat = 12
-        static let mainBarHeight: CGFloat = ReaderTopBarMetrics.mainBarHeight
+        static let mainBarHeight: CGFloat = TopBarMetrics.mainBarHeight
     }
 
     @State private var isEditingFavorites = false
@@ -108,7 +108,7 @@ struct ReaderTopBar: View {
                     recentManuallyOpenedFiles: recentManuallyOpenedFiles,
                     iconProvider: iconProvider,
                     onAction: { menuAction in
-                        if let topBarAction = ReaderTopBarAction(menuAction) {
+                        if let topBarAction = TopBarAction(menuAction) {
                             onAction(topBarAction)
                         } else {
                             isEditingFavorites = true

--- a/minimark/Views/SettingsView.swift
+++ b/minimark/Views/SettingsView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-struct ReaderSettingsView: View {
+struct SettingsView: View {
     private var settingsStore: SettingsStore
     @ObservedObject private var notificationNotifier: SystemNotifier
 
@@ -291,7 +291,7 @@ extension Color {
 }
 
 struct ThemePreviewCard: View {
-    let settings: ReaderSettings
+    let settings: Settings
 
     private var theme: Theme {
         Theme.theme(for: settings.readerTheme)

--- a/minimark/Views/SidebarWorkspaceView.swift
+++ b/minimark/Views/SidebarWorkspaceView.swift
@@ -1,14 +1,14 @@
 import AppKit
 import SwiftUI
 
-enum ReaderSidebarWorkspaceMetrics {
+enum SidebarWorkspaceMetrics {
     static let sidebarMinimumWidth: CGFloat = UITestLaunchConfiguration.current.isUITestModeEnabled ? 273 : 220
     static let sidebarIdealWidth: CGFloat = UITestLaunchConfiguration.current.isUITestModeEnabled ? 273 : 250
     static let detailMinimumWidth: CGFloat = 420
-    static let toolbarHeight: CGFloat = ReaderTopBarMetrics.mainBarHeight
+    static let toolbarHeight: CGFloat = TopBarMetrics.mainBarHeight
 }
 
-struct ReaderSidebarWorkspaceView<Detail: View>: View {
+struct SidebarWorkspaceView<Detail: View>: View {
     var controller: SidebarDocumentController
     var settingsStore: SettingsStore
     var groupState: SidebarGroupStateController
@@ -40,7 +40,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
                     }
                 }
             } else {
-                detail(controller.selectedReaderStore)
+                detail(controller.selectedDocumentStore)
             }
         }
         .onAppear {
@@ -121,9 +121,9 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
             SidebarScanProgressView(controller: controller)
         }
         .frame(
-            minWidth: ReaderSidebarWorkspaceMetrics.sidebarMinimumWidth,
+            minWidth: SidebarWorkspaceMetrics.sidebarMinimumWidth,
             idealWidth: sidebarWidth,
-            maxWidth: isDraggingDivider ? .infinity : max(sidebarWidth, ReaderSidebarWorkspaceMetrics.sidebarMinimumWidth),
+            maxWidth: isDraggingDivider ? .infinity : max(sidebarWidth, SidebarWorkspaceMetrics.sidebarMinimumWidth),
             maxHeight: .infinity
         )
         .background(SidebarDividerPositionSetter(
@@ -157,7 +157,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: ReaderSidebarWorkspaceMetrics.toolbarHeight)
+        .frame(height: SidebarWorkspaceMetrics.toolbarHeight)
         .animation(.easeInOut(duration: 0.15), value: selectedDocumentIDs.count > 1)
     }
 
@@ -201,9 +201,9 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
     }
 
     private var detailColumn: some View {
-        detail(controller.selectedReaderStore)
+        detail(controller.selectedDocumentStore)
             .frame(
-                minWidth: ReaderSidebarWorkspaceMetrics.detailMinimumWidth,
+                minWidth: SidebarWorkspaceMetrics.detailMinimumWidth,
                 maxWidth: .infinity,
                 maxHeight: .infinity
             )
@@ -285,7 +285,7 @@ struct ReaderSidebarWorkspaceView<Detail: View>: View {
 
 }
 
-private struct ReaderSidebarDocumentRow: View {
+private struct SidebarDocumentRow: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
     @State private var isIndicatorPulsing = false
@@ -293,9 +293,9 @@ private struct ReaderSidebarDocumentRow: View {
     @State private var indicatorPulseTask: Task<Void, Never>?
 
     let state: SidebarRowState
-    let settings: ReaderSettings
+    let settings: Settings
     let documents: [SidebarDocumentController.Document]
-    let readerStore: DocumentStore
+    let documentStore: DocumentStore
     let watchedDocumentIDs: Set<UUID>
     let selectedDocumentIDs: Set<UUID>
     let showsSelectionBackground: Bool
@@ -320,24 +320,24 @@ private struct ReaderSidebarDocumentRow: View {
         documents.filter { effectiveDocumentIDs.contains($0.id) }
     }
 
-    private var effectiveReaderStores: [DocumentStore] {
-        effectiveDocuments.map(\.readerStore)
+    private var effectiveDocumentStores: [DocumentStore] {
+        effectiveDocuments.map(\.documentStore)
     }
 
     private var effectiveOpenInApplications: [ExternalApplication] {
-        guard let firstReaderStore = effectiveReaderStores.first(where: { $0.document.fileURL != nil }) else {
+        guard let firstDocumentStore = effectiveDocumentStores.first(where: { $0.document.fileURL != nil }) else {
             return []
         }
 
-        return firstReaderStore.document.openInApplications.filter { application in
-            effectiveReaderStores
+        return firstDocumentStore.document.openInApplications.filter { application in
+            effectiveDocumentStores
                 .filter { $0.document.fileURL != nil }
                 .allSatisfy { $0.document.openInApplications.contains(application) }
         }
     }
 
     private var hasAnyOpenFile: Bool {
-        effectiveReaderStores.contains(where: { $0.document.fileURL != nil })
+        effectiveDocumentStores.contains(where: { $0.document.fileURL != nil })
     }
 
     private var watchingDocumentCount: Int {
@@ -557,7 +557,7 @@ private struct ReaderSidebarDocumentRow: View {
             return "No change timestamp"
         }
 
-        return ReaderStatusFormatting.relativeText(
+        return StatusFormatting.relativeText(
             for: fileLastModifiedAt,
             relativeTo: currentDate
         )
@@ -580,7 +580,7 @@ private struct ReaderSidebarDocumentRow: View {
     }
 }
 
-private struct ReaderSidebarGroupHeader: View {
+private struct SidebarGroupHeader: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isIndicatorPulsing = false
     @State private var lastHandledPulseToken: Int = -1
@@ -591,7 +591,7 @@ private struct ReaderSidebarGroupHeader: View {
     let isPinned: Bool
     let indicatorStates: [DocumentIndicatorState]
     let indicatorPulseToken: Int
-    let settings: ReaderSettings
+    let settings: Settings
     let onTogglePin: () -> Void
     let onCloseGroup: () -> Void
 
@@ -797,7 +797,7 @@ private struct SidebarGroupListContent: View {
         let isExpanded = groupState.isGroupExpanded(group.id)
         let isDragging = draggedGroupID == group.id
 
-        let groupHeader = ReaderSidebarGroupHeader(
+        let groupHeader = SidebarGroupHeader(
             displayName: group.displayName,
             documentCount: group.documents.count,
             isPinned: group.isPinned,
@@ -987,11 +987,11 @@ private struct SidebarGroupListContent: View {
         let rowState = controller.rowStates[document.id]
             ?? controller.deriveRowState(from: document)
 
-        return ReaderSidebarDocumentRow(
+        return SidebarDocumentRow(
             state: rowState,
             settings: settingsStore.currentSettings,
             documents: allDocuments,
-            readerStore: document.readerStore,
+            documentStore: document.documentStore,
             watchedDocumentIDs: watchedDocumentIDs,
             selectedDocumentIDs: selectedDocumentIDs,
             showsSelectionBackground: showsSelectionBackground,
@@ -1015,7 +1015,7 @@ private struct SidebarPinnableGroupHeader: View {
     let groupDisplayName: String
     let isExpanded: Bool
     let onToggleExpanded: () -> Void
-    let header: ReaderSidebarGroupHeader
+    let header: SidebarGroupHeader
 
     @State private var isHovering = false
 

--- a/minimark/Views/ThemeCardView.swift
+++ b/minimark/Views/ThemeCardView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ReaderThemeCard: View {
+struct ThemeCard: View {
     let kind: ThemeKind
     let isSelected: Bool
     let action: () -> Void

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -67,7 +67,7 @@ struct ThemeSelectorView: View {
             ScrollView {
                 VStack(spacing: 4) {
                     ForEach(filteredReaderThemes, id: \.self) { kind in
-                        ReaderThemeCard(
+                        ThemeCard(
                             kind: kind,
                             isSelected: kind == stagedReaderTheme
                         ) {
@@ -210,7 +210,7 @@ struct ThemeSelectorView: View {
         settingsStore.currentSettings.syntaxTheme
     }
 
-    private var previewSettings: ReaderSettings {
+    private var previewSettings: Settings {
         var settings = settingsStore.currentSettings
         settings.readerTheme = stagedReaderTheme
         settings.syntaxTheme = stagedSyntaxTheme

--- a/minimark/Views/Window/Coordination/AppearanceLockCoordinator.swift
+++ b/minimark/Views/Window/Coordination/AppearanceLockCoordinator.swift
@@ -30,7 +30,7 @@ final class AppearanceLockCoordinator {
         if appearanceController.isLocked {
             appearanceController.unlock()
             for document in sidebarDocumentController.documents {
-                document.readerStore.renderingController.clearAppearanceOverride()
+                document.documentStore.renderingController.clearAppearanceOverride()
             }
             if favoriteWorkspaceControllerProvider()?.activeFavoriteWorkspaceState != nil {
                 favoriteWorkspaceControllerProvider()?.updateLockedAppearance(nil)
@@ -39,7 +39,7 @@ final class AppearanceLockCoordinator {
             appearanceController.lock()
             let appearance = appearanceController.effectiveAppearance
             for document in sidebarDocumentController.documents {
-                document.readerStore.renderingController.setAppearanceOverride(appearance)
+                document.documentStore.renderingController.setAppearanceOverride(appearance)
             }
             if favoriteWorkspaceControllerProvider()?.activeFavoriteWorkspaceState != nil {
                 favoriteWorkspaceControllerProvider()?.updateLockedAppearance(appearanceController.lockedAppearance)
@@ -54,7 +54,7 @@ final class AppearanceLockCoordinator {
         Task { @MainActor [sidebarDocumentController] in
             let appearance = appearanceController.effectiveAppearance
             for document in sidebarDocumentController.documents {
-                let store = document.readerStore
+                let store = document.documentStore
                 guard store.document.hasOpenDocument, !store.document.isDeferredDocument else { continue }
 
                 if document.id == sidebarDocumentController.selectedDocumentID {
@@ -76,7 +76,7 @@ final class AppearanceLockCoordinator {
     func renderSelectedDocumentIfNeeded() {
         guard let appearanceController = appearanceControllerProvider() else { return }
         guard let document = sidebarDocumentController.selectedDocument else { return }
-        let store = document.readerStore
+        let store = document.documentStore
         guard store.renderingController.needsAppearanceRender,
               store.document.hasOpenDocument,
               !store.document.isDeferredDocument else { return }

--- a/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
+++ b/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
@@ -102,23 +102,23 @@ final class ContentViewActionRouter {
         case .editSubfolders:
             setEditingSubfolders(true)
         case .saveSourceDraft:
-            sidebarDocumentController.selectedReaderStore.editingFlow.save()
+            sidebarDocumentController.selectedDocumentStore.editingFlow.save()
         case .discardSourceDraft:
-            sidebarDocumentController.selectedReaderStore.editingFlow.discard()
+            sidebarDocumentController.selectedDocumentStore.editingFlow.discard()
         case .startSourceEditing:
-            sidebarDocumentController.selectedReaderStore.editingFlow.startEditing()
+            sidebarDocumentController.selectedDocumentStore.editingFlow.startEditing()
         case .updateSourceDraft(let markdown):
-            sidebarDocumentController.selectedReaderStore.editingFlow.updateDraft(markdown)
+            sidebarDocumentController.selectedDocumentStore.editingFlow.updateDraft(markdown)
         case .grantImageDirectoryAccess(let url):
-            sidebarDocumentController.selectedReaderStore.persister.grantImageDirectoryAccess(folderURL: url)
+            sidebarDocumentController.selectedDocumentStore.persister.grantImageDirectoryAccess(folderURL: url)
         case .openInApplication(let app):
-            sidebarDocumentController.selectedReaderStore.document.openInApplication(app)
+            sidebarDocumentController.selectedDocumentStore.document.openInApplication(app)
         case .revealInFinder:
-            sidebarDocumentController.selectedReaderStore.document.revealInFinder()
+            sidebarDocumentController.selectedDocumentStore.document.revealInFinder()
         case .presentError(let error):
-            sidebarDocumentController.selectedReaderStore.document.handle(error)
+            sidebarDocumentController.selectedDocumentStore.document.handle(error)
         case .updateTOCHeadings(let headings):
-            sidebarDocumentController.selectedReaderStore.toc.updateHeadings(headings)
+            sidebarDocumentController.selectedDocumentStore.toc.updateHeadings(headings)
         }
     }
 

--- a/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
+++ b/minimark/Views/Window/Coordination/UITestLaunchCoordinator.swift
@@ -58,8 +58,8 @@ final class UITestLaunchCoordinator {
 
     // MARK: - Private
 
-    private func resolvedLaunchAction() -> ReaderWindowUITestLaunchAction {
-        ReaderWindowUITestFlowSupport.resolveLaunchAction(
+    private func resolvedLaunchAction() -> WindowUITestLaunchAction {
+        WindowUITestFlowSupport.resolveLaunchAction(
             configuration: UITestLaunchConfiguration.current,
             hostWindowAvailable: actions?.hostWindow() != nil
         )
@@ -85,7 +85,7 @@ final class UITestLaunchCoordinator {
     }
 
     private func startGroupedSidebarFlow() {
-        ReaderWindowUITestFlowSupport.startGroupedSidebarFlow { [actions] fileURLs in
+        WindowUITestFlowSupport.startGroupedSidebarFlow { [actions] fileURLs in
             actions?.openFileRequest(FileOpenRequest(
                 fileURLs: fileURLs,
                 origin: .manual
@@ -94,7 +94,7 @@ final class UITestLaunchCoordinator {
     }
 
     private func startAutoOpenWatchFlow() {
-        ReaderWindowUITestFlowSupport.startAutoOpenWatchFlow(
+        WindowUITestFlowSupport.startAutoOpenWatchFlow(
             startWatchingFolder: { [actions] watchFolderURL in
                 actions?.startWatchingFolder(watchFolderURL, .default)
             },
@@ -102,7 +102,7 @@ final class UITestLaunchCoordinator {
                 self?.watchFlowTask?.cancel()
             },
             waitForFolderWatchStartup: { [actions] in
-                await ReaderWindowUITestFlowSupport.waitForFolderWatchStartup {
+                await WindowUITestFlowSupport.waitForFolderWatchStartup {
                     actions?.isSessionActive() ?? false
                 }
             },

--- a/minimark/Views/Window/Coordination/WindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowCoordinator.swift
@@ -4,7 +4,7 @@ import Observation
 
 @MainActor
 @Observable
-final class ReaderWindowCoordinator {
+final class WindowCoordinator {
     private let settingsStore: SettingsStore
     private let sidebarDocumentController: SidebarDocumentController
     private(set) var folderWatchOpen: WindowFolderWatchOpenController!
@@ -85,7 +85,7 @@ final class ReaderWindowCoordinator {
             sidebarDocumentController: sidebarDocumentController,
             settingsStore: settingsStore,
             favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
-            sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? ReaderSidebarWorkspaceMetrics.sidebarIdealWidth },
+            sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? SidebarWorkspaceMetrics.sidebarIdealWidth },
             refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() }
         )
         self.appearanceLock = AppearanceLockCoordinator(
@@ -125,7 +125,7 @@ final class ReaderWindowCoordinator {
             favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
             recentHistoryCoordinatorProvider: { [weak self] in self?.recentHistoryCoordinator },
             fileOpenCoordinator: sidebarDocumentController.fileOpenCoordinator,
-            sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? ReaderSidebarWorkspaceMetrics.sidebarIdealWidth },
+            sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? SidebarWorkspaceMetrics.sidebarIdealWidth },
             applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
             confirmFolderWatch: { [weak self] options in self?.folderWatchSession.confirm(options) },
             stopFolderWatch: { [weak self] in self?.folderWatchSession.stop() },

--- a/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
@@ -90,7 +90,7 @@ final class WindowDocumentOpenCoordinator {
     }
 
     func openIncomingURL(_ url: URL) {
-        guard ReaderWindowOpenAndWatchFlowSupport.isSupportedIncomingMarkdownFile(url) else {
+        guard WindowOpenAndWatchFlowSupport.isSupportedIncomingMarkdownFile(url) else {
             return
         }
 
@@ -177,7 +177,7 @@ final class WindowDocumentOpenCoordinator {
     }
 
     func applyInitialSeedIfNeeded(seed: WindowSeed?) {
-        ReaderWindowOpenAndWatchFlowSupport.applyInitialSeedIfNeeded(
+        WindowOpenAndWatchFlowSupport.applyInitialSeedIfNeeded(
             seed: seed,
             openDocumentInCurrentWindow: { [weak self] fileURL in
                 self?.openDocumentInCurrentWindow(fileURL)

--- a/minimark/Views/Window/Coordination/WindowShellController.swift
+++ b/minimark/Views/Window/Coordination/WindowShellController.swift
@@ -8,7 +8,7 @@ import Observation
 /// Intentionally narrow: knows *how* to register a window, resolve its title,
 /// and mirror the dock-tile row states. Does not know about folder-watch flow,
 /// UI-test launch configuration, or the folder-watch open queue — those stay
-/// with `ReaderWindowCoordinator` as composite concerns.
+/// with `WindowCoordinator` as composite concerns.
 @MainActor
 @Observable
 final class WindowShellController {

--- a/minimark/Views/Window/Coordination/WindowSidebarMetricsController.swift
+++ b/minimark/Views/Window/Coordination/WindowSidebarMetricsController.swift
@@ -13,7 +13,7 @@ import Observation
 @MainActor
 @Observable
 final class WindowSidebarMetricsController {
-    var width: CGFloat = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
+    var width: CGFloat = SidebarWorkspaceMetrics.sidebarIdealWidth
     @ObservationIgnored private var lastAppliedDelta: CGFloat = 0
 
     private let sidebarDocumentController: SidebarDocumentController
@@ -31,7 +31,7 @@ final class WindowSidebarMetricsController {
     }
 
     func resetToIdealWidth() {
-        width = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
+        width = SidebarWorkspaceMetrics.sidebarIdealWidth
     }
 
     func handleWidthChange(_ newWidth: CGFloat) {
@@ -76,7 +76,7 @@ final class WindowSidebarMetricsController {
             lastAppliedDelta = newFrame.width - oldWidth
         } else {
             lastAppliedDelta = 0
-            width = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth
+            width = SidebarWorkspaceMetrics.sidebarIdealWidth
         }
     }
 }

--- a/minimark/Views/Window/Flow/WindowOpenAndWatchFlowSupport.swift
+++ b/minimark/Views/Window/Flow/WindowOpenAndWatchFlowSupport.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ReaderWindowOpenAndWatchFlowSupport {
+enum WindowOpenAndWatchFlowSupport {
     static func isSupportedIncomingMarkdownFile(_ url: URL) -> Bool {
         url.isFileURL && FileRouting.isSupportedMarkdownFileURL(url)
     }

--- a/minimark/Views/Window/Flow/WindowUITestFlowSupport.swift
+++ b/minimark/Views/Window/Flow/WindowUITestFlowSupport.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ReaderWindowUITestLaunchAction {
+enum WindowUITestLaunchAction {
     case none
     case simulateAutoOpenWatchFlow
     case simulateGroupedSidebar
@@ -8,11 +8,11 @@ enum ReaderWindowUITestLaunchAction {
     case startWatchingFolder(URL)
 }
 
-struct ReaderWindowUITestFlowSupport {
+struct WindowUITestFlowSupport {
     static func resolveLaunchAction(
         configuration: UITestLaunchConfiguration,
         hostWindowAvailable: Bool
-    ) -> ReaderWindowUITestLaunchAction {
+    ) -> WindowUITestLaunchAction {
         guard configuration.isUITestModeEnabled else {
             return .none
         }

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -1,14 +1,14 @@
 import AppKit
 import SwiftUI
 
-struct ReaderWindowRootView: View {
+struct WindowRootView: View {
     let seed: WindowSeed?
     var settingsStore: SettingsStore
     let multiFileDisplayMode: MultiFileDisplayMode
 
     @Environment(\.openWindow) private var openWindow
     @State var sidebarDocumentController: SidebarDocumentController
-    @State var windowCoordinator: ReaderWindowCoordinator
+    @State var windowCoordinator: WindowCoordinator
     @State var appearanceController: WindowAppearanceController
     @State var groupStateController = SidebarGroupStateController()
     @State var favoriteWorkspaceController: FavoriteWorkspaceController
@@ -27,7 +27,7 @@ struct ReaderWindowRootView: View {
         let sidebarDocumentController = SidebarDocumentController(settingsStore: settingsStore)
         _sidebarDocumentController = State(wrappedValue: sidebarDocumentController)
         _windowCoordinator = State(
-            wrappedValue: ReaderWindowCoordinator(
+            wrappedValue: WindowCoordinator(
                 settingsStore: settingsStore,
                 sidebarDocumentController: sidebarDocumentController
             )
@@ -335,7 +335,7 @@ struct ReaderWindowRootView: View {
 
     @ViewBuilder
     private var rootContent: some View {
-        ReaderSidebarWorkspaceView(
+        SidebarWorkspaceView(
             controller: sidebarDocumentController,
             settingsStore: settingsStore,
             groupState: groupStateController,
@@ -412,7 +412,7 @@ struct ReaderWindowRootView: View {
     private func contentView(for store: DocumentStore) -> some View {
         @Bindable var folderWatchFlow = folderWatchFlowController
         return ContentViewAdapter(
-            readerStore: store,
+            documentStore: store,
             sidebarDocumentController: sidebarDocumentController,
             settingsStore: settingsStore,
             appearanceController: appearanceController,

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -26,7 +26,7 @@ struct MarkdownObserverApp: App {
         let appAppearance = settingsStore.currentSettings.appAppearance
 
         WindowGroup("MarkdownObserver", for: WindowSeed.self) { seed in
-            ReaderWindowRootView(
+            WindowRootView(
                 seed: seed.wrappedValue,
                 settingsStore: settingsStore,
                 multiFileDisplayMode: activeMultiFileDisplayMode
@@ -38,11 +38,11 @@ struct MarkdownObserverApp: App {
             height: WindowDefaults.defaultHeight
         )
         .commands {
-            ReaderCommands(settingsStore: settingsStore, multiFileDisplayMode: activeMultiFileDisplayMode)
+            AppCommands(settingsStore: settingsStore, multiFileDisplayMode: activeMultiFileDisplayMode)
         }
 
         Window("MarkdownObserver Settings", id: AppWindowID.settings.rawValue) {
-            ReaderSettingsView(settingsStore: settingsStore)
+            SettingsView(settingsStore: settingsStore)
             .appAppearance(appAppearance)
         }
         .defaultSize(width: 1000, height: 720)

--- a/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
+++ b/minimarkTests/Core/OpenDocumentPathTrackerTests.swift
@@ -37,7 +37,7 @@ struct OpenDocumentPathTrackerTests {
             )
         )
         return SidebarDocumentController.Document(
-            id: UUID(), readerStore: store, normalizedFileURL: normalizedURL
+            id: UUID(), documentStore: store, normalizedFileURL: normalizedURL
         )
     }
 

--- a/minimarkTests/Core/OverlayLayoutModelTests.swift
+++ b/minimarkTests/Core/OverlayLayoutModelTests.swift
@@ -7,18 +7,18 @@ struct OverlayLayoutModelTests {
 
     @Test func topInsetWithoutSourceEditingIsMainBarHeight() {
         let model = OverlayLayoutModel(isSourceEditing: false, isStatusBannerVisible: false)
-        #expect(model.topInset == ReaderTopBarMetrics.mainBarHeight)
+        #expect(model.topInset == TopBarMetrics.mainBarHeight)
     }
 
     @Test func topInsetWithSourceEditingAddsSourceBarHeight() {
         let model = OverlayLayoutModel(isSourceEditing: true, isStatusBannerVisible: false)
-        #expect(model.topInset == ReaderTopBarMetrics.mainBarHeight + ReaderTopBarMetrics.sourceEditingBarHeight)
+        #expect(model.topInset == TopBarMetrics.mainBarHeight + TopBarMetrics.sourceEditingBarHeight)
     }
 
     @Test func insetsDelegateToCalculator() {
         let model = OverlayLayoutModel(isSourceEditing: false, isStatusBannerVisible: true)
         let expected = OverlayInsetCalculator.compute(
-            topBarInset: ReaderTopBarMetrics.mainBarHeight,
+            topBarInset: TopBarMetrics.mainBarHeight,
             hasStatusBanner: true
         )
         #expect(model.insets == expected)
@@ -27,7 +27,7 @@ struct OverlayLayoutModelTests {
     @Test func statusBannerPaddingDelegatesToCalculator() {
         let model = OverlayLayoutModel(isSourceEditing: true, isStatusBannerVisible: false)
         let expected = OverlayInsetCalculator.statusBannerTopPadding(
-            topBarInset: ReaderTopBarMetrics.mainBarHeight + ReaderTopBarMetrics.sourceEditingBarHeight
+            topBarInset: TopBarMetrics.mainBarHeight + TopBarMetrics.sourceEditingBarHeight
         )
         #expect(model.statusBannerTopPadding == expected)
     }

--- a/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWatchedFolderTests.swift
@@ -487,7 +487,7 @@ struct ReaderFavoriteWatchedFolderTests {
         }
         """
 
-        let settings = try JSONDecoder().decode(ReaderSettings.self, from: Data(json.utf8))
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(json.utf8))
         #expect(settings.favoriteWatchedFolders.isEmpty)
     }
 

--- a/minimarkTests/Core/ReaderFavoriteWorkspaceStateTests.swift
+++ b/minimarkTests/Core/ReaderFavoriteWorkspaceStateTests.swift
@@ -46,7 +46,7 @@ struct ReaderFavoriteWorkspaceStateTests {
     }
 
     @Test func defaultFactoryUsesGlobalSettingsAndEmptySets() {
-        let settings = ReaderSettings.default
+        let settings = Settings.default
 
         let state = FavoriteWorkspaceState.from(
             settings: settings,
@@ -65,7 +65,7 @@ struct ReaderFavoriteWorkspaceStateTests {
 
     @Test func snapshotCapturesCurrentValues() {
         let state = FavoriteWorkspaceState.from(
-            settings: ReaderSettings.default,
+            settings: Settings.default,
             pinnedGroupIDs: ["pinned1"],
             collapsedGroupIDs: ["collapsed1", "collapsed2"],
             sidebarWidth: 350
@@ -101,11 +101,11 @@ struct ReaderFavoriteWorkspaceStateTests {
             createdAt: .now
         )
 
-        var settings = ReaderSettings.default
+        var settings = Settings.default
         settings.favoriteWatchedFolders = [favorite]
 
         let data = try JSONEncoder().encode(settings)
-        let decoded = try JSONDecoder().decode(ReaderSettings.self, from: data)
+        let decoded = try JSONDecoder().decode(Settings.self, from: data)
 
         let restoredFavorite = decoded.favoriteWatchedFolders.first!
         #expect(restoredFavorite.workspaceState == workspaceState)
@@ -160,7 +160,7 @@ struct ReaderFavoriteWorkspaceStateTests {
 
     @Test func legacyMigrationUsesDecodedGlobalSettings() throws {
         // Simulate settings with customized globals and a legacy favorite (no workspaceState key)
-        var settings = ReaderSettings.default
+        var settings = Settings.default
         settings.sidebarSortMode = .nameAscending
         settings.sidebarGroupSortMode = .nameDescending
         settings.multiFileDisplayMode = .sidebarRight
@@ -180,7 +180,7 @@ struct ReaderFavoriteWorkspaceStateTests {
 
         // Encode, then decode — simulates upgrade path where favorite has default workspace state
         let data = try JSONEncoder().encode(settings)
-        let decoded = try JSONDecoder().decode(ReaderSettings.self, from: data)
+        let decoded = try JSONDecoder().decode(Settings.self, from: data)
 
         let migrated = decoded.favoriteWatchedFolders.first!
         #expect(migrated.workspaceState.fileSortMode == .nameAscending)

--- a/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
+++ b/minimarkTests/Core/ReaderSettingsAndModelsTests.swift
@@ -233,7 +233,7 @@ struct ReaderSettingsAndModelsTests {
         let storage = TestSettingsKeyValueStorage()
         let storageKey = "reader.settings.recent-file.invalid-bookmark.tests"
         let fileURL = URL(fileURLWithPath: "/tmp/invalid-bookmark.md")
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -260,7 +260,7 @@ struct ReaderSettingsAndModelsTests {
         let storage = TestSettingsKeyValueStorage()
         let storageKey = "reader.settings.recent-folder.invalid-bookmark.tests"
         let folderURL = URL(fileURLWithPath: "/tmp/invalid-watch-folder", isDirectory: true)
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -293,7 +293,7 @@ struct ReaderSettingsAndModelsTests {
         let folderURL = URL(fileURLWithPath: "/tmp/stale-watch-folder", isDirectory: true)
         let originalBookmarkData = Data([0x01, 0x02, 0x03])
         let refreshedBookmarkData = Data([0x10, 0x20, 0x30])
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -347,7 +347,7 @@ struct ReaderSettingsAndModelsTests {
         }
 
         let entry = RecentOpenedFile(fileURL: fileURL)
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -540,7 +540,7 @@ struct ReaderSettingsAndModelsTests {
         let resolvedURL = URL(fileURLWithPath: "/tmp/resolved-notes", isDirectory: true)
         let bookmarkData = Data([0x01, 0x02, 0x03])
 
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -574,7 +574,7 @@ struct ReaderSettingsAndModelsTests {
         let folderURL = URL(fileURLWithPath: "/tmp/my-notes", isDirectory: true)
         let bookmarkData = Data([0x01, 0x02, 0x03])
 
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -607,7 +607,7 @@ struct ReaderSettingsAndModelsTests {
         let storageKey = "reader.settings.trusted-image-invalid.tests"
         let folderURL = URL(fileURLWithPath: "/tmp/invalid-trust", isDirectory: true)
 
-        let seededSettings = ReaderSettings(
+        let seededSettings = Settings(
             appAppearance: .system,
             readerTheme: .blackOnWhite,
             syntaxTheme: .monokai,
@@ -906,21 +906,21 @@ struct ReaderSettingsAndModelsTests {
 
     @Test func readerSettingsDecodesDefaultLookbackWhenKeyMissing() throws {
         var settingsDict = try JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(ReaderSettings.default)
+            with: JSONEncoder().encode(Settings.default)
         ) as! [String: Any]
         settingsDict.removeValue(forKey: "diffBaselineLookback")
         let data = try JSONSerialization.data(withJSONObject: settingsDict)
 
-        let decoded = try JSONDecoder().decode(ReaderSettings.self, from: data)
+        let decoded = try JSONDecoder().decode(Settings.self, from: data)
         #expect(decoded.diffBaselineLookback == .twoMinutes)
     }
 
     @Test func readerSettingsCodableRoundTripPreservesDiffBaselineLookback() throws {
-        var settings = ReaderSettings.default
+        var settings = Settings.default
         settings.diffBaselineLookback = .fiveMinutes
 
         let data = try JSONEncoder().encode(settings)
-        let decoded = try JSONDecoder().decode(ReaderSettings.self, from: data)
+        let decoded = try JSONDecoder().decode(Settings.self, from: data)
         #expect(decoded.diffBaselineLookback == .fiveMinutes)
     }
 

--- a/minimarkTests/Core/SidebarDocumentActionRouterTests.swift
+++ b/minimarkTests/Core/SidebarDocumentActionRouterTests.swift
@@ -9,7 +9,7 @@ struct SidebarDocumentActionRouterTests {
     @MainActor
     private func makeRouter(
         favoriteWorkspaceController: FavoriteWorkspaceController? = nil,
-        sidebarWidth: CGFloat = ReaderSidebarWorkspaceMetrics.sidebarIdealWidth,
+        sidebarWidth: CGFloat = SidebarWorkspaceMetrics.sidebarIdealWidth,
         onAfterRefresh: @escaping () -> Void = {}
     ) throws -> (SidebarDocumentActionRouter, ReaderSidebarControllerTestHarness) {
         let harness = try ReaderSidebarControllerTestHarness()

--- a/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
+++ b/minimarkTests/Core/SourceHTMLDocumentCacheTests.swift
@@ -12,8 +12,8 @@ struct SourceHTMLDocumentCacheTests {
     private static func makeSettings(
         readerTheme: ThemeKind = .blackOnWhite,
         baseFontSize: Double = 15
-    ) -> ReaderSettings {
-        ReaderSettings(
+    ) -> Settings {
+        Settings(
             appAppearance: .system,
             readerTheme: readerTheme,
             syntaxTheme: .monokai,

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -11,10 +11,10 @@ import Testing
 struct WindowShellStateTests {
 
     @MainActor
-    private func makeCoordinator() throws -> (ReaderWindowCoordinator, ReaderSidebarControllerTestHarness) {
+    private func makeCoordinator() throws -> (WindowCoordinator, ReaderSidebarControllerTestHarness) {
         WindowRegistry.shared.resetForTesting()
         let harness = try ReaderSidebarControllerTestHarness()
-        let coordinator = ReaderWindowCoordinator(
+        let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )

--- a/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
+++ b/minimarkTests/FolderWatch/EditFolderWatchExclusionsTests.swift
@@ -162,7 +162,7 @@ struct EditFolderWatchExclusionsTests {
         let controllerWatcher = TestFolderWatcher()
         let controller = SidebarDocumentController(
             settingsStore: settingsStore,
-            makeReaderStore: {
+            makeDocumentStore: {
                 let fw = TestFileWatcher()
                 createdFileWatchers.append(fw)
                 let securityScopeResolver = SecurityScopeResolver(
@@ -215,18 +215,18 @@ struct EditFolderWatchExclusionsTests {
 
         #expect(controller.documents.count == 2)
 
-        let docA = controller.documents.first { $0.readerStore.document.fileURL == fileA }
+        let docA = controller.documents.first { $0.documentStore.document.fileURL == fileA }
         #expect(docA != nil)
         controller.selectDocument(docA?.id)
-        #expect(controller.selectedDocument?.readerStore.document.fileURL == fileA)
+        #expect(controller.selectedDocument?.documentStore.document.fileURL == fileA)
 
         controller.closeDocument(docA!.id)
 
         #expect(controller.documents.count == 1)
         let selected = controller.selectedDocument
         #expect(selected != nil)
-        #expect(selected?.readerStore.document.fileURL == fileB)
-        #expect(selected?.readerStore.document.isDeferredDocument == false)
+        #expect(selected?.documentStore.document.fileURL == fileB)
+        #expect(selected?.documentStore.document.isDeferredDocument == false)
 
         try? FileManager.default.removeItem(at: tempDir)
     }

--- a/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
+++ b/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
@@ -772,7 +772,7 @@ struct FolderWatchCoordinationTests {
             storage: TestSettingsKeyValueStorage(),
             storageKey: "reader.settings.window-local-open.\(UUID().uuidString)"
         )
-        let view = ReaderWindowRootView(
+        let view = WindowRootView(
             seed: nil,
             settingsStore: settingsStore,
             multiFileDisplayMode: .sidebarLeft
@@ -781,7 +781,7 @@ struct FolderWatchCoordinationTests {
         view.windowCoordinator.documentOpen.openAdditionalDocumentInCurrentWindow(markdownURL)
 
         #expect(focusedURLs.isEmpty)
-        #expect(view.sidebarDocumentController.selectedReaderStore.document.fileURL?.path == markdownURL.path)
+        #expect(view.sidebarDocumentController.selectedDocumentStore.document.fileURL?.path == markdownURL.path)
     }
 
     @Test @MainActor func openAdditionalDocumentsInCurrentWindowKeepsBatchLocal() throws {
@@ -818,7 +818,7 @@ struct FolderWatchCoordinationTests {
             storage: TestSettingsKeyValueStorage(),
             storageKey: "reader.settings.window-local-batch-open.\(UUID().uuidString)"
         )
-        let view = ReaderWindowRootView(
+        let view = WindowRootView(
             seed: nil,
             settingsStore: settingsStore,
             multiFileDisplayMode: .sidebarLeft
@@ -831,18 +831,18 @@ struct FolderWatchCoordinationTests {
         ))
 
         #expect(focusedURLs.isEmpty)
-        #expect(Set(view.sidebarDocumentController.documents.compactMap { $0.readerStore.document.fileURL?.path }) == Set([
+        #expect(Set(view.sidebarDocumentController.documents.compactMap { $0.documentStore.document.fileURL?.path }) == Set([
             alphaURL.path,
             zetaURL.path
         ]))
-        #expect(view.sidebarDocumentController.selectedReaderStore.document.fileURL?.path == zetaURL.path)
+        #expect(view.sidebarDocumentController.selectedDocumentStore.document.fileURL?.path == zetaURL.path)
     }
 
     @Test @MainActor func readerWindowCoordinatorResolvesTitleFromSelectedDocumentState() throws {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
+        let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )
@@ -861,7 +861,7 @@ struct FolderWatchCoordinationTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let coordinator = ReaderWindowCoordinator(
+        let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )

--- a/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
+++ b/minimarkTests/Rendering/MarkdownSourceHTMLRendererTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @Suite
 struct MarkdownSourceHTMLRendererTests {
-    private var defaultSettings: ReaderSettings { .default }
+    private var defaultSettings: Settings { .default }
 
     @Test func makeHTMLDocumentContainsDoctype() {
         let html = MarkdownSourceHTMLRenderer.makeHTMLDocument(

--- a/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/DocumentCloseCoordinatorTests.swift
@@ -58,7 +58,7 @@ struct DocumentCloseCoordinatorTests {
     private static func makeDocument(settingsStore: SettingsStore) -> SidebarDocumentController.Document {
         SidebarDocumentController.Document(
             id: UUID(),
-            readerStore: makeStore(settingsStore: settingsStore),
+            documentStore: makeStore(settingsStore: settingsStore),
             normalizedFileURL: nil
         )
     }

--- a/minimarkTests/Sidebar/FileOpenCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/FileOpenCoordinatorTests.swift
@@ -75,7 +75,7 @@ struct FileOpenCoordinatorTests {
         ))
 
         let existingDocID = harness.controller.documents.first(where: {
-            $0.readerStore.document.fileURL?.lastPathComponent == "alpha.md"
+            $0.documentStore.document.fileURL?.lastPathComponent == "alpha.md"
         })!.id
 
         let plan = coordinator.buildPlan(for: FileOpenRequest(
@@ -193,7 +193,7 @@ struct FileOpenCoordinatorTests {
         ))
 
         #expect(harness.controller.documents.count == 3)
-        let openFileNames = Set(harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.lastPathComponent })
+        let openFileNames = Set(harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.lastPathComponent })
         #expect(openFileNames == ["alpha.md", "beta.md", "zeta.md"])
     }
 
@@ -208,7 +208,7 @@ struct FileOpenCoordinatorTests {
         ))
 
         #expect(harness.controller.documents.count == 2)
-        let orderedNames = harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.lastPathComponent }
+        let orderedNames = harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.lastPathComponent }
         #expect(orderedNames == ["alpha.md", "zeta.md"])
     }
 
@@ -224,7 +224,7 @@ struct FileOpenCoordinatorTests {
         ))
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "alpha.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "alpha.md")
     }
 
     @Test @MainActor func openWithDeferThenMaterializeDefersAllFiles() throws {
@@ -238,8 +238,8 @@ struct FileOpenCoordinatorTests {
             materializationStrategy: .deferThenMaterializeNewest(count: 1)
         ))
 
-        let deferredCount = harness.controller.documents.filter { $0.readerStore.document.isDeferredDocument }.count
-        let loadedCount = harness.controller.documents.filter { !$0.readerStore.document.isDeferredDocument && $0.readerStore.document.fileURL != nil }.count
+        let deferredCount = harness.controller.documents.filter { $0.documentStore.document.isDeferredDocument }.count
+        let loadedCount = harness.controller.documents.filter { !$0.documentStore.document.isDeferredDocument && $0.documentStore.document.fileURL != nil }.count
 
         #expect(deferredCount == 1)
         #expect(loadedCount == 1)
@@ -279,7 +279,7 @@ struct FileOpenCoordinatorTests {
         ))
 
         #expect(harness.controller.documents.count == 2)
-        let openFileNames = Set(harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.lastPathComponent })
+        let openFileNames = Set(harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.lastPathComponent })
         #expect(openFileNames == ["alpha.md", "zeta.md"])
     }
 
@@ -294,6 +294,6 @@ struct FileOpenCoordinatorTests {
         ))
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
     }
 }

--- a/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
+++ b/minimarkTests/Sidebar/FileOpenPlanExecutorTests.swift
@@ -8,7 +8,7 @@ struct FileOpenPlanExecutorTests {
 
     final class MockDelegate: FileOpenPlanExecutorDelegate {
         var selectedDocumentID: UUID
-        var selectedReaderStore: DocumentStore
+        var selectedDocumentStore: DocumentStore
         var storeConfigurator: ((DocumentStore) -> Void)?
         var selectDocumentCalls: [UUID?] = []
         var bindSelectedStoreCalled = false
@@ -16,11 +16,11 @@ struct FileOpenPlanExecutorTests {
 
         init(
             selectedDocumentID: UUID,
-            selectedReaderStore: DocumentStore,
+            selectedDocumentStore: DocumentStore,
             makeDocument: @escaping () -> SidebarDocumentController.Document
         ) {
             self.selectedDocumentID = selectedDocumentID
-            self.selectedReaderStore = selectedReaderStore
+            self.selectedDocumentStore = selectedDocumentStore
             self.makeDocumentFactory = makeDocument
         }
 
@@ -82,7 +82,7 @@ struct FileOpenPlanExecutorTests {
         )
         let initialStore = makeStore(settingsStore: settingsStore)
         let initialDocument = SidebarDocumentController.Document(
-            id: UUID(), readerStore: initialStore, normalizedFileURL: nil
+            id: UUID(), documentStore: initialStore, normalizedFileURL: nil
         )
         let documentList = SidebarDocumentList(initialDocument: initialDocument)
         let observationManager = SidebarObservationManager()
@@ -97,11 +97,11 @@ struct FileOpenPlanExecutorTests {
 
         let delegate = MockDelegate(
             selectedDocumentID: initialDocument.id,
-            selectedReaderStore: initialStore,
+            selectedDocumentStore: initialStore,
             makeDocument: {
                 SidebarDocumentController.Document(
                     id: UUID(),
-                    readerStore: makeStore(settingsStore: settingsStore),
+                    documentStore: makeStore(settingsStore: settingsStore),
                     normalizedFileURL: nil
                 )
             }
@@ -174,7 +174,7 @@ struct FileOpenPlanExecutorTests {
         let store = Self.makeStore(settingsStore: settingsStore)
         store.opener.open(at: fileURL, origin: .manual)
         let doc = SidebarDocumentController.Document(
-            id: UUID(), readerStore: store, normalizedFileURL: fileURL
+            id: UUID(), documentStore: store, normalizedFileURL: fileURL
         )
         documentList.append(doc)
 

--- a/minimarkTests/Sidebar/FolderWatchSessionCoordinatorTests.swift
+++ b/minimarkTests/Sidebar/FolderWatchSessionCoordinatorTests.swift
@@ -8,8 +8,8 @@ struct FolderWatchSessionCoordinatorTests {
 
     final class MockDelegate: FolderWatchSessionCoordinatorDelegate {
         var documents: [SidebarDocumentController.Document] = []
-        var _selectedReaderStore: DocumentStore?
-        var selectedReaderStore: DocumentStore { _selectedReaderStore! }
+        var _selectedDocumentStore: DocumentStore?
+        var selectedDocumentStore: DocumentStore { _selectedDocumentStore! }
         var documentForURLResult: SidebarDocumentController.Document?
         var selectNewestCalled = false
         var lastOpenRequest: FileOpenRequest?

--- a/minimarkTests/Sidebar/ReaderSidebarDeferredLoadingTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDeferredLoadingTests.swift
@@ -8,7 +8,7 @@ struct ReaderSidebarDeferredLoadingTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let session = FolderWatchSession(
             folderURL: harness.temporaryDirectoryURL,
             options: .default,
@@ -29,7 +29,7 @@ struct ReaderSidebarDeferredLoadingTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let session = FolderWatchSession(
             folderURL: harness.temporaryDirectoryURL,
             options: .default,
@@ -53,7 +53,7 @@ struct ReaderSidebarDeferredLoadingTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let missingURL = harness.temporaryDirectoryURL.appendingPathComponent("gone.md")
         let session = FolderWatchSession(
             folderURL: harness.temporaryDirectoryURL,
@@ -91,11 +91,11 @@ struct ReaderSidebarDeferredLoadingTests {
             $0.id != harness.controller.selectedDocumentID
         }
         for document in nonSelectedDocuments {
-            #expect(document.readerStore.document.isDeferredDocument)
-            #expect(document.readerStore.document.sourceMarkdown.isEmpty)
+            #expect(document.documentStore.document.isDeferredDocument)
+            #expect(document.documentStore.document.sourceMarkdown.isEmpty)
         }
         // The selected document should have been materialized
-        #expect(!harness.controller.selectedReaderStore.document.isDeferredDocument)
+        #expect(!harness.controller.selectedDocumentStore.document.isDeferredDocument)
     }
 
     @Test @MainActor func burstOpenWithManualOriginLoadsAllDocumentsFully() throws {
@@ -110,9 +110,9 @@ struct ReaderSidebarDeferredLoadingTests {
 
         #expect(harness.controller.documents.count == 2)
         for document in harness.controller.documents {
-            #expect(!document.readerStore.document.isDeferredDocument)
-            #expect(document.readerStore.document.fileURL != nil)
-            #expect(!document.readerStore.document.sourceMarkdown.isEmpty)
+            #expect(!document.documentStore.document.isDeferredDocument)
+            #expect(document.documentStore.document.fileURL != nil)
+            #expect(!document.documentStore.document.sourceMarkdown.isEmpty)
         }
     }
 
@@ -138,7 +138,7 @@ struct ReaderSidebarDeferredLoadingTests {
         let deferredDocument = harness.controller.documents.first {
             $0.id != harness.controller.selectedDocumentID
         }!
-        #expect(deferredDocument.readerStore.document.isDeferredDocument)
+        #expect(deferredDocument.documentStore.document.isDeferredDocument)
 
         // Select it
         harness.controller.selectDocument(deferredDocument.id)
@@ -147,9 +147,9 @@ struct ReaderSidebarDeferredLoadingTests {
         for _ in 0..<5 { await Task.yield() }
 
         // Now it should be fully loaded
-        #expect(!deferredDocument.readerStore.document.isDeferredDocument)
-        #expect(!deferredDocument.readerStore.document.sourceMarkdown.isEmpty)
-        #expect(!deferredDocument.readerStore.renderingController.renderedHTMLDocument.isEmpty)
+        #expect(!deferredDocument.documentStore.document.isDeferredDocument)
+        #expect(!deferredDocument.documentStore.document.sourceMarkdown.isEmpty)
+        #expect(!deferredDocument.documentStore.renderingController.renderedHTMLDocument.isEmpty)
     }
 
     @Test @MainActor func openingAlreadyDeferredDocumentDoesNotDuplicate() throws {
@@ -207,9 +207,9 @@ struct ReaderSidebarDeferredLoadingTests {
             slotStrategy: .replaceSelectedSlot
         ))
 
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "gamma.md")
-        #expect(!harness.controller.selectedReaderStore.document.isDeferredDocument)
-        #expect(!harness.controller.selectedReaderStore.document.sourceMarkdown.isEmpty)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "gamma.md")
+        #expect(!harness.controller.selectedDocumentStore.document.isDeferredDocument)
+        #expect(!harness.controller.selectedDocumentStore.document.sourceMarkdown.isEmpty)
     }
 
     @Test @MainActor func liveFolderWatchEventForDeferredDocumentDoesNotDuplicate() throws {
@@ -264,15 +264,15 @@ struct ReaderSidebarDeferredLoadingTests {
 
         // Find the deferred (non-selected) document
         let deferredDocument = harness.controller.documents.first {
-            $0.readerStore.document.isDeferredDocument
+            $0.documentStore.document.isDeferredDocument
         }!
-        #expect(deferredDocument.readerStore.document.sourceMarkdown.isEmpty)
+        #expect(deferredDocument.documentStore.document.sourceMarkdown.isEmpty)
 
         // Simulate a live folder-watch change event for the deferred file.
         // Use executePlan directly so this test can provide a one-off plan
         // that reuses the existing deferred document, forces .loadFully,
         // and supplies a specific diff baseline for the change event.
-        let deferredFileURL = deferredDocument.readerStore.document.fileURL!
+        let deferredFileURL = deferredDocument.documentStore.document.fileURL!
         harness.controller.executePlan(FileOpenPlan(
             assignments: [FileOpenPlan.SlotAssignment(
                 fileURL: deferredFileURL,
@@ -287,9 +287,9 @@ struct ReaderSidebarDeferredLoadingTests {
         for _ in 0..<5 { await Task.yield() }
 
         // The deferred document should now be fully loaded
-        #expect(!deferredDocument.readerStore.document.isDeferredDocument)
-        #expect(!deferredDocument.readerStore.document.sourceMarkdown.isEmpty)
-        #expect(!deferredDocument.readerStore.renderingController.renderedHTMLDocument.isEmpty)
+        #expect(!deferredDocument.documentStore.document.isDeferredDocument)
+        #expect(!deferredDocument.documentStore.document.sourceMarkdown.isEmpty)
+        #expect(!deferredDocument.documentStore.renderingController.renderedHTMLDocument.isEmpty)
     }
 
     @Test @MainActor func liveChangeEventShowsIndicatorForDeferredDocument() async throws {
@@ -312,11 +312,11 @@ struct ReaderSidebarDeferredLoadingTests {
         await Task.yield()
 
         let deferredDocument = harness.controller.documents.first {
-            $0.readerStore.document.isDeferredDocument
+            $0.documentStore.document.isDeferredDocument
         }!
 
         // Simulate a live change with a diff baseline (file was modified).
-        let deferredFileURL = deferredDocument.readerStore.document.fileURL!
+        let deferredFileURL = deferredDocument.documentStore.document.fileURL!
         harness.controller.executePlan(FileOpenPlan(
             assignments: [FileOpenPlan.SlotAssignment(
                 fileURL: deferredFileURL,
@@ -331,7 +331,7 @@ struct ReaderSidebarDeferredLoadingTests {
         for _ in 0..<5 { await Task.yield() }
 
         // The yellow change indicator should be visible
-        #expect(deferredDocument.readerStore.externalChange.hasUnacknowledgedExternalChange)
+        #expect(deferredDocument.documentStore.externalChange.hasUnacknowledgedExternalChange)
     }
 
     @Test @MainActor func liveAddEventDoesNotShowIndicatorForDeferredDocument() async throws {
@@ -354,11 +354,11 @@ struct ReaderSidebarDeferredLoadingTests {
         await Task.yield()
 
         let deferredDocument = harness.controller.documents.first {
-            $0.readerStore.document.isDeferredDocument
+            $0.documentStore.document.isDeferredDocument
         }!
 
         // Simulate a live event without a diff baseline (new file, not a modification).
-        let deferredFileURL = deferredDocument.readerStore.document.fileURL!
+        let deferredFileURL = deferredDocument.documentStore.document.fileURL!
         harness.controller.executePlan(FileOpenPlan(
             assignments: [FileOpenPlan.SlotAssignment(
                 fileURL: deferredFileURL,
@@ -373,14 +373,14 @@ struct ReaderSidebarDeferredLoadingTests {
         for _ in 0..<5 { await Task.yield() }
 
         // No yellow indicator — this wasn't a modification
-        #expect(!deferredDocument.readerStore.externalChange.hasUnacknowledgedExternalChange)
+        #expect(!deferredDocument.documentStore.externalChange.hasUnacknowledgedExternalChange)
     }
 
     @Test @MainActor func materializeDeferredDocumentWorksFromLoadingState() throws {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let session = FolderWatchSession(
             folderURL: harness.temporaryDirectoryURL,
             options: .default,
@@ -419,27 +419,27 @@ struct ReaderSidebarDeferredLoadingTests {
         let deferredDocument = harness.controller.documents.first {
             $0.id != harness.controller.selectedDocumentID
         }!
-        #expect(deferredDocument.readerStore.document.documentLoadState == .deferred)
+        #expect(deferredDocument.documentStore.document.documentLoadState == .deferred)
 
         harness.controller.selectDocument(deferredDocument.id)
 
         // Immediately after selectDocument: state should be .loading, not yet fully loaded
-        #expect(deferredDocument.readerStore.document.documentLoadState == .loading)
-        #expect(deferredDocument.readerStore.document.sourceMarkdown.isEmpty)
+        #expect(deferredDocument.documentStore.document.documentLoadState == .loading)
+        #expect(deferredDocument.documentStore.document.sourceMarkdown.isEmpty)
 
         // After yielding: the Task completes and the document content is loaded.
         // State may still be .loading due to holdLoadingOverlayBriefly() keeping the
         // overlay visible for the WKWebView to render.
         for _ in 0..<5 { await Task.yield() }
-        #expect(!deferredDocument.readerStore.document.sourceMarkdown.isEmpty)
-        #expect(!deferredDocument.readerStore.renderingController.renderedHTMLDocument.isEmpty)
+        #expect(!deferredDocument.documentStore.document.sourceMarkdown.isEmpty)
+        #expect(!deferredDocument.documentStore.renderingController.renderedHTMLDocument.isEmpty)
     }
 
     @Test @MainActor func transitionToLoadingSetsLoadingState() throws {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let session = FolderWatchSession(
             folderURL: harness.temporaryDirectoryURL,
             options: .default,
@@ -458,7 +458,7 @@ struct ReaderSidebarDeferredLoadingTests {
         let harness = try ReaderSidebarControllerTestHarness()
         defer { harness.cleanup() }
 
-        let store = harness.controller.selectedReaderStore
+        let store = harness.controller.selectedDocumentStore
 
         let coordinator = FileOpenCoordinator(controller: harness.controller)
         coordinator.open(FileOpenRequest(

--- a/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarDocumentControllerTests.swift
@@ -31,8 +31,8 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.primaryFileURL.path)
-        #expect(harness.controller.selectedReaderStore.folderWatchDispatcher.activeFolderWatchSession?.folderURL.path == harness.temporaryDirectoryURL.path)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.path == harness.primaryFileURL.path)
+        #expect(harness.controller.selectedDocumentStore.folderWatchDispatcher.activeFolderWatchSession?.folderURL.path == harness.temporaryDirectoryURL.path)
     }
 
     @Test @MainActor func sidebarControllerBurstOpenDeduplicatesSortsAndReusesInitialDocument() throws {
@@ -50,11 +50,11 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         #expect(harness.controller.documents.count == 2)
-        #expect(harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.path } == [
+        #expect(harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.path } == [
             harness.primaryFileURL.path,
             harness.secondaryFileURL.path
         ])
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.secondaryFileURL.path)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.path == harness.secondaryFileURL.path)
     }
 
     @Test @MainActor func sidebarControllerFocusingExistingDocumentDoesNotDuplicateEntry() throws {
@@ -70,7 +70,7 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.focusDocument(at: harness.primaryFileURL)
 
         #expect(harness.controller.documents.count == 2)
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.primaryFileURL.path)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.path == harness.primaryFileURL.path)
     }
 
     @Test @MainActor func sidebarControllerDoesNotKeepBlankDocumentWhenWatchedOpenFails() throws {
@@ -94,7 +94,7 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
     }
 
     @Test @MainActor func sidebarControllerFailedWatchedOpenKeepsActiveFolderWatchSession() throws {
@@ -120,7 +120,7 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
         #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
         #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
         #expect(harness.folderWatchControllerWatcher.stopCallCount == stopCallCountBeforeFailedOpen)
@@ -183,8 +183,8 @@ struct ReaderSidebarDocumentControllerTests {
             slotStrategy: .replaceSelectedSlot
         ))
 
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.primaryFileURL.path)
-        #expect(harness.controller.selectedReaderStore.folderWatchDispatcher.activeFolderWatchSession?.folderURL.path == harness.temporaryDirectoryURL.path)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.path == harness.primaryFileURL.path)
+        #expect(harness.controller.selectedDocumentStore.folderWatchDispatcher.activeFolderWatchSession?.folderURL.path == harness.temporaryDirectoryURL.path)
     }
 
     @Test @MainActor func sidebarControllerWatchedOpenDocumentsRetainDedicatedFileWatchers() throws {
@@ -228,7 +228,7 @@ struct ReaderSidebarDocumentControllerTests {
         )
 
         let topLevelDocumentIDs: Set<UUID> = Set(harness.controller.documents.compactMap { document in
-            guard let fileURL = document.readerStore.document.fileURL,
+            guard let fileURL = document.documentStore.document.fileURL,
                   fileURL.deletingLastPathComponent().path == harness.temporaryDirectoryURL.path else {
                 return nil
             }
@@ -260,7 +260,7 @@ struct ReaderSidebarDocumentControllerTests {
         )
         let controller = SidebarDocumentController(
             settingsStore: settingsStore,
-            makeReaderStore: {
+            makeDocumentStore: {
                 {
                     let settler = AutoOpenSettler(settlingInterval: 1.0)
                     let securityScopeResolver = SecurityScopeResolver(
@@ -317,7 +317,7 @@ struct ReaderSidebarDocumentControllerTests {
         try? await Task.sleep(for: .milliseconds(300))
 
         #expect(controller.documents.count == 1)
-        #expect(controller.selectedReaderStore.document.fileURL == nil)
+        #expect(controller.selectedDocumentStore.document.fileURL == nil)
     }
 
     @Test @MainActor func sidebarControllerRestoresFavoriteSavedOpenDocuments() throws {
@@ -354,7 +354,7 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         #expect(harness.controller.documents.count == 2)
-        #expect(harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.path } == [
+        #expect(harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.path } == [
             harness.primaryFileURL.path,
             harness.secondaryFileURL.path
         ])
@@ -376,12 +376,12 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.selectDocument(primaryDocument.id)
         await Task.yield()
         #expect(harness.controller.selectedFileURL?.path == harness.primaryFileURL.path)
-        #expect(harness.controller.selectedWindowTitle == primaryDocument.readerStore.document.windowTitle)
+        #expect(harness.controller.selectedWindowTitle == primaryDocument.documentStore.document.windowTitle)
 
         harness.controller.selectDocument(secondaryDocument.id)
         await Task.yield()
         #expect(harness.controller.selectedFileURL?.path == harness.secondaryFileURL.path)
-        #expect(harness.controller.selectedWindowTitle == secondaryDocument.readerStore.document.windowTitle)
+        #expect(harness.controller.selectedWindowTitle == secondaryDocument.documentStore.document.windowTitle)
     }
 
     @Test @MainActor func sidebarControllerPublishesWhenUnselectedDocumentChanges() async throws {
@@ -408,10 +408,10 @@ struct ReaderSidebarDocumentControllerTests {
             changeDetected = true
         }
 
-        unselectedDocument.readerStore.externalChangeHandler.handleObservedFileChange()
+        unselectedDocument.documentStore.externalChangeHandler.handleObservedFileChange()
         try await Task.sleep(for: .milliseconds(50))
 
-        #expect(unselectedDocument.readerStore.externalChange.lastExternalChangeAt != nil)
+        #expect(unselectedDocument.documentStore.externalChange.lastExternalChangeAt != nil)
         #expect(changeDetected)
     }
 
@@ -455,7 +455,7 @@ struct ReaderSidebarDocumentControllerTests {
 
         #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest == nil)
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
     }
 
     @Test @MainActor func sidebarControllerLiveBurstDoesNotPublishWarningForOmittedFiles() async throws {
@@ -543,8 +543,8 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.closeAllDocuments()
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.documents[0].readerStore.document.fileURL == nil)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.documents[0].documentStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
     }
 
     @Test @MainActor func sidebarControllerCloseAllDocumentsKeepsActiveFolderWatch() throws {
@@ -569,7 +569,7 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.closeAllDocuments()
 
         #expect(harness.controller.documents.count == 1)
-        #expect(harness.controller.selectedReaderStore.document.fileURL == nil)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL == nil)
         #expect(harness.controller.folderWatchCoordinator.canStopFolderWatch)
         #expect(harness.controller.folderWatchCoordinator.activeFolderWatchSession?.folderURL == harness.temporaryDirectoryURL)
         #expect(watcher.stopCallCount == stopCallCountBeforeCloseAll)
@@ -630,7 +630,7 @@ struct ReaderSidebarDocumentControllerTests {
         })
 
         #expect(harness.controller.documents.count == 3)
-        let openFileURLPaths = Set(harness.controller.documents.compactMap { $0.readerStore.document.fileURL?.path })
+        let openFileURLPaths = Set(harness.controller.documents.compactMap { $0.documentStore.document.fileURL?.path })
         #expect(openFileURLPaths.contains(harness.primaryFileURL.path))
         #expect(openFileURLPaths.contains(harness.secondaryFileURL.path))
         #expect(openFileURLPaths.contains(subfolderFileURL.path))
@@ -658,7 +658,7 @@ struct ReaderSidebarDocumentControllerTests {
 
         // The initial empty document should be reused for the first file.
         #expect(harness.controller.documents.count == 2)
-        #expect(harness.controller.documents.allSatisfy { $0.readerStore.document.fileURL != nil })
+        #expect(harness.controller.documents.allSatisfy { $0.documentStore.document.fileURL != nil })
     }
 
     @Test @MainActor func selectDocumentWithNewestModificationDateSelectsCorrectDocument() throws {
@@ -683,7 +683,7 @@ struct ReaderSidebarDocumentControllerTests {
 
         harness.controller.selectDocumentWithNewestModificationDate()
 
-        let selectedStore = harness.controller.selectedReaderStore
+        let selectedStore = harness.controller.selectedDocumentStore
         #expect(selectedStore.document.fileURL?.lastPathComponent == "newer.md")
     }
 
@@ -733,19 +733,19 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(harness.controller.folderWatchCoordinator.pendingFileSelectionRequest == nil)
         #expect(harness.controller.documents.count == fileCount)
 
-        let loadedDocs = harness.controller.documents.filter { !$0.readerStore.document.isDeferredDocument }
-        let deferredDocs = harness.controller.documents.filter { $0.readerStore.document.isDeferredDocument }
+        let loadedDocs = harness.controller.documents.filter { !$0.documentStore.document.isDeferredDocument }
+        let deferredDocs = harness.controller.documents.filter { $0.documentStore.document.isDeferredDocument }
 
         #expect(loadedDocs.count == FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)
         #expect(deferredDocs.count == fileCount - FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)
 
-        let loadedFileNames = Set(loadedDocs.compactMap { $0.readerStore.document.fileURL?.lastPathComponent })
+        let loadedFileNames = Set(loadedDocs.compactMap { $0.documentStore.document.fileURL?.lastPathComponent })
         for index in (fileCount - FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)..<fileCount {
             #expect(loadedFileNames.contains(String(format: "note-%02d.md", index)))
         }
 
         // Newest file (note-19) should be selected
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "note-19.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "note-19.md")
     }
 
     @Test @MainActor func materializeNewestDeferredDocumentsLoads12NewestAndSelectsNewest() throws {
@@ -788,25 +788,25 @@ struct ReaderSidebarDocumentControllerTests {
 
         // All should be deferred
         #expect(harness.controller.documents.count == fileCount)
-        #expect(harness.controller.documents.allSatisfy { $0.readerStore.document.isDeferredDocument })
+        #expect(harness.controller.documents.allSatisfy { $0.documentStore.document.isDeferredDocument })
 
         // Now materialize the 12 newest
         harness.controller.materializeNewestDeferredDocuments()
 
-        let loadedDocs = harness.controller.documents.filter { !$0.readerStore.document.isDeferredDocument }
-        let deferredDocs = harness.controller.documents.filter { $0.readerStore.document.isDeferredDocument }
+        let loadedDocs = harness.controller.documents.filter { !$0.documentStore.document.isDeferredDocument }
+        let deferredDocs = harness.controller.documents.filter { $0.documentStore.document.isDeferredDocument }
 
         #expect(loadedDocs.count == FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)
         #expect(deferredDocs.count == fileCount - FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)
 
-        let loadedFileNames = Set(loadedDocs.compactMap { $0.readerStore.document.fileURL?.lastPathComponent })
+        let loadedFileNames = Set(loadedDocs.compactMap { $0.documentStore.document.fileURL?.lastPathComponent })
         for index in (fileCount - FolderWatchAutoOpenPolicy.maximumInitialAutoOpenFileCount)..<fileCount {
             #expect(loadedFileNames.contains(String(format: "fav-%02d.md", index)))
         }
 
         // Newest file should be selected
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "fav-19.md")
-        #expect(!harness.controller.selectedReaderStore.document.isDeferredDocument)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "fav-19.md")
+        #expect(!harness.controller.selectedDocumentStore.document.isDeferredDocument)
     }
 
     @Test @MainActor func sidebarControllerLoadsAllFilesAndSelectsNewestForSmallFolder() throws {
@@ -833,15 +833,15 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(harness.controller.documents.count == fileCount)
 
         // All files should be fully loaded (none deferred)
-        let deferredDocs = harness.controller.documents.filter { $0.readerStore.document.isDeferredDocument }
+        let deferredDocs = harness.controller.documents.filter { $0.documentStore.document.isDeferredDocument }
         #expect(deferredDocs.isEmpty)
 
         for document in harness.controller.documents {
-            #expect(!document.readerStore.document.sourceMarkdown.isEmpty)
+            #expect(!document.documentStore.document.sourceMarkdown.isEmpty)
         }
 
         // Newest file (doc-04) should be selected
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "doc-04.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "doc-04.md")
     }
 
     // MARK: - Locked appearance propagation (#152)
@@ -853,7 +853,7 @@ struct ReaderSidebarDocumentControllerTests {
         let lockedAppearance = LockedAppearance(readerTheme: .newspaper, baseFontSize: 22, syntaxTheme: .nord)
 
         // Wire up the coordinator the same way the real app does
-        let coordinator = ReaderWindowCoordinator(
+        let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )
@@ -873,7 +873,7 @@ struct ReaderSidebarDocumentControllerTests {
         // The newly created document should have the locked appearance applied
         let newDocument = harness.controller.document(for: harness.secondaryFileURL)
         #expect(newDocument != nil)
-        #expect(newDocument?.readerStore.renderingController.needsAppearanceRender == true)
+        #expect(newDocument?.documentStore.renderingController.needsAppearanceRender == true)
     }
 
     @Test @MainActor func coordinatorDoesNotApplyAppearanceWhenUnlocked() throws {
@@ -881,7 +881,7 @@ struct ReaderSidebarDocumentControllerTests {
         defer { harness.cleanup() }
 
         // No locked appearance
-        let coordinator = ReaderWindowCoordinator(
+        let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
             sidebarDocumentController: harness.controller
         )
@@ -897,7 +897,7 @@ struct ReaderSidebarDocumentControllerTests {
 
         let newDocument = harness.controller.document(for: harness.secondaryFileURL)
         #expect(newDocument != nil)
-        #expect(newDocument?.readerStore.renderingController.needsAppearanceRender == false)
+        #expect(newDocument?.documentStore.renderingController.needsAppearanceRender == false)
     }
 
     // MARK: - Favorite restore newest-file selection (#144)
@@ -945,7 +945,7 @@ struct ReaderSidebarDocumentControllerTests {
         #expect(harness.controller.documents.count == 5)
 
         // The selected document must be charlie.md (newest by mod date), not echo.md (last alphabetically).
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "charlie.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "charlie.md")
     }
 
     @Test @MainActor func discoveryOfAlreadyOpenFilesDoesNotOverrideNewestSelection() throws {
@@ -990,7 +990,7 @@ struct ReaderSidebarDocumentControllerTests {
             folderWatchSession: session,
             materializationStrategy: .deferThenMaterializeNewest(count: 12)
         ))
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "beta.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "beta.md")
 
         // Simulate discoverNewFilesForFavorite re-processing the same files.
         coordinator.open(FileOpenRequest(
@@ -1005,7 +1005,7 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.selectDocumentWithNewestModificationDate()
 
         // beta.md should still be selected (newest by mod date).
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "beta.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "beta.md")
     }
 
     @Test @MainActor func discoveryOfNewFilesSelectsNewestOverall() throws {
@@ -1042,7 +1042,7 @@ struct ReaderSidebarDocumentControllerTests {
             folderWatchSession: session,
             materializationStrategy: .deferThenMaterializeNewest(count: 12)
         ))
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "beta.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "beta.md")
 
         // A newer file appears (discovered by folder watch).
         let gammaURL = harness.temporaryDirectoryURL.appendingPathComponent("gamma.md")
@@ -1064,7 +1064,7 @@ struct ReaderSidebarDocumentControllerTests {
         harness.controller.selectDocumentWithNewestModificationDate()
 
         // gamma.md should now be selected (newest overall).
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.lastPathComponent == "gamma.md")
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.lastPathComponent == "gamma.md")
     }
 
     @Test @MainActor func liveAutoOpenedFileShowsExternalChangeIndicator() async throws {
@@ -1089,13 +1089,13 @@ struct ReaderSidebarDocumentControllerTests {
         await Task.yield()
 
         let autoOpenedDoc = harness.controller.documents.first {
-            $0.readerStore.document.fileURL?.lastPathComponent == "zeta.md"
+            $0.documentStore.document.fileURL?.lastPathComponent == "zeta.md"
         }
         #expect(autoOpenedDoc != nil)
 
         let hasIndicator = await waitUntil(timeout: .seconds(2)) {
             guard let autoOpenedDoc else { return false }
-            return autoOpenedDoc.readerStore.externalChange.hasUnacknowledgedExternalChange
+            return autoOpenedDoc.documentStore.externalChange.hasUnacknowledgedExternalChange
         }
         #expect(hasIndicator)
 
@@ -1126,8 +1126,8 @@ struct ReaderSidebarDocumentControllerTests {
         ])
 
         let autoOpenedDoc = try #require(await waitUntil(timeout: .seconds(2)) {
-            harness.controller.documents.contains { $0.readerStore.document.fileURL?.path == harness.secondaryFileURL.path }
-        } ? harness.controller.documents.first { $0.readerStore.document.fileURL?.path == harness.secondaryFileURL.path } : nil)
+            harness.controller.documents.contains { $0.documentStore.document.fileURL?.path == harness.secondaryFileURL.path }
+        } ? harness.controller.documents.first { $0.documentStore.document.fileURL?.path == harness.secondaryFileURL.path } : nil)
 
         _ = await waitUntil(timeout: .seconds(2)) {
             (harness.controller.rowStates[autoOpenedDoc.id]?.indicatorPulseToken ?? 0) >= 1
@@ -1149,7 +1149,7 @@ struct ReaderSidebarDocumentControllerTests {
 
         try "# Zeta Edited".write(to: harness.secondaryFileURL, atomically: true, encoding: .utf8)
 
-        autoOpenedDoc.readerStore.externalChangeHandler.handleObservedFileChange()
+        autoOpenedDoc.documentStore.externalChangeHandler.handleObservedFileChange()
 
         _ = await waitUntil(timeout: .seconds(2)) {
             harness.controller.rowStates[autoOpenedDoc.id]?.indicatorState.showsIndicator == true
@@ -1189,7 +1189,7 @@ struct ReaderSidebarDocumentControllerTests {
         )
 
         for document in harness.controller.documents {
-            #expect(!document.readerStore.externalChange.hasUnacknowledgedExternalChange)
+            #expect(!document.documentStore.externalChange.hasUnacknowledgedExternalChange)
         }
     }
 
@@ -1204,7 +1204,7 @@ struct ReaderSidebarDocumentControllerTests {
         ))
 
         let document = harness.controller.documents.first {
-            $0.readerStore.document.fileURL != nil
+            $0.documentStore.document.fileURL != nil
         }
         #expect(document != nil)
         #expect(document?.normalizedFileURL == FileRouting.normalizedFileURL(harness.primaryFileURL))
@@ -1257,7 +1257,7 @@ struct ReaderSidebarDocumentControllerTests {
         )
         let controller = SidebarDocumentController(
             settingsStore: settingsStore,
-            makeReaderStore: {
+            makeDocumentStore: {
                 let settler = AutoOpenSettler(settlingInterval: 1.0)
                 let securityScopeResolver = SecurityScopeResolver(
                     securityScope: TestSecurityScopeAccess(),
@@ -1331,22 +1331,22 @@ struct ReaderSidebarDocumentControllerTests {
 
         // Both appended docs deferred; selection is on the last appended doc (zeta.md by sort order).
         let newestDoc = try #require(
-            harness.controller.documents.first { $0.readerStore.document.fileURL?.path == harness.secondaryFileURL.path }
+            harness.controller.documents.first { $0.documentStore.document.fileURL?.path == harness.secondaryFileURL.path }
         )
         let primaryDoc = try #require(
-            harness.controller.documents.first { $0.readerStore.document.fileURL?.path == harness.primaryFileURL.path }
+            harness.controller.documents.first { $0.documentStore.document.fileURL?.path == harness.primaryFileURL.path }
         )
-        #expect(newestDoc.readerStore.document.isDeferredDocument)
-        #expect(primaryDoc.readerStore.document.isDeferredDocument)
+        #expect(newestDoc.documentStore.document.isDeferredDocument)
+        #expect(primaryDoc.documentStore.document.isDeferredDocument)
         #expect(harness.controller.selectedDocumentID == newestDoc.id)
 
         // Trigger the code path `FavoriteWorkspaceController.discoverNewFilesForFavorite` uses.
         harness.controller.selectDocumentWithNewestModificationDate()
 
         #expect(await waitUntil(timeout: .seconds(2)) {
-            !harness.controller.selectedReaderStore.document.isDeferredDocument
+            !harness.controller.selectedDocumentStore.document.isDeferredDocument
         })
-        #expect(harness.controller.selectedReaderStore.document.fileURL?.path == harness.secondaryFileURL.path)
+        #expect(harness.controller.selectedDocumentStore.document.fileURL?.path == harness.secondaryFileURL.path)
     }
 
     /// Guards the ready-state path: re-selecting an already materialized document
@@ -1366,13 +1366,13 @@ struct ReaderSidebarDocumentControllerTests {
 
         let documentID = try #require(harness.controller.documents.first?.id)
         #expect(harness.controller.selectedDocumentID == documentID)
-        #expect(harness.controller.selectedReaderStore.document.documentLoadState == .ready)
+        #expect(harness.controller.selectedDocumentStore.document.documentLoadState == .ready)
 
         // Re-selecting the already-ready document should not regress it into loading.
         harness.controller.selectDocument(documentID)
         await Task.yield()
 
-        #expect(harness.controller.selectedReaderStore.document.documentLoadState == .ready)
+        #expect(harness.controller.selectedDocumentStore.document.documentLoadState == .ready)
         #expect(harness.controller.selectedFileURL?.path == harness.primaryFileURL.path)
     }
 }

--- a/minimarkTests/Sidebar/ReaderSidebarGroupingTests.swift
+++ b/minimarkTests/Sidebar/ReaderSidebarGroupingTests.swift
@@ -50,8 +50,8 @@ struct ReaderSidebarGroupingTests {
         // Set modification dates: "newer" group has a more recent date
         let olderDoc = harness.documentsInSubdirectory("older").first!
         let newerDoc = harness.documentsInSubdirectory("newer").first!
-        olderDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
-        newerDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
+        olderDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+        newerDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
         let grouping = SidebarGrouping.group(harness.documents)
 
@@ -142,7 +142,7 @@ struct ReaderSidebarGroupingTests {
 
         let sharedDate = Date(timeIntervalSince1970: 1000)
         for document in harness.documents {
-            document.readerStore.testSetFileLastModifiedAt(sharedDate)
+            document.documentStore.testSetFileLastModifiedAt(sharedDate)
         }
 
         let zetaDoc = try #require(harness.documentsInSubdirectory("zeta").first)
@@ -172,8 +172,8 @@ struct ReaderSidebarGroupingTests {
         let betaDoc = harness.documentsInSubdirectory("beta").first!
 
         // Initially beta is newer
-        alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
-        betaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
+        alphaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+        betaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
         let grouping1 = SidebarGrouping.group(harness.documents)
         guard case .grouped(let groups1) = grouping1 else {
@@ -183,7 +183,7 @@ struct ReaderSidebarGroupingTests {
         #expect(groups1[0].displayName == "beta")
 
         // Now alpha gets modified more recently
-        alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 3000))
+        alphaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 3000))
 
         let grouping2 = SidebarGrouping.group(harness.documents)
         guard case .grouped(let groups2) = grouping2 else {
@@ -213,8 +213,8 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        harness.documents[0].readerStore.testSetHasUnacknowledgedExternalChange(true)
-        harness.documents[0].readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
+        harness.documents[0].documentStore.testSetHasUnacknowledgedExternalChange(true)
+        harness.documents[0].documentStore.externalChange.unacknowledgedExternalChangeKind = .modified
 
         let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states == [.externalChange])
@@ -227,9 +227,9 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        harness.documents[0].readerStore.testSetHasUnacknowledgedExternalChange(true)
-        harness.documents[0].readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
-        harness.documents[0].readerStore.testSetIsCurrentFileMissing(true)
+        harness.documents[0].documentStore.testSetHasUnacknowledgedExternalChange(true)
+        harness.documents[0].documentStore.externalChange.unacknowledgedExternalChangeKind = .modified
+        harness.documents[0].documentStore.testSetIsCurrentFileMissing(true)
 
         let states = SidebarGrouping.indicators(for: harness.documents)
         #expect(states == [.deletedExternalChange])
@@ -246,7 +246,7 @@ struct ReaderSidebarGroupingTests {
 
         // Give all groups the same mod date so only pinning affects order
         for doc in harness.documents {
-            doc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+            doc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         }
 
         let gammaPath = harness.directoryPath(for: "gamma")
@@ -273,9 +273,9 @@ struct ReaderSidebarGroupingTests {
         let gammaDoc = harness.documentsInSubdirectory("gamma").first!
         let betaDoc = harness.documentsInSubdirectory("beta").first!
 
-        alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 3000))
-        gammaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
-        betaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
+        alphaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 3000))
+        gammaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+        betaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
         let alphaPath = harness.directoryPath(for: "alpha")
         let gammaPath = harness.directoryPath(for: "gamma")
@@ -308,8 +308,8 @@ struct ReaderSidebarGroupingTests {
         let alphaDoc = harness.documentsInSubdirectory("alpha").first!
         let betaDoc = harness.documentsInSubdirectory("beta").first!
 
-        alphaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
-        betaDoc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
+        alphaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+        betaDoc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 2000))
 
         let grouping = SidebarGrouping.group(harness.documents, pinnedGroupIDs: [])
 
@@ -329,17 +329,17 @@ struct ReaderSidebarGroupingTests {
         defer { harness.cleanup() }
 
         // One doc has modified change, another has deleted-added change.
-        harness.documents[0].readerStore.testSetHasUnacknowledgedExternalChange(true)
-        harness.documents[0].readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
-        harness.documents[1].readerStore.testSetHasUnacknowledgedExternalChange(true)
-        harness.documents[1].readerStore.externalChange.unacknowledgedExternalChangeKind = .added
-        harness.documents[1].readerStore.testSetIsCurrentFileMissing(true)
+        harness.documents[0].documentStore.testSetHasUnacknowledgedExternalChange(true)
+        harness.documents[0].documentStore.externalChange.unacknowledgedExternalChangeKind = .modified
+        harness.documents[1].documentStore.testSetHasUnacknowledgedExternalChange(true)
+        harness.documents[1].documentStore.externalChange.unacknowledgedExternalChangeKind = .added
+        harness.documents[1].documentStore.testSetIsCurrentFileMissing(true)
 
         let documentStates = harness.documents.map { document in
             DocumentIndicatorState(
-                hasUnacknowledgedExternalChange: document.readerStore.externalChange.hasUnacknowledgedExternalChange,
-                isCurrentFileMissing: document.readerStore.document.isCurrentFileMissing,
-                unacknowledgedExternalChangeKind: document.readerStore.externalChange.unacknowledgedExternalChangeKind
+                hasUnacknowledgedExternalChange: document.documentStore.externalChange.hasUnacknowledgedExternalChange,
+                isCurrentFileMissing: document.documentStore.document.isCurrentFileMissing,
+                unacknowledgedExternalChangeKind: document.documentStore.externalChange.unacknowledgedExternalChangeKind
             )
         }
         #expect(documentStates.contains(.externalChange))
@@ -436,9 +436,9 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        harness.documentsInSubdirectory("src").first!.readerStore
+        harness.documentsInSubdirectory("src").first!.documentStore
             .testSetHasUnacknowledgedExternalChange(true)
-        harness.documentsInSubdirectory("src").first!.readerStore.externalChange.unacknowledgedExternalChangeKind = .modified
+        harness.documentsInSubdirectory("src").first!.documentStore.externalChange.unacknowledgedExternalChangeKind = .modified
 
         let grouping = SidebarGrouping.group(harness.documents)
 
@@ -460,9 +460,9 @@ struct ReaderSidebarGroupingTests {
         )
         defer { harness.cleanup() }
 
-        harness.documentsInSubdirectory("src").first!.readerStore
+        harness.documentsInSubdirectory("src").first!.documentStore
             .testSetHasUnacknowledgedExternalChange(true)
-        harness.documentsInSubdirectory("src").first!.readerStore.externalChange.unacknowledgedExternalChangeKind = .added
+        harness.documentsInSubdirectory("src").first!.documentStore.externalChange.unacknowledgedExternalChangeKind = .added
 
         let grouping = SidebarGrouping.group(harness.documents)
 

--- a/minimarkTests/Sidebar/SidebarDocumentListTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentListTests.swift
@@ -38,7 +38,7 @@ struct SidebarDocumentListTests {
             )
         )
         return SidebarDocumentController.Document(
-            id: id, readerStore: store, normalizedFileURL: normalizedURL
+            id: id, documentStore: store, normalizedFileURL: normalizedURL
         )
     }
 

--- a/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
+++ b/minimarkTests/Sidebar/SidebarGroupStateControllerTests.swift
@@ -50,7 +50,7 @@ struct SidebarGroupStateControllerTests {
         defer { harness.cleanup() }
 
         for doc in harness.documents {
-            doc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+            doc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         }
 
         let controller = SidebarGroupStateController()
@@ -352,7 +352,7 @@ struct SidebarGroupStateControllerTests {
         defer { harness.cleanup() }
 
         for doc in harness.documents {
-            doc.readerStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
+            doc.documentStore.testSetFileLastModifiedAt(Date(timeIntervalSince1970: 1000))
         }
 
         let betaPath = harness.directoryPath(for: "beta")

--- a/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateComputerTests.swift
@@ -37,7 +37,7 @@ struct SidebarRowStateComputerTests {
             )
         )
         return SidebarDocumentController.Document(
-            id: id, readerStore: store, normalizedFileURL: nil
+            id: id, documentStore: store, normalizedFileURL: nil
         )
     }
 
@@ -91,7 +91,7 @@ struct SidebarRowStateComputerTests {
         try "# Test".write(to: fileURL, atomically: true, encoding: .utf8)
 
         let doc = makeDocument(settingsStore: settings)
-        doc.readerStore.opener.open(at: fileURL, origin: .manual)
+        doc.documentStore.opener.open(at: fileURL, origin: .manual)
         let computer = SidebarRowStateComputer()
 
         // First rebuild — no previous state, so no pulse
@@ -99,7 +99,7 @@ struct SidebarRowStateComputerTests {
         #expect(computer.rowStates[doc.id]?.indicatorPulseToken == 0)
 
         // Simulate external change -> indicator becomes active
-        doc.readerStore.externalChange.noteObservedExternalChange()
+        doc.documentStore.externalChange.noteObservedExternalChange()
 
         // Second rebuild — indicator transitioned to active, pulse increments
         computer.rebuildAllRowStates(from: [doc])
@@ -179,7 +179,7 @@ struct SidebarRowStateComputerTests {
         try "# Test".write(to: fileURL, atomically: true, encoding: .utf8)
 
         let doc = makeDocument(settingsStore: settings)
-        doc.readerStore.opener.open(at: fileURL, origin: .manual)
+        doc.documentStore.opener.open(at: fileURL, origin: .manual)
         let computer = SidebarRowStateComputer()
         computer.rebuildAllRowStates(from: [doc])
 
@@ -188,7 +188,7 @@ struct SidebarRowStateComputerTests {
         computer.onRowStatesChanged = { _ in callbackFired = true }
         computer.onDockTileRowStatesChanged = { _ in dockTileCallbackFired = true }
 
-        doc.readerStore.externalChange.noteObservedExternalChange()
+        doc.documentStore.externalChange.noteObservedExternalChange()
         computer.updateRowStateIfNeeded(for: doc.id, in: [doc])
 
         #expect(callbackFired)

--- a/minimarkTests/Sidebar/SidebarRowStateTests.swift
+++ b/minimarkTests/Sidebar/SidebarRowStateTests.swift
@@ -92,7 +92,7 @@ struct SidebarRowStateDerivationTests {
         ))
 
         let docID = harness.controller.documents[0].id
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
         let initialState = harness.controller.rowStates[docID]
 
         // Let the observation tracking tasks start their first withObservationTracking call
@@ -121,7 +121,7 @@ struct SidebarRowStateDerivationTests {
         ))
 
         let docID = harness.controller.documents[0].id
-        let store = harness.controller.documents[0].readerStore
+        let store = harness.controller.documents[0].documentStore
 
         await Task.yield()
 

--- a/minimarkTests/Stores/Settings/ReaderPreferencesStoreTests.swift
+++ b/minimarkTests/Stores/Settings/ReaderPreferencesStoreTests.swift
@@ -77,7 +77,7 @@ struct ReaderPreferencesStoreTests {
         #expect(store.currentPreferences.baseFontSize == 12)
 
         store.resetFontSize()
-        #expect(store.currentPreferences.baseFontSize == ReaderSettings.default.baseFontSize)
+        #expect(store.currentPreferences.baseFontSize == Settings.default.baseFontSize)
     }
 
     @Test @MainActor func dismissHintUsesImmediatePersistence() {

--- a/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
+++ b/minimarkTests/TestSupport/ReaderSidebarGroupingTestHarness.swift
@@ -52,7 +52,7 @@ struct ReaderSidebarGroupingTestHarness {
                 store.testSetFileDisplayName(fileURL.lastPathComponent)
 
                 allDocuments.append(
-                    SidebarDocumentController.Document(id: UUID(), readerStore: store)
+                    SidebarDocumentController.Document(id: UUID(), documentStore: store)
                 )
             }
         }
@@ -63,7 +63,7 @@ struct ReaderSidebarGroupingTestHarness {
     func documentsInSubdirectory(_ name: String) -> [SidebarDocumentController.Document] {
         let subURL = temporaryDirectoryURL.appendingPathComponent(name, isDirectory: true)
         return documents.filter { doc in
-            doc.readerStore.document.fileURL?.deletingLastPathComponent().path(percentEncoded: false) == subURL.path(percentEncoded: false)
+            doc.documentStore.document.fileURL?.deletingLastPathComponent().path(percentEncoded: false) == subURL.path(percentEncoded: false)
         }
     }
 

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -96,11 +96,11 @@ final class TestFileWatcher: FileChangeWatching {
 
 @MainActor
 final class TestReaderSettingsStore: SettingsStoring {
-    var settingsPublisher: AnyPublisher<ReaderSettings, Never> {
+    var settingsPublisher: AnyPublisher<Settings, Never> {
         subject.eraseToAnyPublisher()
     }
 
-    var currentSettings: ReaderSettings {
+    var currentSettings: Settings {
         subject.value
     }
 
@@ -108,7 +108,7 @@ final class TestReaderSettingsStore: SettingsStoring {
     private(set) var recordedRecentWatchedFolders: [RecentWatchedFolder] = []
     private(set) var recordedRecentManuallyOpenedFiles: [RecentOpenedFile] = []
 
-    private let subject: CurrentValueSubject<ReaderSettings, Never>
+    private let subject: CurrentValueSubject<Settings, Never>
 
     init(
         autoRefreshOnExternalChange: Bool,
@@ -116,7 +116,7 @@ final class TestReaderSettingsStore: SettingsStoring {
         diffBaselineLookback: DiffBaselineLookback = .twoMinutes
     ) {
         subject = CurrentValueSubject(
-            ReaderSettings(
+            Settings(
                 appAppearance: .system,
                 readerTheme: .blackOnWhite,
                 syntaxTheme: .monokai,
@@ -166,7 +166,7 @@ final class TestReaderSettingsStore: SettingsStoring {
     }
 
     func resetFontSize() {
-        updateBaseFontSize(ReaderSettings.default.baseFontSize)
+        updateBaseFontSize(Settings.default.baseFontSize)
     }
 
     func updateNotificationsEnabled(_ isEnabled: Bool) {
@@ -942,7 +942,7 @@ struct ReaderSidebarControllerTestHarness {
         var createdFileWatchers: [TestFileWatcher] = []
         controller = SidebarDocumentController(
             settingsStore: settingsStore,
-            makeReaderStore: {
+            makeDocumentStore: {
                 let fileWatcher = TestFileWatcher()
                 createdFileWatchers.append(fileWatcher)
                 let settler = AutoOpenSettler(settlingInterval: 1.0)


### PR DESCRIPTION
Batch 5 of 6 for #355 — renames SwiftUI view and command types. Re-opened after the original #360 was auto-closed when its base branch was deleted during batch 4 merge.

## View / command renames

- `ReaderSidebarWorkspaceView` (+ metrics + private subviews `ReaderSidebarDocumentRow`, `ReaderSidebarGroupHeader`) → drop Reader
- `ReaderSettingsView` → `SettingsView`
- `ReaderWindowRootView` → `WindowRootView`
- `ReaderWindowCoordinator` → `WindowCoordinator`
- `ReaderWindowOpenAndWatchFlowSupport`, `ReaderWindowUITestFlowSupport` (+ `ReaderWindowUITestLaunchAction`) → drop Reader
- `ReaderTopBar` (+ `Metrics`, `Action`) → drop Reader
- `ReaderStatusFormatting` → `StatusFormatting`
- `ReaderThemeCard` (in `ThemeCardView.swift`) → `ThemeCard`
- `ReaderCommands` → **`AppCommands`** (file renamed to `AppCommands.swift`)

## Additional cleanup

- `ReaderSettings` → `Settings` (data struct in `SettingsStore.swift`, missed in batch 4)
- `BundledReaderRuntimeAssetResolver` → `BundledRuntimeAssetResolver`
- Property/var names coupled to the `DocumentStore` rename: `readerStore` → `documentStore`, `selectedReaderStore` → `selectedDocumentStore`, `effectiveReaderStores`, `firstReaderStore`, `makeReaderStore`, etc.

User-facing UI strings (`"Reader text colors"`, `"Reader Theme"`) left unchanged — they describe the reading experience, not type names.

## Test plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:minimarkTests` → ** TEST SUCCEEDED **
- [ ] CI green