### PR TITLE
Eliminate pass-through in ContentView hierarchy via @Environment (#368)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -4,32 +4,26 @@ import SwiftUI
 
 struct ContentView: View {
     let viewModel: ContentAreaViewModel
-    @Bindable var toc: TOCController
-    let document: DocumentController
-    let rendering: RenderingController
-    let sourceEditing: SourceEditingController
+    let documentStore: DocumentStore
     let settingsStore: SettingsStore
     let surfaceViewModel: DocumentSurfaceViewModel
     let folderWatchState: ContentViewFolderWatchState
 
-    @Binding var isFolderWatchOptionsPresented: Bool
-    @Binding var pendingFolderWatchOpenMode: FolderWatchOpenMode
-    @Binding var pendingFolderWatchScope: FolderWatchScope
-    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
+    private var toc: TOCController { documentStore.toc }
+    private var document: DocumentController { documentStore.document }
+    private var rendering: RenderingController { documentStore.renderingController }
+    private var sourceEditing: SourceEditingController { documentStore.sourceEditingController }
 
     var body: some View {
-        baseBody.modifier(ContentViewFocusedValues(
-            document: document,
-            sourceEditing: sourceEditing,
-            toc: toc,
+        @Bindable var toc = toc
+        return baseBody.modifier(ContentViewFocusedValues(
+            documentStore: documentStore,
             folderWatchState: folderWatchState,
             onAction: viewModel.onAction,
-            canNavigateChangedRegions: viewModel.canNavigateChangedRegions,
-            onNavigateChangedRegion: viewModel.requestChangeNavigation,
-            isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
-            pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
-            pendingFolderWatchScope: $pendingFolderWatchScope,
-            pendingFolderWatchExcludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths
+            changedRegionNavigation: ChangedRegionNavigationAction(
+                canNavigate: viewModel.canNavigateChangedRegions,
+                navigate: viewModel.requestChangeNavigation
+            )
         ))
     }
 
@@ -70,14 +64,10 @@ struct ContentView: View {
 
     private var topBar: some View {
         TopBar(
-            document: document,
-            sourceEditing: sourceEditing,
+            documentStore: documentStore,
             statusBarTimestamp: viewModel.statusBarTimestamp,
-            canStopFolderWatch: folderWatchState.canStopFolderWatch,
+            folderWatchState: folderWatchState,
             apps: document.openInApplications,
-            favoriteWatchedFolders: folderWatchState.favoriteWatchedFolders,
-            recentWatchedFolders: folderWatchState.recentWatchedFolders,
-            recentManuallyOpenedFiles: folderWatchState.recentManuallyOpenedFiles,
             iconProvider: appIconImage(for:),
             onAction: viewModel.dispatchTopBarAction
         )
@@ -105,7 +95,8 @@ struct ContentView: View {
     }
 
     private var utilityRail: some View {
-        ContentUtilityRailView(
+        @Bindable var toc = toc
+        return ContentUtilityRailView(
             state: ContentUtilityRailState(
                 hasFile: document.fileURL != nil,
                 documentViewMode: sourceEditing.documentViewMode,
@@ -178,34 +169,29 @@ struct ContentView: View {
 
 #Preview {
     let settingsStore = SettingsStore()
-    let settler = AutoOpenSettler(settlingInterval: 1.0)
     let securityScopeResolver = SecurityScopeResolver(
         securityScope: SecurityScopedResourceAccess(),
         settingsStore: settingsStore,
         requestWatchedFolderReauthorization: { _ in nil }
     )
-    let fileDeps = FileDependencies(
-        watcher: FileChangeWatcher(),
-        io: DocumentIOService(),
-        actions: FileActionService()
-    )
-    let renderingDeps = RenderingDependencies(
-        renderer: MarkdownRenderingService(),
-        differ: ChangedRegionDiffer()
-    )
-    let document = DocumentController(
-        fileDependencies: fileDeps,
-        settingsStore: settingsStore,
-        settler: settler
-    )
-    let rendering = RenderingController(
-        renderingDependencies: renderingDeps,
+    let documentStore = DocumentStore(
+        rendering: RenderingDependencies(
+            renderer: MarkdownRenderingService(),
+            differ: ChangedRegionDiffer()
+        ),
+        file: FileDependencies(
+            watcher: FileChangeWatcher(),
+            io: DocumentIOService(),
+            actions: FileActionService()
+        ),
+        folderWatch: FolderWatchDependencies(
+            autoOpenPlanner: FolderWatchAutoOpenPlanner(),
+            settler: AutoOpenSettler(settlingInterval: 1.0),
+            systemNotifier: SystemNotifier.shared
+        ),
         settingsStore: settingsStore,
         securityScopeResolver: securityScopeResolver
     )
-    let sourceEditing = SourceEditingController()
-    let externalChange = ExternalChangeController()
-    let toc = TOCController()
     let surfaceViewModel = DocumentSurfaceViewModel()
     let folderWatchState = ContentViewFolderWatchState(
         activeFolderWatch: nil,
@@ -222,29 +208,33 @@ struct ContentView: View {
     )
 
     let viewModel = ContentAreaViewModel(
-        document: document,
-        rendering: rendering,
-        sourceEditing: sourceEditing,
-        externalChange: externalChange,
-        toc: toc,
+        document: documentStore.document,
+        rendering: documentStore.renderingController,
+        sourceEditing: documentStore.sourceEditingController,
+        externalChange: documentStore.externalChange,
+        toc: documentStore.toc,
         settingsStore: settingsStore,
         folderWatchState: folderWatchState,
         surfaceViewModel: surfaceViewModel,
         onAction: { _ in }
     )
 
+    let sidebarDocumentController = SidebarDocumentController(settingsStore: settingsStore)
+    let appearanceController = WindowAppearanceController(settingsStore: settingsStore)
+    let folderWatchFlow = FolderWatchFlowController(
+        settingsStore: settingsStore,
+        sidebarDocumentController: sidebarDocumentController
+    )
+
     return ContentView(
         viewModel: viewModel,
-        toc: toc,
-        document: document,
-        rendering: rendering,
-        sourceEditing: sourceEditing,
+        documentStore: documentStore,
         settingsStore: settingsStore,
         surfaceViewModel: surfaceViewModel,
-        folderWatchState: folderWatchState,
-        isFolderWatchOptionsPresented: .constant(false),
-        pendingFolderWatchOpenMode: .constant(.watchChangesOnly),
-        pendingFolderWatchScope: .constant(.selectedFolderOnly),
-        pendingFolderWatchExcludedSubdirectoryPaths: .constant([])
+        folderWatchState: folderWatchState
     )
+    .environment(settingsStore)
+    .environment(appearanceController)
+    .environment(sidebarDocumentController)
+    .environment(folderWatchFlow)
 }

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -15,8 +15,7 @@ struct ContentView: View {
     private var sourceEditing: SourceEditingController { documentStore.sourceEditingController }
 
     var body: some View {
-        @Bindable var toc = toc
-        return baseBody.modifier(ContentViewFocusedValues(
+        baseBody.modifier(ContentViewFocusedValues(
             documentStore: documentStore,
             folderWatchState: folderWatchState,
             onAction: viewModel.onAction,

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -2,7 +2,6 @@
 import AppKit
 import Foundation
 import Observation
-import SwiftUI
 
 @MainActor
 @Observable
@@ -74,47 +73,6 @@ final class FolderWatchFlowController {
         guard var request = pendingFolderWatchRequest else { return }
         update(&request)
         pendingFolderWatchRequest = request
-    }
-
-    // MARK: - Sheet Bindings
-
-    /// Binding to the pending request's open mode, falling back to the default value when
-    /// no pending request exists. Used by `FolderWatchOptionsSheet`.
-    var pendingOpenModeBinding: Binding<FolderWatchOpenMode> {
-        Binding(
-            get: { [self] in
-                pendingFolderWatchRequest?.options.openMode ?? FolderWatchOptions.default.openMode
-            },
-            set: { [self] newValue in
-                updatePendingRequest { $0.options.openMode = newValue }
-            }
-        )
-    }
-
-    /// Binding to the pending request's scope, falling back to the default value when
-    /// no pending request exists.
-    var pendingScopeBinding: Binding<FolderWatchScope> {
-        Binding(
-            get: { [self] in
-                pendingFolderWatchRequest?.options.scope ?? FolderWatchOptions.default.scope
-            },
-            set: { [self] newValue in
-                updatePendingRequest { $0.options.scope = newValue }
-            }
-        )
-    }
-
-    /// Binding to the pending request's excluded subdirectory paths, falling back to an
-    /// empty array when no pending request exists.
-    var pendingExcludedSubdirectoryPathsBinding: Binding<[String]> {
-        Binding(
-            get: { [self] in
-                pendingFolderWatchRequest?.options.excludedSubdirectoryPaths ?? []
-            },
-            set: { [self] newValue in
-                updatePendingRequest { $0.options.excludedSubdirectoryPaths = newValue }
-            }
-        )
     }
 
     // MARK: - Shared State Sync

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -2,6 +2,7 @@
 import AppKit
 import Foundation
 import Observation
+import SwiftUI
 
 @MainActor
 @Observable
@@ -73,6 +74,47 @@ final class FolderWatchFlowController {
         guard var request = pendingFolderWatchRequest else { return }
         update(&request)
         pendingFolderWatchRequest = request
+    }
+
+    // MARK: - Sheet Bindings
+
+    /// Binding to the pending request's open mode, falling back to the default value when
+    /// no pending request exists. Used by `FolderWatchOptionsSheet`.
+    var pendingOpenModeBinding: Binding<FolderWatchOpenMode> {
+        Binding(
+            get: { [self] in
+                pendingFolderWatchRequest?.options.openMode ?? FolderWatchOptions.default.openMode
+            },
+            set: { [self] newValue in
+                updatePendingRequest { $0.options.openMode = newValue }
+            }
+        )
+    }
+
+    /// Binding to the pending request's scope, falling back to the default value when
+    /// no pending request exists.
+    var pendingScopeBinding: Binding<FolderWatchScope> {
+        Binding(
+            get: { [self] in
+                pendingFolderWatchRequest?.options.scope ?? FolderWatchOptions.default.scope
+            },
+            set: { [self] newValue in
+                updatePendingRequest { $0.options.scope = newValue }
+            }
+        )
+    }
+
+    /// Binding to the pending request's excluded subdirectory paths, falling back to an
+    /// empty array when no pending request exists.
+    var pendingExcludedSubdirectoryPathsBinding: Binding<[String]> {
+        Binding(
+            get: { [self] in
+                pendingFolderWatchRequest?.options.excludedSubdirectoryPaths ?? []
+            },
+            set: { [self] newValue in
+                updatePendingRequest { $0.options.excludedSubdirectoryPaths = newValue }
+            }
+        )
     }
 
     // MARK: - Shared State Sync

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -1,39 +1,32 @@
 import SwiftUI
 
 /// Narrows the `@Observable` observation scope for `ContentView`: reads from the sidebar
-/// controller, settings store, and appearance controller are tracked only for this view's
-/// body, not for the root or sidebar workspace view.
+/// controller, settings store, folder-watch flow, and appearance controller are tracked
+/// only for this view's body, not for the root or sidebar workspace view.
 struct ContentViewAdapter: View {
     let documentStore: DocumentStore
-    let sidebarDocumentController: SidebarDocumentController
-    let settingsStore: SettingsStore
-    let appearanceController: WindowAppearanceController
-
-    let sharedFolderWatchSession: FolderWatchSession?
-    let canStopSharedFolderWatch: Bool
-    let pendingFolderWatchURL: URL?
-
     let onAction: (ContentViewAction) -> Void
 
-    @Binding var isFolderWatchOptionsPresented: Bool
-    @Binding var pendingFolderWatchOpenMode: FolderWatchOpenMode
-    @Binding var pendingFolderWatchScope: FolderWatchScope
-    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
+    @Environment(SettingsStore.self) private var settingsStore
+    @Environment(WindowAppearanceController.self) private var appearanceController
+    @Environment(SidebarDocumentController.self) private var sidebarDocumentController
+    @Environment(FolderWatchFlowController.self) private var folderWatchFlow
 
     var body: some View {
         let favorites = settingsStore.currentSettings.favoriteWatchedFolders
+        let session = folderWatchFlow.sharedFolderWatchSession
         let isCurrentWatchAFavorite: Bool = {
-            guard let session = sharedFolderWatchSession else { return false }
+            guard let session else { return false }
             let normalizedPath = FileRouting.normalizedFileURL(session.folderURL).path
             return favorites.contains { $0.matches(folderPath: normalizedPath, options: session.options) }
         }()
 
         let folderWatchState = ContentViewFolderWatchState(
-            activeFolderWatch: sharedFolderWatchSession,
+            activeFolderWatch: session,
             isFolderWatchInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
             isFolderWatchInitialScanFailed: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
-            canStopFolderWatch: canStopSharedFolderWatch,
-            pendingFolderWatchURL: pendingFolderWatchURL,
+            canStopFolderWatch: folderWatchFlow.canStopSharedFolderWatch,
+            pendingFolderWatchURL: folderWatchFlow.pendingFolderWatchURL,
             isCurrentWatchAFavorite: isCurrentWatchAFavorite,
             favoriteWatchedFolders: favorites,
             recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
@@ -46,11 +39,7 @@ struct ContentViewAdapter: View {
             documentStore: documentStore,
             settingsStore: settingsStore,
             folderWatchState: folderWatchState,
-            onAction: onAction,
-            isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
-            pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
-            pendingFolderWatchScope: $pendingFolderWatchScope,
-            pendingFolderWatchExcludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths
+            onAction: onAction
         )
         // Remount the host (and its @State viewModel) when the selected
         // DocumentStore changes; otherwise SwiftUI preserves @State across
@@ -68,11 +57,6 @@ private struct ContentAreaHost: View {
     let folderWatchState: ContentViewFolderWatchState
     let onAction: (ContentViewAction) -> Void
 
-    @Binding var isFolderWatchOptionsPresented: Bool
-    @Binding var pendingFolderWatchOpenMode: FolderWatchOpenMode
-    @Binding var pendingFolderWatchScope: FolderWatchScope
-    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
-
     @State private var surfaceViewModel: DocumentSurfaceViewModel
     @State private var viewModel: ContentAreaViewModel
 
@@ -80,20 +64,12 @@ private struct ContentAreaHost: View {
         documentStore: DocumentStore,
         settingsStore: SettingsStore,
         folderWatchState: ContentViewFolderWatchState,
-        onAction: @escaping (ContentViewAction) -> Void,
-        isFolderWatchOptionsPresented: Binding<Bool>,
-        pendingFolderWatchOpenMode: Binding<FolderWatchOpenMode>,
-        pendingFolderWatchScope: Binding<FolderWatchScope>,
-        pendingFolderWatchExcludedSubdirectoryPaths: Binding<[String]>
+        onAction: @escaping (ContentViewAction) -> Void
     ) {
         self.documentStore = documentStore
         self.settingsStore = settingsStore
         self.folderWatchState = folderWatchState
         self.onAction = onAction
-        self._isFolderWatchOptionsPresented = isFolderWatchOptionsPresented
-        self._pendingFolderWatchOpenMode = pendingFolderWatchOpenMode
-        self._pendingFolderWatchScope = pendingFolderWatchScope
-        self._pendingFolderWatchExcludedSubdirectoryPaths = pendingFolderWatchExcludedSubdirectoryPaths
         let surfaceViewModel = DocumentSurfaceViewModel()
         _surfaceViewModel = State(wrappedValue: surfaceViewModel)
         _viewModel = State(wrappedValue: ContentAreaViewModel(
@@ -113,17 +89,10 @@ private struct ContentAreaHost: View {
         viewModel.applyHostInputs(folderWatchState: folderWatchState, onAction: onAction)
         return ContentView(
             viewModel: viewModel,
-            toc: documentStore.toc,
-            document: documentStore.document,
-            rendering: documentStore.renderingController,
-            sourceEditing: documentStore.sourceEditingController,
+            documentStore: documentStore,
             settingsStore: settingsStore,
             surfaceViewModel: surfaceViewModel,
-            folderWatchState: folderWatchState,
-            isFolderWatchOptionsPresented: $isFolderWatchOptionsPresented,
-            pendingFolderWatchOpenMode: $pendingFolderWatchOpenMode,
-            pendingFolderWatchScope: $pendingFolderWatchScope,
-            pendingFolderWatchExcludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths
+            folderWatchState: folderWatchState
         )
     }
 }

--- a/minimark/Views/Content/ContentViewFocusedValues.swift
+++ b/minimark/Views/Content/ContentViewFocusedValues.swift
@@ -12,6 +12,33 @@ struct ContentViewFocusedValues: ViewModifier {
     private var sourceEditing: SourceEditingController { documentStore.sourceEditingController }
     private var toc: TOCController { documentStore.toc }
 
+    private var pendingOpenModeBinding: Binding<FolderWatchOpenMode> {
+        Binding(
+            get: { folderWatchFlow.pendingFolderWatchRequest?.options.openMode ?? FolderWatchOptions.default.openMode },
+            set: { newValue in
+                folderWatchFlow.updatePendingRequest { $0.options.openMode = newValue }
+            }
+        )
+    }
+
+    private var pendingScopeBinding: Binding<FolderWatchScope> {
+        Binding(
+            get: { folderWatchFlow.pendingFolderWatchRequest?.options.scope ?? FolderWatchOptions.default.scope },
+            set: { newValue in
+                folderWatchFlow.updatePendingRequest { $0.options.scope = newValue }
+            }
+        )
+    }
+
+    private var pendingExcludedSubdirectoryPathsBinding: Binding<[String]> {
+        Binding(
+            get: { folderWatchFlow.pendingFolderWatchRequest?.options.excludedSubdirectoryPaths ?? [] },
+            set: { newValue in
+                folderWatchFlow.updatePendingRequest { $0.options.excludedSubdirectoryPaths = newValue }
+            }
+        )
+    }
+
     private func openOrAppendDocument(_ fileURL: URL) {
         let strategy: FileOpenRequest.SlotStrategy =
             document.fileURL == nil ? .replaceSelectedSlot : .alwaysAppend
@@ -122,9 +149,9 @@ struct ContentViewFocusedValues: ViewModifier {
             .sheet(isPresented: $folderWatchFlow.isFolderWatchOptionsPresented) {
                 FolderWatchOptionsSheet(
                     folderURL: folderWatchState.pendingFolderWatchURL,
-                    openMode: folderWatchFlow.pendingOpenModeBinding,
-                    scope: folderWatchFlow.pendingScopeBinding,
-                    excludedSubdirectoryPaths: folderWatchFlow.pendingExcludedSubdirectoryPathsBinding,
+                    openMode: pendingOpenModeBinding,
+                    scope: pendingScopeBinding,
+                    excludedSubdirectoryPaths: pendingExcludedSubdirectoryPathsBinding,
                     onCancel: { onAction(.cancelFolderWatch) },
                     onConfirm: { options in onAction(.confirmFolderWatch(options)) }
                 )

--- a/minimark/Views/Content/ContentViewFocusedValues.swift
+++ b/minimark/Views/Content/ContentViewFocusedValues.swift
@@ -1,17 +1,16 @@
 import SwiftUI
 
 struct ContentViewFocusedValues: ViewModifier {
-    let document: DocumentController
-    let sourceEditing: SourceEditingController
-    let toc: TOCController
+    let documentStore: DocumentStore
     let folderWatchState: ContentViewFolderWatchState
     let onAction: (ContentViewAction) -> Void
-    let canNavigateChangedRegions: Bool
-    let onNavigateChangedRegion: (ChangedRegionNavigationDirection) -> Void
-    @Binding var isFolderWatchOptionsPresented: Bool
-    @Binding var pendingFolderWatchOpenMode: FolderWatchOpenMode
-    @Binding var pendingFolderWatchScope: FolderWatchScope
-    @Binding var pendingFolderWatchExcludedSubdirectoryPaths: [String]
+    let changedRegionNavigation: ChangedRegionNavigationAction
+
+    @Environment(FolderWatchFlowController.self) private var folderWatchFlow
+
+    private var document: DocumentController { documentStore.document }
+    private var sourceEditing: SourceEditingController { documentStore.sourceEditingController }
+    private var toc: TOCController { documentStore.toc }
 
     private func openOrAppendDocument(_ fileURL: URL) {
         let strategy: FileOpenRequest.SlotStrategy =
@@ -24,7 +23,8 @@ struct ContentViewFocusedValues: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        content
+        @Bindable var folderWatchFlow = folderWatchFlow
+        return content
             .focusedValue(
                 \.openDocumentInCurrentWindow,
                 OpenDocumentInCurrentWindowAction { fileURL in
@@ -106,10 +106,7 @@ struct ContentViewFocusedValues: ViewModifier {
             )
             .focusedValue(
                 \.changedRegionNavigation,
-                ChangedRegionNavigationAction(
-                    canNavigate: canNavigateChangedRegions,
-                    navigate: onNavigateChangedRegion
-                )
+                changedRegionNavigation
             )
             .focusedValue(
                 \.toggleTOC,
@@ -118,16 +115,16 @@ struct ContentViewFocusedValues: ViewModifier {
                     toggle: { toc.toggle() }
                 )
             )
-            .onChange(of: isFolderWatchOptionsPresented) { _, isPresented in
+            .onChange(of: folderWatchFlow.isFolderWatchOptionsPresented) { _, isPresented in
                 guard !isPresented else { return }
                 onAction(.cancelFolderWatch)
             }
-            .sheet(isPresented: $isFolderWatchOptionsPresented) {
+            .sheet(isPresented: $folderWatchFlow.isFolderWatchOptionsPresented) {
                 FolderWatchOptionsSheet(
                     folderURL: folderWatchState.pendingFolderWatchURL,
-                    openMode: $pendingFolderWatchOpenMode,
-                    scope: $pendingFolderWatchScope,
-                    excludedSubdirectoryPaths: $pendingFolderWatchExcludedSubdirectoryPaths,
+                    openMode: folderWatchFlow.pendingOpenModeBinding,
+                    scope: folderWatchFlow.pendingScopeBinding,
+                    excludedSubdirectoryPaths: folderWatchFlow.pendingExcludedSubdirectoryPathsBinding,
                     onCancel: { onAction(.cancelFolderWatch) },
                     onConfirm: { options in onAction(.confirmFolderWatch(options)) }
                 )

--- a/minimark/Views/Content/TopBar.swift
+++ b/minimark/Views/Content/TopBar.swift
@@ -66,16 +66,15 @@ enum TopBarAction {
 }
 
 struct TopBar: View {
-    let document: DocumentController
-    let sourceEditing: SourceEditingController
+    let documentStore: DocumentStore
     let statusBarTimestamp: StatusBarTimestamp?
-    let canStopFolderWatch: Bool
+    let folderWatchState: ContentViewFolderWatchState
     let apps: [ExternalApplication]
-    let favoriteWatchedFolders: [FavoriteWatchedFolder]
-    let recentWatchedFolders: [RecentWatchedFolder]
-    let recentManuallyOpenedFiles: [RecentOpenedFile]
     let iconProvider: (ExternalApplication) -> NSImage?
     let onAction: (TopBarAction) -> Void
+
+    private var document: DocumentController { documentStore.document }
+    private var sourceEditing: SourceEditingController { documentStore.sourceEditingController }
 
     private enum Metrics {
         static let barHorizontalPadding: CGFloat = 12
@@ -101,11 +100,11 @@ struct TopBar: View {
 
                 OpenInMenuButton(
                     hasFile: document.fileURL != nil,
-                    hasActiveFolderWatch: canStopFolderWatch,
+                    hasActiveFolderWatch: folderWatchState.canStopFolderWatch,
                     apps: apps,
-                    favoriteWatchedFolders: favoriteWatchedFolders,
-                    recentWatchedFolders: recentWatchedFolders,
-                    recentManuallyOpenedFiles: recentManuallyOpenedFiles,
+                    favoriteWatchedFolders: folderWatchState.favoriteWatchedFolders,
+                    recentWatchedFolders: folderWatchState.recentWatchedFolders,
+                    recentManuallyOpenedFiles: folderWatchState.recentManuallyOpenedFiles,
                     iconProvider: iconProvider,
                     onAction: { menuAction in
                         if let topBarAction = TopBarAction(menuAction) {
@@ -149,7 +148,7 @@ struct TopBar: View {
         }
         .sheet(isPresented: $isEditingFavorites) {
             EditFavoritesSheet(
-                favorites: favoriteWatchedFolders,
+                favorites: folderWatchState.favoriteWatchedFolders,
                 onAction: { action in
                     switch action {
                     case .rename(let id, let name):

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -51,51 +51,18 @@ struct WindowRootView: View {
         return effectiveMode.sidebarPlacement
     }
 
-    private var pendingFolderWatchOpenModeBinding: Binding<FolderWatchOpenMode> {
-        Binding(
-            get: { [folderWatchFlowController] in
-                folderWatchFlowController.pendingFolderWatchRequest?.options.openMode ?? FolderWatchOptions.default.openMode
-            },
-            set: { [folderWatchFlowController] newValue in
-                folderWatchFlowController.updatePendingRequest { request in
-                    request.options.openMode = newValue
-                }
-            }
-        )
-    }
-
-    private var pendingFolderWatchScopeBinding: Binding<FolderWatchScope> {
-        Binding(
-            get: { [folderWatchFlowController] in
-                folderWatchFlowController.pendingFolderWatchRequest?.options.scope ?? FolderWatchOptions.default.scope
-            },
-            set: { [folderWatchFlowController] newValue in
-                folderWatchFlowController.updatePendingRequest { request in
-                    request.options.scope = newValue
-                }
-            }
-        )
-    }
-
-    private var pendingFolderWatchExcludedSubdirectoryPathsBinding: Binding<[String]> {
-        Binding(
-            get: { [folderWatchFlowController] in
-                folderWatchFlowController.pendingFolderWatchRequest?.options.excludedSubdirectoryPaths ?? []
-            },
-            set: { [folderWatchFlowController] newValue in
-                folderWatchFlowController.updatePendingRequest { request in
-                    request.options.excludedSubdirectoryPaths = newValue
-                }
-            }
-        )
-    }
-
     var body: some View {
-        if windowCoordinator.hasCompletedWindowPhase {
-            commandNotificationAwareView(windowLifecycleChangeObservers(windowLifecycleBaseView(rootContent)))
-        } else {
-            windowShell
+        Group {
+            if windowCoordinator.hasCompletedWindowPhase {
+                commandNotificationAwareView(windowLifecycleChangeObservers(windowLifecycleBaseView(rootContent)))
+            } else {
+                windowShell
+            }
         }
+        .environment(settingsStore)
+        .environment(appearanceController)
+        .environment(sidebarDocumentController)
+        .environment(folderWatchFlowController)
     }
 
     private var windowShell: some View {
@@ -410,22 +377,11 @@ struct WindowRootView: View {
     }
 
     private func contentView(for store: DocumentStore) -> some View {
-        @Bindable var folderWatchFlow = folderWatchFlowController
-        return ContentViewAdapter(
+        ContentViewAdapter(
             documentStore: store,
-            sidebarDocumentController: sidebarDocumentController,
-            settingsStore: settingsStore,
-            appearanceController: appearanceController,
-            sharedFolderWatchSession: folderWatchFlowController.sharedFolderWatchSession,
-            canStopSharedFolderWatch: folderWatchFlowController.canStopSharedFolderWatch,
-            pendingFolderWatchURL: folderWatchFlowController.pendingFolderWatchURL,
             onAction: { action in
                 windowCoordinator.contentActions.handle(action)
-            },
-            isFolderWatchOptionsPresented: $folderWatchFlow.isFolderWatchOptionsPresented,
-            pendingFolderWatchOpenMode: pendingFolderWatchOpenModeBinding,
-            pendingFolderWatchScope: pendingFolderWatchScopeBinding,
-            pendingFolderWatchExcludedSubdirectoryPaths: pendingFolderWatchExcludedSubdirectoryPathsBinding
+            }
         )
     }
 


### PR DESCRIPTION
Closes #368.

## Summary

Window-scoped `@Observable` controllers (`SettingsStore`, `WindowAppearanceController`, `SidebarDocumentController`, `FolderWatchFlowController`) are now injected once at `WindowRootView` via `.environment(...)`. Deep views read only what they use via `@Environment(T.self)`. Intermediate layers no longer thread parameters they don't consume — pass-through is genuinely eliminated, not just compressed.

Also adopts the `DocumentStore` aggregate for `ContentView`, `TopBar`, `ContentViewFocusedValues` (the issue's judgement-call fix #4) — controllers are still read directly (`documentStore.document.x`), not through a VM facade.

## Param counts

| Type | Before | After |
|---|---|---|
| `ContentViewAdapter` | 12 | 2 |
| `ContentAreaHost` | 8 | 4 |
| `ContentView` | 12 | 5 |
| `ContentViewFocusedValues` | 11 | 4 |
| `TopBar` | 10 | 6 |

All types in `minimark/Views/Content/` at or below the 6-param acceptance ceiling.

## Notable changes

- `WindowRootView` injects the four window-scoped `@Observable` controllers at the root of its body.
- The three custom `Binding(get:set:)` helpers for pending folder-watch options moved from `WindowRootView` into `FolderWatchFlowController` as computed `Binding<T>` properties.
- `ContentViewFocusedValues` reads `FolderWatchFlowController` from env and uses `@Bindable` locally for the sheet — the 4 sheet `@Binding`s are gone from every intermediate layer.
- `canNavigateChangedRegions + onNavigateChangedRegion` bundled into the existing `ChangedRegionNavigationAction` at the `ContentViewFocusedValues` boundary.

## Test plan

- [x] `xcodebuild build` (Debug, macOS) — green.
- [x] `minimarkTests` — full unit suite green.
- [x] `minimarkUITests` — full UI suite green.
- [ ] Manual smoke — open file, watch folder, edit favorites, toggle appearance lock.