### PR TITLE
Eliminate pass-through in SidebarWorkspaceView via @Environment (#371)

### DIFF
--- a/minimark/Views/SidebarSelectionActions.swift
+++ b/minimark/Views/SidebarSelectionActions.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// Bundles the per-row / selection-wide action closures that `WindowRootView`
-/// hands to `SidebarWorkspaceView` and its children. Always constructed together;
-/// always consumed by the same sidebar selection subview, so a named value type
-/// is more honest than threading each closure as a separate parameter.
+/// hands to `SidebarWorkspaceView` and related sidebar list/row UI. Always
+/// constructed together as the shared sidebar action surface, so a named value
+/// type is more honest than threading each closure as a separate parameter.
 struct SidebarSelectionActions {
     let openInDefaultApp: (Set<UUID>) -> Void
     let openInApplication: (ExternalApplication, Set<UUID>) -> Void

--- a/minimark/Views/SidebarSelectionActions.swift
+++ b/minimark/Views/SidebarSelectionActions.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Bundles the per-row / selection-wide action closures that `WindowRootView`
+/// hands to `SidebarWorkspaceView` and its children. Always constructed together;
+/// always consumed by the same sidebar selection subview, so a named value type
+/// is more honest than threading each closure as a separate parameter.
+struct SidebarSelectionActions {
+    let openInDefaultApp: (Set<UUID>) -> Void
+    let openInApplication: (ExternalApplication, Set<UUID>) -> Void
+    let revealInFinder: (Set<UUID>) -> Void
+    let stopWatchingFolders: (Set<UUID>) -> Void
+    let closeDocuments: (Set<UUID>) -> Void
+    let closeOtherDocuments: (Set<UUID>) -> Void
+    let closeAll: () -> Void
+}

--- a/minimark/Views/SidebarWorkspaceView.swift
+++ b/minimark/Views/SidebarWorkspaceView.swift
@@ -9,21 +9,14 @@ enum SidebarWorkspaceMetrics {
 }
 
 struct SidebarWorkspaceView<Detail: View>: View {
-    var controller: SidebarDocumentController
-    var settingsStore: SettingsStore
-    var groupState: SidebarGroupStateController
+    @Environment(SidebarDocumentController.self) private var controller
+    @Environment(SettingsStore.self) private var settingsStore
+    @Environment(SidebarGroupStateController.self) private var groupState
     let sidebarPlacement: MultiFileDisplayMode.SidebarPlacement
     let sidebarWidth: CGFloat
     let onSidebarWidthChanged: (CGFloat) -> Void
     let detail: (DocumentStore) -> Detail
-    let onToggleSidebarPlacement: () -> Void
-    let onOpenInDefaultApp: (Set<UUID>) -> Void
-    let onOpenInApplication: (ExternalApplication, Set<UUID>) -> Void
-    let onRevealInFinder: (Set<UUID>) -> Void
-    let onStopWatchingFolders: (Set<UUID>) -> Void
-    let onCloseDocuments: (Set<UUID>) -> Void
-    let onCloseOtherDocuments: (Set<UUID>) -> Void
-    let onCloseAllDocuments: () -> Void
+    let actions: SidebarSelectionActions
     @State private var selectedDocumentIDs: Set<UUID> = []
     @State private var isDraggingDivider = false
 
@@ -99,21 +92,10 @@ struct SidebarWorkspaceView<Detail: View>: View {
                 Divider()
 
                 SidebarGroupListContent(
-                    groupState: groupState,
-                    controller: controller,
-                    settingsStore: settingsStore,
                     selectedDocumentIDs: $selectedDocumentIDs,
                     watchedDocumentIDs: watchedDocumentIDs,
                     onUpdateSelection: { updateSelection($0) },
-                    onOpenInDefaultApp: onOpenInDefaultApp,
-                    onOpenInApplication: { application, documentIDs in
-                        onOpenInApplication(application, documentIDs)
-                    },
-                    onRevealInFinder: onRevealInFinder,
-                    onStopWatchingFolders: onStopWatchingFolders,
-                    onCloseDocuments: onCloseDocuments,
-                    onCloseOtherDocuments: onCloseOtherDocuments,
-                    onCloseAllDocuments: onCloseAllDocuments
+                    actions: actions
                 )
             }
             .frame(maxHeight: .infinity)
@@ -715,19 +697,13 @@ private struct SidebarGroupDropIndicator: View {
 }
 
 private struct SidebarGroupListContent: View {
-    var groupState: SidebarGroupStateController
-    var controller: SidebarDocumentController
-    let settingsStore: SettingsStore
+    @Environment(SidebarGroupStateController.self) private var groupState
+    @Environment(SidebarDocumentController.self) private var controller
+    @Environment(SettingsStore.self) private var settingsStore
     @Binding var selectedDocumentIDs: Set<UUID>
     let watchedDocumentIDs: Set<UUID>
     let onUpdateSelection: (Set<UUID>) -> Void
-    let onOpenInDefaultApp: (Set<UUID>) -> Void
-    let onOpenInApplication: (ExternalApplication, Set<UUID>) -> Void
-    let onRevealInFinder: (Set<UUID>) -> Void
-    let onStopWatchingFolders: (Set<UUID>) -> Void
-    let onCloseDocuments: (Set<UUID>) -> Void
-    let onCloseOtherDocuments: (Set<UUID>) -> Void
-    let onCloseAllDocuments: () -> Void
+    let actions: SidebarSelectionActions
     @State private var draggedGroupID: String?
     @State private var dropTargetIndex: Int?
     @State private var dragTranslation: CGSize = .zero
@@ -808,7 +784,7 @@ private struct SidebarGroupListContent: View {
                 groupState.toggleGroupPin(group.id)
             },
             onCloseGroup: {
-                onCloseDocuments(Set(group.documents.map(\.id)))
+                actions.closeDocuments(Set(group.documents.map(\.id)))
             }
         )
 
@@ -996,17 +972,13 @@ private struct SidebarGroupListContent: View {
             selectedDocumentIDs: selectedDocumentIDs,
             showsSelectionBackground: showsSelectionBackground,
             canClose: true,
-            onOpenInDefaultApp: onOpenInDefaultApp,
-            onOpenInApplication: { application, documentIDs in
-                onOpenInApplication(application, documentIDs)
-            },
-            onRevealInFinder: onRevealInFinder,
-            onStopWatchingFolders: onStopWatchingFolders,
-            onClose: onCloseDocuments,
-            onCloseOthers: onCloseOtherDocuments,
-            onCloseAll: {
-                onCloseAllDocuments()
-            }
+            onOpenInDefaultApp: actions.openInDefaultApp,
+            onOpenInApplication: actions.openInApplication,
+            onRevealInFinder: actions.revealInFinder,
+            onStopWatchingFolders: actions.stopWatchingFolders,
+            onClose: actions.closeDocuments,
+            onCloseOthers: actions.closeOtherDocuments,
+            onCloseAll: actions.closeAll
         )
     }
 }

--- a/minimark/Views/SidebarWorkspaceView.swift
+++ b/minimark/Views/SidebarWorkspaceView.swift
@@ -9,8 +9,8 @@ enum SidebarWorkspaceMetrics {
 }
 
 struct SidebarWorkspaceView<Detail: View>: View {
-    @Environment(SidebarDocumentController.self) private var controller
     @Environment(SettingsStore.self) private var settingsStore
+    @Environment(SidebarDocumentController.self) private var controller
     @Environment(SidebarGroupStateController.self) private var groupState
     let sidebarPlacement: MultiFileDisplayMode.SidebarPlacement
     let sidebarWidth: CGFloat
@@ -697,9 +697,9 @@ private struct SidebarGroupDropIndicator: View {
 }
 
 private struct SidebarGroupListContent: View {
-    @Environment(SidebarGroupStateController.self) private var groupState
-    @Environment(SidebarDocumentController.self) private var controller
     @Environment(SettingsStore.self) private var settingsStore
+    @Environment(SidebarDocumentController.self) private var controller
+    @Environment(SidebarGroupStateController.self) private var groupState
     @Binding var selectedDocumentIDs: Set<UUID>
     let watchedDocumentIDs: Set<UUID>
     let onUpdateSelection: (Set<UUID>) -> Void

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -304,9 +304,6 @@ struct WindowRootView: View {
     @ViewBuilder
     private var rootContent: some View {
         SidebarWorkspaceView(
-            controller: sidebarDocumentController,
-            settingsStore: settingsStore,
-            groupState: groupStateController,
             sidebarPlacement: sidebarPlacement,
             sidebarWidth: windowCoordinator.sidebarMetrics.width,
             onSidebarWidthChanged: { newWidth in
@@ -315,30 +312,29 @@ struct WindowRootView: View {
             detail: { store in
                 contentView(for: store)
             },
-            onToggleSidebarPlacement: {
-                windowCoordinator.sidebarActions.toggleSidebarPlacement(currentMultiFileDisplayMode: multiFileDisplayMode)
-            },
-            onOpenInDefaultApp: { documentIDs in
-                windowCoordinator.sidebarActions.openDocumentsInDefaultApp(documentIDs)
-            },
-            onOpenInApplication: { application, documentIDs in
-                windowCoordinator.sidebarActions.openDocumentsInApplication(application, documentIDs)
-            },
-            onRevealInFinder: { documentIDs in
-                windowCoordinator.sidebarActions.revealDocumentsInFinder(documentIDs)
-            },
-            onStopWatchingFolders: { documentIDs in
-                windowCoordinator.sidebarActions.stopWatchingFolders(documentIDs)
-            },
-            onCloseDocuments: { documentIDs in
-                windowCoordinator.sidebarActions.closeSelectedDocuments(documentIDs)
-            },
-            onCloseOtherDocuments: { documentIDs in
-                windowCoordinator.sidebarActions.closeOtherDocuments(keeping: documentIDs)
-            },
-            onCloseAllDocuments: {
-                windowCoordinator.sidebarActions.closeAllDocuments()
-            }
+            actions: SidebarSelectionActions(
+                openInDefaultApp: { documentIDs in
+                    windowCoordinator.sidebarActions.openDocumentsInDefaultApp(documentIDs)
+                },
+                openInApplication: { application, documentIDs in
+                    windowCoordinator.sidebarActions.openDocumentsInApplication(application, documentIDs)
+                },
+                revealInFinder: { documentIDs in
+                    windowCoordinator.sidebarActions.revealDocumentsInFinder(documentIDs)
+                },
+                stopWatchingFolders: { documentIDs in
+                    windowCoordinator.sidebarActions.stopWatchingFolders(documentIDs)
+                },
+                closeDocuments: { documentIDs in
+                    windowCoordinator.sidebarActions.closeSelectedDocuments(documentIDs)
+                },
+                closeOtherDocuments: { documentIDs in
+                    windowCoordinator.sidebarActions.closeOtherDocuments(keeping: documentIDs)
+                },
+                closeAll: {
+                    windowCoordinator.sidebarActions.closeAllDocuments()
+                }
+            )
         )
         .toolbar {
             ToolbarItem(placement: .navigation) {

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -63,6 +63,7 @@ struct WindowRootView: View {
         .environment(appearanceController)
         .environment(sidebarDocumentController)
         .environment(folderWatchFlowController)
+        .environment(groupStateController)
     }
 
     private var windowShell: some View {

--- a/minimarkTests/Sidebar/SidebarSelectionActionsTests.swift
+++ b/minimarkTests/Sidebar/SidebarSelectionActionsTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+@testable import minimark
+
+@MainActor
+struct SidebarSelectionActionsTests {
+    @Test
+    func openInDefaultApp_forwardsDocumentIDs() {
+        var captured: Set<UUID> = []
+        let idA = UUID()
+        let idB = UUID()
+        let actions = makeActions(openInDefaultApp: { captured = $0 })
+
+        actions.openInDefaultApp([idA, idB])
+
+        #expect(captured == [idA, idB])
+    }
+
+    @Test
+    func openInApplication_forwardsApplicationAndIDs() {
+        var capturedApp: ExternalApplication?
+        var capturedIDs: Set<UUID> = []
+        let app = ExternalApplication(
+            id: "com.example.test",
+            displayName: "Test Editor",
+            bundleIdentifier: "com.example.test",
+            bundleURL: URL(fileURLWithPath: "/Applications/TestEditor.app")
+        )
+        let id = UUID()
+        let actions = makeActions(openInApplication: { application, ids in
+            capturedApp = application
+            capturedIDs = ids
+        })
+
+        actions.openInApplication(app, [id])
+
+        #expect(capturedApp == app)
+        #expect(capturedIDs == [id])
+    }
+
+    @Test
+    func revealInFinder_forwardsDocumentIDs() {
+        var captured: Set<UUID> = []
+        let id = UUID()
+        let actions = makeActions(revealInFinder: { captured = $0 })
+
+        actions.revealInFinder([id])
+
+        #expect(captured == [id])
+    }
+
+    @Test
+    func stopWatchingFolders_forwardsDocumentIDs() {
+        var captured: Set<UUID> = []
+        let id = UUID()
+        let actions = makeActions(stopWatchingFolders: { captured = $0 })
+
+        actions.stopWatchingFolders([id])
+
+        #expect(captured == [id])
+    }
+
+    @Test
+    func closeDocuments_forwardsDocumentIDs() {
+        var captured: Set<UUID> = []
+        let id = UUID()
+        let actions = makeActions(closeDocuments: { captured = $0 })
+
+        actions.closeDocuments([id])
+
+        #expect(captured == [id])
+    }
+
+    @Test
+    func closeOtherDocuments_forwardsDocumentIDs() {
+        var captured: Set<UUID> = []
+        let id = UUID()
+        let actions = makeActions(closeOtherDocuments: { captured = $0 })
+
+        actions.closeOtherDocuments([id])
+
+        #expect(captured == [id])
+    }
+
+    @Test
+    func closeAll_invokesClosure() {
+        var invoked = false
+        let actions = makeActions(closeAll: { invoked = true })
+
+        actions.closeAll()
+
+        #expect(invoked)
+    }
+
+    // MARK: - Helpers
+
+    private func makeActions(
+        openInDefaultApp: @escaping (Set<UUID>) -> Void = { _ in },
+        openInApplication: @escaping (ExternalApplication, Set<UUID>) -> Void = { _, _ in },
+        revealInFinder: @escaping (Set<UUID>) -> Void = { _ in },
+        stopWatchingFolders: @escaping (Set<UUID>) -> Void = { _ in },
+        closeDocuments: @escaping (Set<UUID>) -> Void = { _ in },
+        closeOtherDocuments: @escaping (Set<UUID>) -> Void = { _ in },
+        closeAll: @escaping () -> Void = {}
+    ) -> SidebarSelectionActions {
+        SidebarSelectionActions(
+            openInDefaultApp: openInDefaultApp,
+            openInApplication: openInApplication,
+            revealInFinder: revealInFinder,
+            stopWatchingFolders: stopWatchingFolders,
+            closeDocuments: closeDocuments,
+            closeOtherDocuments: closeOtherDocuments,
+            closeAll: closeAll
+        )
+    }
+}


### PR DESCRIPTION
Closes #371. Part of tracking issue #376.

## Summary

- Add `SidebarGroupStateController` to the window environment chain at `WindowRootView`, alongside the four controllers already wired in #368.
- Replace the three `@Observable` controller parameters on `SidebarWorkspaceView` and its private `SidebarGroupListContent` with `@Environment(T.self)` at the use site.
- Bundle the seven selection-action closures into a new `SidebarSelectionActions` value type in `minimark/Views/SidebarSelectionActions.swift`.
- Drop the dead `onToggleSidebarPlacement: () -> Void` parameter (declared on `SidebarWorkspaceView`, never referenced in its body).

## Param-count impact

| Type | Before | After |
| --- | --- | --- |
| `SidebarWorkspaceView` | ~16 | 5 |
| `SidebarGroupListContent` (private) | 13 | 4 |

Both land at ≤ 6 non-environment, non-state params per issue #376 rule.

## Non-goals (kept)

- No VM facade over the sidebar controllers (rule from #328 / #368).
- `SettingsStore` + `SidebarDocumentController` are not bundled into a wrapper — they're already `@Environment`-ready.
- `SidebarDocumentRow` and `SidebarGroupHeader` keep their fine-grained action closures; they were already ≤ 6 params and are not the problem.

## Test plan

- [x] Full `minimarkTests` suite green
- [x] New `SidebarSelectionActionsTests` covers closure forwarding for all 7 actions
- [x] `minimarkUITests` green
- [ ] Manual smoke: open two documents, right-click a row, exercise Open in Default / Reveal in Finder / Close / Close All / Stop Watching Folder