### PR TITLE
Extract shared ObservationAsyncChange helper (#354)

### DIFF
--- a/minimark/Stores/SidebarObservationManager.swift
+++ b/minimark/Stores/SidebarObservationManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Observation
 
 @MainActor
 final class SidebarObservationManager {
@@ -44,7 +43,7 @@ final class SidebarObservationManager {
                 let store = document.documentStore
                 defer { store.externalChange.onStateChanged = nil }
                 while !Task.isCancelled {
-                    let cancelled = await Self.awaitObservationChange {
+                    let cancelled = await ObservationAsyncChange.next {
                         _ = store.document.fileDisplayName
                         _ = store.document.fileLastModifiedAt
                         _ = store.externalChange.lastExternalChangeAt
@@ -70,7 +69,7 @@ final class SidebarObservationManager {
         selectedStoreObservationTask?.cancel()
         selectedStoreObservationTask = Task { [weak self] in
             while !Task.isCancelled {
-                let cancelled = await Self.awaitObservationChange {
+                let cancelled = await ObservationAsyncChange.next {
                     _ = store.document.windowTitle
                     _ = store.document.fileURL
                     _ = store.externalChange.hasUnacknowledgedExternalChange
@@ -80,49 +79,6 @@ final class SidebarObservationManager {
                       self.selectedStoreBindingGeneration == generation else { break }
                 onChange()
             }
-        }
-    }
-
-    // MARK: - Observation helpers
-
-    private static func awaitObservationChange(
-        tracking: @escaping @MainActor () -> Void
-    ) async -> Bool {
-        let box = ObservationContinuationBox()
-        return await withTaskCancellationHandler {
-            await withUnsafeContinuation { continuation in
-                box.store(continuation)
-                if Task.isCancelled {
-                    box.resume(returning: true)
-                    return
-                }
-                withObservationTracking {
-                    tracking()
-                } onChange: {
-                    box.resume(returning: false)
-                }
-            }
-        } onCancel: {
-            box.resume(returning: true)
-        }
-    }
-
-    private final class ObservationContinuationBox: @unchecked Sendable {
-        private nonisolated(unsafe) var continuation: UnsafeContinuation<Bool, Never>?
-        private nonisolated let lock = NSLock()
-
-        nonisolated func store(_ continuation: UnsafeContinuation<Bool, Never>) {
-            lock.lock()
-            self.continuation = continuation
-            lock.unlock()
-        }
-
-        nonisolated func resume(returning value: Bool) {
-            lock.lock()
-            let c = continuation
-            continuation = nil
-            lock.unlock()
-            c?.resume(returning: value)
         }
     }
 }

--- a/minimark/Support/ObservationAsyncChange.swift
+++ b/minimark/Support/ObservationAsyncChange.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Observation
+
+enum ObservationAsyncChange {
+    @MainActor
+    static func next(
+        tracking: @escaping @MainActor () -> Void
+    ) async -> Bool {
+        let box = ContinuationBox()
+        return await withTaskCancellationHandler {
+            await withUnsafeContinuation { continuation in
+                box.store(continuation)
+                if Task.isCancelled {
+                    box.resume(returning: true)
+                    return
+                }
+                withObservationTracking {
+                    tracking()
+                } onChange: {
+                    box.resume(returning: false)
+                }
+            }
+        } onCancel: {
+            box.resume(returning: true)
+        }
+    }
+
+    private final class ContinuationBox: @unchecked Sendable {
+        private nonisolated(unsafe) var continuation: UnsafeContinuation<Bool, Never>?
+        private nonisolated let lock = NSLock()
+
+        nonisolated func store(_ continuation: UnsafeContinuation<Bool, Never>) {
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+        }
+
+        nonisolated func resume(returning value: Bool) {
+            lock.lock()
+            let c = continuation
+            continuation = nil
+            lock.unlock()
+            c?.resume(returning: value)
+        }
+    }
+}

--- a/minimark/Support/ObservationAsyncChange.swift
+++ b/minimark/Support/ObservationAsyncChange.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Observation
 
+@MainActor
 enum ObservationAsyncChange {
-    @MainActor
     static func next(
         tracking: @escaping @MainActor () -> Void
     ) async -> Bool {
@@ -31,15 +31,18 @@ enum ObservationAsyncChange {
 
         nonisolated func store(_ continuation: UnsafeContinuation<Bool, Never>) {
             lock.lock()
+            defer { lock.unlock() }
             self.continuation = continuation
-            lock.unlock()
         }
 
         nonisolated func resume(returning value: Bool) {
-            lock.lock()
-            let c = continuation
-            continuation = nil
-            lock.unlock()
+            let c: UnsafeContinuation<Bool, Never>?
+            do {
+                lock.lock()
+                defer { lock.unlock() }
+                c = continuation
+                continuation = nil
+            }
             c?.resume(returning: value)
         }
     }

--- a/minimark/Views/Content/ContentAreaObservationCoordinator.swift
+++ b/minimark/Views/Content/ContentAreaObservationCoordinator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Observation
 
 @MainActor
 final class ContentAreaObservationCoordinator {
@@ -78,7 +77,7 @@ final class ContentAreaObservationCoordinator {
         let task = Task { [weak viewModel] in
             while !Task.isCancelled {
                 guard let currentVM = viewModel else { return }
-                let cancelled = await Self.awaitObservationChange {
+                let cancelled = await ObservationAsyncChange.next {
                     _ = read(currentVM)
                 }
                 if cancelled { return }
@@ -91,46 +90,5 @@ final class ContentAreaObservationCoordinator {
             }
         }
         tasks.append(task)
-    }
-
-    private static func awaitObservationChange(
-        tracking: @escaping @MainActor () -> Void
-    ) async -> Bool {
-        let box = ObservationContinuationBox()
-        return await withTaskCancellationHandler {
-            await withUnsafeContinuation { continuation in
-                box.store(continuation)
-                if Task.isCancelled {
-                    box.resume(returning: true)
-                    return
-                }
-                withObservationTracking {
-                    tracking()
-                } onChange: {
-                    box.resume(returning: false)
-                }
-            }
-        } onCancel: {
-            box.resume(returning: true)
-        }
-    }
-
-    private final class ObservationContinuationBox: @unchecked Sendable {
-        private nonisolated(unsafe) var continuation: UnsafeContinuation<Bool, Never>?
-        private nonisolated let lock = NSLock()
-
-        nonisolated func store(_ continuation: UnsafeContinuation<Bool, Never>) {
-            lock.lock()
-            self.continuation = continuation
-            lock.unlock()
-        }
-
-        nonisolated func resume(returning value: Bool) {
-            lock.lock()
-            let c = continuation
-            continuation = nil
-            lock.unlock()
-            c?.resume(returning: value)
-        }
     }
 }


### PR DESCRIPTION
Closes #354.

## Summary
- Extracts the duplicated `awaitObservationChange` + `ObservationContinuationBox` out of `SidebarObservationManager` and `ContentAreaObservationCoordinator` into a single shared `ObservationAsyncChange` enum in `minimark/Support/`.
- Both coordinators now call `ObservationAsyncChange.next { ... }` instead of each carrying their own copy of the subtle cancellation / single-resume logic.
- Purely mechanical extraction — no behaviour change.

## Notes
- `ObservationAsyncChange.next` is `@MainActor` to match the original static methods (both lived on `@MainActor` classes).
- The `NSLock`-guarded `ContinuationBox` is nested privately inside the enum so the unsafe-Sendable surface stays contained.

## Test plan
- [x] `xcodebuild build` succeeds (Debug, macOS).
- [x] `xcodebuild test -only-testing:minimarkTests` — **TEST SUCCEEDED**.
- [ ] UI tests locally / in CI.