### PR TITLE
refactor(ContentView): inject controllers directly via DI (#339)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -4,6 +4,13 @@ import SwiftUI
 
 struct ContentView: View {
     let viewModel: ContentAreaViewModel
+    @Bindable var toc: TOCController
+    let document: DocumentController
+    let rendering: RenderingController
+    let sourceEditing: SourceEditingController
+    let settingsStore: SettingsStore
+    let surfaceViewModel: DocumentSurfaceViewModel
+    let folderWatchState: ContentViewFolderWatchState
 
     @Binding var isFolderWatchOptionsPresented: Bool
     @Binding var pendingFolderWatchOpenMode: FolderWatchOpenMode
@@ -12,10 +19,10 @@ struct ContentView: View {
 
     var body: some View {
         baseBody.modifier(ContentViewFocusedValues(
-            document: viewModel.document,
-            sourceEditing: viewModel.sourceEditing,
-            toc: viewModel.toc,
-            folderWatchState: viewModel.folderWatchState,
+            document: document,
+            sourceEditing: sourceEditing,
+            toc: toc,
+            folderWatchState: folderWatchState,
             onAction: viewModel.onAction,
             canNavigateChangedRegions: viewModel.canNavigateChangedRegions,
             onNavigateChangedRegion: viewModel.requestChangeNavigation,
@@ -44,10 +51,10 @@ struct ContentView: View {
     private var mainStack: some View {
         VStack(spacing: 0) {
             ContentStatusBanner(
-                isCurrentFileMissing: viewModel.document.isCurrentFileMissing,
-                fileDisplayName: viewModel.document.fileDisplayName,
-                errorMessage: viewModel.document.lastError?.message,
-                needsImageDirectoryAccess: viewModel.rendering.needsImageDirectoryAccess,
+                isCurrentFileMissing: document.isCurrentFileMissing,
+                fileDisplayName: document.fileDisplayName,
+                errorMessage: document.lastError?.message,
+                needsImageDirectoryAccess: rendering.needsImageDirectoryAccess,
                 topPadding: viewModel.overlayLayout.statusBannerTopPadding,
                 onGrantImageAccess: viewModel.promptForImageDirectoryAccess
             )
@@ -55,22 +62,22 @@ struct ContentView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .modifier(ContentDropModifier(
-            isBlockedFolderDropTargeted: viewModel.surfaceViewModel.dropTargeting.isBlockedFolderDropTargeted,
-            isDragTargeted: viewModel.surfaceViewModel.dropTargeting.isDragTargeted
+            isBlockedFolderDropTargeted: surfaceViewModel.dropTargeting.isBlockedFolderDropTargeted,
+            isDragTargeted: surfaceViewModel.dropTargeting.isDragTargeted
         ))
         .onAppear { viewModel.handleAppear() }
     }
 
     private var topBar: some View {
         TopBar(
-            document: viewModel.document,
-            sourceEditing: viewModel.sourceEditing,
+            document: document,
+            sourceEditing: sourceEditing,
             statusBarTimestamp: viewModel.statusBarTimestamp,
-            canStopFolderWatch: viewModel.folderWatchState.canStopFolderWatch,
-            apps: viewModel.document.openInApplications,
-            favoriteWatchedFolders: viewModel.folderWatchState.favoriteWatchedFolders,
-            recentWatchedFolders: viewModel.folderWatchState.recentWatchedFolders,
-            recentManuallyOpenedFiles: viewModel.folderWatchState.recentManuallyOpenedFiles,
+            canStopFolderWatch: folderWatchState.canStopFolderWatch,
+            apps: document.openInApplications,
+            favoriteWatchedFolders: folderWatchState.favoriteWatchedFolders,
+            recentWatchedFolders: folderWatchState.recentWatchedFolders,
+            recentManuallyOpenedFiles: folderWatchState.recentManuallyOpenedFiles,
             iconProvider: appIconImage(for:),
             onAction: viewModel.dispatchTopBarAction
         )
@@ -81,39 +88,36 @@ struct ContentView: View {
         documentSurfaceLayout
             .overlay(alignment: .topTrailing) { utilityRail }
             .overlayPreferenceValue(TOCButtonAnchorKey.self) { anchor in
-                if viewModel.toc.isVisible, let anchor {
+                if toc.isVisible, let anchor {
                     TOCOverlayView(
-                        headings: viewModel.toc.headings,
+                        headings: toc.headings,
                         buttonAnchor: anchor,
                         colorScheme: viewModel.overlayColorScheme,
-                        onDismiss: { viewModel.toc.isVisible = false },
-                        onSelectHeading: { viewModel.toc.scrollTo($0) }
+                        onDismiss: { toc.isVisible = false },
+                        onSelectHeading: { toc.scrollTo($0) }
                     )
                 }
             }
             .overlay(alignment: .topLeading) { changeNavigationOverlay }
             .animation(.easeOut(duration: 0.25), value: viewModel.canNavigateChangedRegions)
             .overlay(alignment: .top) { watchPillOverlay }
-            .animation(.easeOut(duration: 0.25), value: viewModel.folderWatchState.activeFolderWatch != nil)
+            .animation(.easeOut(duration: 0.25), value: folderWatchState.activeFolderWatch != nil)
     }
 
     private var utilityRail: some View {
         ContentUtilityRailView(
             state: ContentUtilityRailState(
-                hasFile: viewModel.document.fileURL != nil,
-                documentViewMode: viewModel.sourceEditing.documentViewMode,
-                showEditButton: viewModel.showSourceEditingControls && !viewModel.sourceEditing.isSourceEditing,
-                canStartSourceEditing: viewModel.document.hasOpenDocument
-                    && !viewModel.document.isCurrentFileMissing
-                    && !viewModel.sourceEditing.isSourceEditing,
-                hasTOCHeadings: !viewModel.toc.headings.isEmpty
+                hasFile: document.fileURL != nil,
+                documentViewMode: sourceEditing.documentViewMode,
+                showEditButton: viewModel.showSourceEditingControls && !sourceEditing.isSourceEditing,
+                canStartSourceEditing: document.hasOpenDocument
+                    && !document.isCurrentFileMissing
+                    && !sourceEditing.isSourceEditing,
+                hasTOCHeadings: !toc.headings.isEmpty
             ),
-            isTOCVisible: Binding(
-                get: { viewModel.toc.isVisible },
-                set: { viewModel.toc.isVisible = $0 }
-            ),
+            isTOCVisible: $toc.isVisible,
             onSetDocumentViewMode: { mode in
-                viewModel.sourceEditing.setViewMode(mode, hasOpenDocument: viewModel.document.hasOpenDocument)
+                sourceEditing.setViewMode(mode, hasOpenDocument: document.hasOpenDocument)
             },
             onStartSourceEditing: { viewModel.onAction(.startSourceEditing) }
         )
@@ -125,12 +129,12 @@ struct ContentView: View {
         ChangeNavigationOverlayView(
             state: ChangeNavigationState(
                 canNavigate: viewModel.canNavigateChangedRegions,
-                currentIndex: viewModel.surfaceViewModel.changeNavigation.currentIndex,
-                totalCount: viewModel.document.changedRegions.count
+                currentIndex: surfaceViewModel.changeNavigation.currentIndex,
+                totalCount: document.changedRegions.count
             ),
             insets: viewModel.overlayLayout.insets,
             colorScheme: viewModel.overlayColorScheme,
-            settingsStore: viewModel.settingsStore,
+            settingsStore: settingsStore,
             onNavigate: viewModel.requestChangeNavigation
         )
     }
@@ -138,10 +142,10 @@ struct ContentView: View {
     private var watchPillOverlay: some View {
         WatchPillOverlayView(
             state: WatchPillState(
-                activeFolderWatch: viewModel.folderWatchState.activeFolderWatch,
-                isCurrentWatchAFavorite: viewModel.folderWatchState.isCurrentWatchAFavorite,
-                canStop: viewModel.folderWatchState.canStopFolderWatch,
-                isAppearanceLocked: viewModel.folderWatchState.isAppearanceLocked
+                activeFolderWatch: folderWatchState.activeFolderWatch,
+                isCurrentWatchAFavorite: folderWatchState.isCurrentWatchAFavorite,
+                canStop: folderWatchState.canStopFolderWatch,
+                isAppearanceLocked: folderWatchState.isAppearanceLocked
             ),
             insets: viewModel.overlayLayout.insets,
             hasChangeNavigation: viewModel.canNavigateChangedRegions,
@@ -152,8 +156,8 @@ struct ContentView: View {
 
     private var documentSurfaceLayout: some View {
         DocumentSurfaceLayoutView(
-            documentViewMode: viewModel.sourceEditing.documentViewMode,
-            hasOpenDocument: viewModel.document.hasOpenDocument,
+            documentViewMode: sourceEditing.documentViewMode,
+            hasOpenDocument: document.hasOpenDocument,
             showsLoadingOverlay: viewModel.shouldShowDocumentLoadingOverlay,
             loadingOverlayHeadline: viewModel.loadingOverlayHeadline,
             loadingOverlaySubtitle: viewModel.loadingOverlaySubtitle,
@@ -162,11 +166,11 @@ struct ContentView: View {
             onDroppedFileURLs: viewModel.handleDroppedFileURLs,
             previewSurface: DocumentSurfaceHost(
                 configuration: viewModel.makeSurfaceConfiguration(for: .preview),
-                fallbackMarkdown: viewModel.document.sourceMarkdown
+                fallbackMarkdown: document.sourceMarkdown
             ),
             sourceSurface: DocumentSurfaceHost(
                 configuration: viewModel.makeSurfaceConfiguration(for: .source),
-                fallbackMarkdown: viewModel.document.sourceMarkdown
+                fallbackMarkdown: document.sourceMarkdown
             )
         )
     }
@@ -202,6 +206,20 @@ struct ContentView: View {
     let sourceEditing = SourceEditingController()
     let externalChange = ExternalChangeController()
     let toc = TOCController()
+    let surfaceViewModel = DocumentSurfaceViewModel()
+    let folderWatchState = ContentViewFolderWatchState(
+        activeFolderWatch: nil,
+        isFolderWatchInitialScanInProgress: false,
+        isFolderWatchInitialScanFailed: false,
+        canStopFolderWatch: false,
+        pendingFolderWatchURL: nil,
+        isCurrentWatchAFavorite: false,
+        favoriteWatchedFolders: [],
+        recentWatchedFolders: [],
+        recentManuallyOpenedFiles: [],
+        isAppearanceLocked: false,
+        effectiveReaderTheme: .blackOnWhite
+    )
 
     let viewModel = ContentAreaViewModel(
         document: document,
@@ -210,25 +228,20 @@ struct ContentView: View {
         externalChange: externalChange,
         toc: toc,
         settingsStore: settingsStore,
-        folderWatchState: ContentViewFolderWatchState(
-            activeFolderWatch: nil,
-            isFolderWatchInitialScanInProgress: false,
-            isFolderWatchInitialScanFailed: false,
-            canStopFolderWatch: false,
-            pendingFolderWatchURL: nil,
-            isCurrentWatchAFavorite: false,
-            favoriteWatchedFolders: [],
-            recentWatchedFolders: [],
-            recentManuallyOpenedFiles: [],
-            isAppearanceLocked: false,
-            effectiveReaderTheme: .blackOnWhite
-        ),
-        surfaceViewModel: DocumentSurfaceViewModel(),
+        folderWatchState: folderWatchState,
+        surfaceViewModel: surfaceViewModel,
         onAction: { _ in }
     )
 
     return ContentView(
         viewModel: viewModel,
+        toc: toc,
+        document: document,
+        rendering: rendering,
+        sourceEditing: sourceEditing,
+        settingsStore: settingsStore,
+        surfaceViewModel: surfaceViewModel,
+        folderWatchState: folderWatchState,
         isFolderWatchOptionsPresented: .constant(false),
         pendingFolderWatchOpenMode: .constant(.watchChangesOnly),
         pendingFolderWatchScope: .constant(.selectedFolderOnly),

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -73,6 +73,7 @@ private struct ContentAreaHost: View {
     @Binding var pendingFolderWatchScope: FolderWatchScope
     @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
 
+    @State private var surfaceViewModel: DocumentSurfaceViewModel
     @State private var viewModel: ContentAreaViewModel
 
     init(
@@ -93,6 +94,8 @@ private struct ContentAreaHost: View {
         self._pendingFolderWatchOpenMode = pendingFolderWatchOpenMode
         self._pendingFolderWatchScope = pendingFolderWatchScope
         self._pendingFolderWatchExcludedSubdirectoryPaths = pendingFolderWatchExcludedSubdirectoryPaths
+        let surfaceViewModel = DocumentSurfaceViewModel()
+        _surfaceViewModel = State(wrappedValue: surfaceViewModel)
         _viewModel = State(wrappedValue: ContentAreaViewModel(
             document: documentStore.document,
             rendering: documentStore.renderingController,
@@ -101,7 +104,7 @@ private struct ContentAreaHost: View {
             toc: documentStore.toc,
             settingsStore: settingsStore,
             folderWatchState: folderWatchState,
-            surfaceViewModel: DocumentSurfaceViewModel(),
+            surfaceViewModel: surfaceViewModel,
             onAction: onAction
         ))
     }
@@ -115,7 +118,7 @@ private struct ContentAreaHost: View {
             rendering: documentStore.renderingController,
             sourceEditing: documentStore.sourceEditingController,
             settingsStore: settingsStore,
-            surfaceViewModel: viewModel.surfaceViewModel,
+            surfaceViewModel: surfaceViewModel,
             folderWatchState: folderWatchState,
             isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
             pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -110,6 +110,13 @@ private struct ContentAreaHost: View {
         viewModel.applyHostInputs(folderWatchState: folderWatchState, onAction: onAction)
         return ContentView(
             viewModel: viewModel,
+            toc: documentStore.toc,
+            document: documentStore.document,
+            rendering: documentStore.renderingController,
+            sourceEditing: documentStore.sourceEditingController,
+            settingsStore: settingsStore,
+            surfaceViewModel: viewModel.surfaceViewModel,
+            folderWatchState: folderWatchState,
             isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
             pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
             pendingFolderWatchScope: $pendingFolderWatchScope,


### PR DESCRIPTION
Closes #339.

## Summary

`ContentView` no longer reaches through `ContentAreaViewModel` to access controllers. Instead, it declares the controllers it reads as explicit init parameters and receives them from its composition root (`ContentAreaHost`). Constructor DI replaces the facade pattern the original issue proposed.

## Design divergence from the original issue

The original acceptance criteria proposed making all 8 VM controller fields `private` and exposing ~30 narrow projections. That would have re-created the pass-through/facade pattern removed in #328 when the old `ReaderStore` facades were deleted.

Since the controllers are already SRP-compliant `@Observable` types, and every other subview in this area (`TopBar`, `ContentViewFocusedValues`, `ChangeNavigationOverlayView`, `ContentDropModifier`, `DocumentSurfaceLayoutView`, `ContentUtilityRailView`, `WatchPillOverlayView`) already takes the specific controller it needs via DI, the real gap was `ContentView` itself. The fix brings `ContentView` in line with the rest of the subview DI.

Detailed rationale in issue comments: https://github.com/larspohlmann/markdownobserver/issues/339#issuecomment-4270487118

## What changed

- `ContentView` now takes `document`, `rendering`, `sourceEditing`, `toc` (as `@Bindable`), `settingsStore`, `surfaceViewModel`, and `folderWatchState` as explicit init params. Body reads them directly — zero chained `viewModel.<controller>.<x>` access.
- `ContentAreaViewModel` shape is unchanged — controllers stay public `let`s, no new projection getters, no new tests needed (the VM's API didn't change).
- `ContentAreaHost` passes the same controller references to both the VM and to `ContentView`, so they observe the same instances.
- The hand-rolled `Binding(get: { viewModel.toc.isVisible }, set: { viewModel.toc.isVisible = $0 })` is now just `$toc.isVisible` via `@Bindable`.

Two files touched: `minimark/ContentView.swift`, `minimark/Views/Content/ContentViewAdapter.swift`.

## Acceptance (reframed)

- [x] ContentView and its subviews do not reach through the VM for controller state — achieved via constructor DI.
- [x] `ContentAreaViewModelTests` still green (VM API unchanged).
- [x] No user-visible behaviour change.
- [ ] ~~All `let` controller fields on `ContentAreaViewModel` are `private`.~~ — superseded by the DI approach.

## Follow-up

#368 tracks constructor parameter sprawl in the same hierarchy (unrelated to this PR's DI direction — it's about collapsing pass-through layers).

## Test plan

- [x] `xcodebuild -project minimark.xcodeproj -scheme minimark -configuration Debug build` — succeeds
- [x] `xcodebuild test -only-testing:minimarkTests` — full suite green
- [x] `grep "viewModel\\.\\(document\\|rendering\\|sourceEditing\\|externalChange\\|toc\\|folderWatchState\\|surfaceViewModel\\)\\." minimark/ContentView.swift` — zero matches
- [ ] Manual smoke test: open document, toggle view modes, drop folder, start/stop source editing, open/dismiss TOC, navigate changed regions