### PR TITLE
Bundle decomposed fields in Content views (#374)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -44,10 +44,12 @@ struct ContentView: View {
     private var mainStack: some View {
         VStack(spacing: 0) {
             ContentStatusBanner(
-                isCurrentFileMissing: document.isCurrentFileMissing,
-                fileDisplayName: document.fileDisplayName,
-                errorMessage: document.lastError?.message,
-                needsImageDirectoryAccess: rendering.needsImageDirectoryAccess,
+                state: DocumentStatusBannerState(
+                    isCurrentFileMissing: document.isCurrentFileMissing,
+                    fileDisplayName: document.fileDisplayName,
+                    errorMessage: document.lastError?.message,
+                    needsImageDirectoryAccess: rendering.needsImageDirectoryAccess
+                ),
                 topPadding: viewModel.overlayLayout.statusBannerTopPadding,
                 onGrantImageAccess: viewModel.promptForImageDirectoryAccess
             )

--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -146,13 +146,8 @@ struct ContentView: View {
 
     private var documentSurfaceLayout: some View {
         DocumentSurfaceLayoutView(
-            documentViewMode: sourceEditing.documentViewMode,
-            hasOpenDocument: document.hasOpenDocument,
-            showsLoadingOverlay: viewModel.shouldShowDocumentLoadingOverlay,
-            loadingOverlayHeadline: viewModel.loadingOverlayHeadline,
-            loadingOverlaySubtitle: viewModel.loadingOverlaySubtitle,
-            emptyStateVariant: viewModel.emptyStateVariant,
-            currentReaderTheme: viewModel.currentReaderTheme,
+            content: makeSurfaceContent(),
+            theme: viewModel.currentReaderTheme,
             onDroppedFileURLs: viewModel.handleDroppedFileURLs,
             previewSurface: DocumentSurfaceHost(
                 configuration: viewModel.makeSurfaceConfiguration(for: .preview),
@@ -163,6 +158,19 @@ struct ContentView: View {
                 fallbackMarkdown: document.sourceMarkdown
             )
         )
+    }
+
+    private func makeSurfaceContent() -> DocumentSurfaceContent {
+        if viewModel.shouldShowDocumentLoadingOverlay {
+            return .loading(LoadingOverlayState(
+                headline: viewModel.loadingOverlayHeadline,
+                subtitle: viewModel.loadingOverlaySubtitle
+            ))
+        } else if !document.hasOpenDocument {
+            return .empty(viewModel.emptyStateVariant)
+        } else {
+            return .document(sourceEditing.documentViewMode)
+        }
     }
 }
 

--- a/minimark/Views/Content/ContentDocumentSurfaceViews.swift
+++ b/minimark/Views/Content/ContentDocumentSurfaceViews.swift
@@ -253,28 +253,24 @@ struct DocumentSurfaceHost: View {
 }
 
 struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: View {
-    let documentViewMode: DocumentViewMode
-    let hasOpenDocument: Bool
-    let showsLoadingOverlay: Bool
-    let loadingOverlayHeadline: String
-    let loadingOverlaySubtitle: String?
-    let emptyStateVariant: ContentEmptyStateView.Variant
-    let currentReaderTheme: Theme
+    let content: DocumentSurfaceContent
+    let theme: Theme
     let onDroppedFileURLs: ([URL]) -> Void
     let previewSurface: PreviewSurface
     let sourceSurface: SourceSurface
 
     var body: some View {
-        if showsLoadingOverlay {
+        switch content {
+        case .loading(let overlay):
             DocumentLoadingOverlay(
-                theme: currentReaderTheme,
-                headline: loadingOverlayHeadline,
-                subtitle: loadingOverlaySubtitle
+                theme: theme,
+                headline: overlay.headline,
+                subtitle: overlay.subtitle
             )
-        } else if !hasOpenDocument {
+        case .empty(let variant):
             ContentEmptyStateView(
-                variant: emptyStateVariant,
-                theme: currentReaderTheme
+                variant: variant,
+                theme: theme
             )
             .dropDestination(for: URL.self) { urls, _ in
                 let fileURLs = urls.filter { $0.isFileURL }
@@ -282,7 +278,7 @@ struct DocumentSurfaceLayoutView<PreviewSurface: View, SourceSurface: View>: Vie
                 onDroppedFileURLs(fileURLs)
                 return true
             }
-        } else {
+        case .document(let documentViewMode):
             switch documentViewMode {
             case .preview:
                 previewSurface

--- a/minimark/Views/Content/ContentStatusBanner.swift
+++ b/minimark/Views/Content/ContentStatusBanner.swift
@@ -1,18 +1,15 @@
 import SwiftUI
 
 struct ContentStatusBanner: View {
-    let isCurrentFileMissing: Bool
-    let fileDisplayName: String
-    let errorMessage: String?
-    let needsImageDirectoryAccess: Bool
+    let state: DocumentStatusBannerState
     let topPadding: CGFloat
     let onGrantImageAccess: () -> Void
 
     var body: some View {
-        if isCurrentFileMissing {
-            DeletedFileWarningBar(fileName: fileDisplayName, message: errorMessage)
+        if state.isCurrentFileMissing {
+            DeletedFileWarningBar(fileName: state.fileDisplayName, message: state.errorMessage)
                 .padding(.top, topPadding)
-        } else if needsImageDirectoryAccess {
+        } else if state.needsImageDirectoryAccess {
             ImageAccessWarningBar(onGrantAccess: onGrantImageAccess)
                 .padding(.top, topPadding)
         }

--- a/minimark/Views/Content/ContentUtilityRail.swift
+++ b/minimark/Views/Content/ContentUtilityRail.swift
@@ -2,13 +2,9 @@ import AppKit
 import SwiftUI
 
 struct ContentUtilityRail: View {
-    let hasFile: Bool
-    let documentViewMode: DocumentViewMode
-    let showEditButton: Bool
-    let canStartSourceEditing: Bool
+    let state: ContentUtilityRailState
     let onSetDocumentViewMode: (DocumentViewMode) -> Void
     let onStartSourceEditing: () -> Void
-    let hasTOCHeadings: Bool
     let isTOCVisible: Binding<Bool>
 
     @State private var isHovering = false
@@ -27,16 +23,16 @@ struct ContentUtilityRail: View {
     }
 
     var body: some View {
-        if hasFile {
+        if state.hasFile {
             VStack(spacing: Metrics.groupSpacing) {
                 viewModeGroup
 
-                if showEditButton {
+                if state.showEditButton {
                     groupSeparator
                     editGroup
                 }
 
-                if hasTOCHeadings && documentViewMode == .preview {
+                if state.hasTOCHeadings && state.documentViewMode == .preview {
                     groupSeparator
                     tocGroup
                 }
@@ -67,14 +63,14 @@ struct ContentUtilityRail: View {
                 viewModeButton(mode: mode)
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: documentViewMode)
+        .animation(.easeInOut(duration: 0.25), value: state.documentViewMode)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Document view mode")
         .accessibilityHint("Switch between preview, split, and source views of the document.")
     }
 
     private func viewModeButton(mode: DocumentViewMode) -> some View {
-        let isSelected = documentViewMode == mode
+        let isSelected = state.documentViewMode == mode
 
         return Button {
             onSetDocumentViewMode(mode)
@@ -101,8 +97,8 @@ struct ContentUtilityRail: View {
                 )
         }
         .buttonStyle(.plain)
-        .disabled(!hasFile || isSelected)
-        .foregroundStyle(isSelected ? .primary : (hasFile ? .secondary : .tertiary))
+        .disabled(!state.hasFile || isSelected)
+        .foregroundStyle(isSelected ? .primary : (state.hasFile ? .secondary : .tertiary))
         .help(mode.displayName)
         .accessibilityLabel(mode.displayName)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
@@ -118,15 +114,15 @@ struct ContentUtilityRail: View {
                 .font(.system(size: Metrics.iconSize, weight: .semibold))
                 .frame(width: Metrics.buttonSize, height: Metrics.buttonSize)
                 .railButtonBackground(cornerRadius: Metrics.buttonCornerRadius,
-                    fill: Color.primary.opacity(canStartSourceEditing ? 0.06 : 0.03),
-                    border: Color.primary.opacity(canStartSourceEditing ? 0.10 : 0.05),
-                    hoverFill: canStartSourceEditing ? Color.primary.opacity(0.10) : nil,
-                    hoverBorder: canStartSourceEditing ? Color.primary.opacity(0.14) : nil
+                    fill: Color.primary.opacity(state.canStartSourceEditing ? 0.06 : 0.03),
+                    border: Color.primary.opacity(state.canStartSourceEditing ? 0.10 : 0.05),
+                    hoverFill: state.canStartSourceEditing ? Color.primary.opacity(0.10) : nil,
+                    hoverBorder: state.canStartSourceEditing ? Color.primary.opacity(0.14) : nil
                 )
         }
         .buttonStyle(.plain)
-        .disabled(!canStartSourceEditing)
-        .foregroundStyle(canStartSourceEditing ? .primary : .tertiary)
+        .disabled(!state.canStartSourceEditing)
+        .foregroundStyle(state.canStartSourceEditing ? .primary : .tertiary)
         .help("Edit Source (⌘E)")
         .accessibilityLabel("Edit source")
     }

--- a/minimark/Views/Content/ContentUtilityRailView.swift
+++ b/minimark/Views/Content/ContentUtilityRailView.swift
@@ -8,13 +8,9 @@ struct ContentUtilityRailView: View {
 
     var body: some View {
         ContentUtilityRail(
-            hasFile: state.hasFile,
-            documentViewMode: state.documentViewMode,
-            showEditButton: state.showEditButton,
-            canStartSourceEditing: state.canStartSourceEditing,
+            state: state,
             onSetDocumentViewMode: onSetDocumentViewMode,
             onStartSourceEditing: onStartSourceEditing,
-            hasTOCHeadings: state.hasTOCHeadings,
             isTOCVisible: $isTOCVisible
         )
     }

--- a/minimark/Views/Content/DocumentStatusBannerState.swift
+++ b/minimark/Views/Content/DocumentStatusBannerState.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct DocumentStatusBannerState: Equatable {
     let isCurrentFileMissing: Bool
     let fileDisplayName: String

--- a/minimark/Views/Content/DocumentStatusBannerState.swift
+++ b/minimark/Views/Content/DocumentStatusBannerState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct DocumentStatusBannerState: Equatable {
+    let isCurrentFileMissing: Bool
+    let fileDisplayName: String
+    let errorMessage: String?
+    let needsImageDirectoryAccess: Bool
+}

--- a/minimark/Views/Content/DocumentSurfaceContent.swift
+++ b/minimark/Views/Content/DocumentSurfaceContent.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Which of the three mutually-exclusive surface states `DocumentSurfaceLayoutView`
+/// should render. The host picks exactly one; the view doesn't need separate flags
+/// plus mode plus overlay-text params.
+enum DocumentSurfaceContent {
+    case loading(LoadingOverlayState)
+    case empty(ContentEmptyStateView.Variant)
+    case document(DocumentViewMode)
+}

--- a/minimark/Views/Content/DocumentSurfaceContent.swift
+++ b/minimark/Views/Content/DocumentSurfaceContent.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Which of the three mutually-exclusive surface states `DocumentSurfaceLayoutView`
 /// should render. The host picks exactly one; the view doesn't need separate flags
 /// plus mode plus overlay-text params.

--- a/minimark/Views/Content/LoadingOverlayState.swift
+++ b/minimark/Views/Content/LoadingOverlayState.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct LoadingOverlayState: Equatable {
     let headline: String
     let subtitle: String?

--- a/minimark/Views/Content/LoadingOverlayState.swift
+++ b/minimark/Views/Content/LoadingOverlayState.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct LoadingOverlayState: Equatable {
+    let headline: String
+    let subtitle: String?
+}

--- a/minimark/Views/Content/ReaderTopBarComponents.swift
+++ b/minimark/Views/Content/ReaderTopBarComponents.swift
@@ -12,11 +12,7 @@ enum FolderWatchToolbarAction {
 }
 
 struct FolderWatchToolbarButton: View {
-    let activeFolderWatch: FolderWatchSession?
-    let isInitialScanInProgress: Bool
-    let didInitialScanFail: Bool
-    let favoriteWatchedFolders: [FavoriteWatchedFolder]
-    let recentWatchedFolders: [RecentWatchedFolder]
+    let state: ToolbarFolderWatchState
     let onAction: (FolderWatchToolbarAction) -> Void
     var compact: Bool = false
 
@@ -29,7 +25,7 @@ struct FolderWatchToolbarButton: View {
         static let compactControlHeight: CGFloat = 22
     }
 
-    private var isActive: Bool { activeFolderWatch != nil }
+    private var isActive: Bool { state.activeFolderWatch != nil }
 
     private var resolvedControlHeight: CGFloat {
         compact ? Metrics.compactControlHeight : Metrics.controlHeight
@@ -91,11 +87,11 @@ struct FolderWatchToolbarButton: View {
         }
         .overlay(alignment: .topTrailing) {
             Group {
-                if isInitialScanInProgress {
+                if state.isInitialScanInProgress {
                     ProgressView()
                         .scaleEffect(0.6)
                         .controlSize(.small)
-                } else if didInitialScanFail {
+                } else if state.didInitialScanFail {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 10))
                         .foregroundStyle(.red)
@@ -126,10 +122,10 @@ struct FolderWatchToolbarButton: View {
     @ViewBuilder
     private var watchMenuPopover: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if !favoriteWatchedFolders.isEmpty {
+            if !state.favoriteWatchedFolders.isEmpty {
                 menuSectionHeader("Favorites")
 
-                ForEach(favoriteWatchedFolders) { entry in
+                ForEach(state.favoriteWatchedFolders) { entry in
                     Button {
                         isMenuPresented = false
                         onAction(.startFavoriteWatch(entry))
@@ -166,15 +162,15 @@ struct FolderWatchToolbarButton: View {
                 .contentShape(Rectangle())
             }
 
-            if !recentWatchedFolders.isEmpty {
-                if !favoriteWatchedFolders.isEmpty {
+            if !state.recentWatchedFolders.isEmpty {
+                if !state.favoriteWatchedFolders.isEmpty {
                     Divider().padding(.vertical, 4)
                 }
 
                 menuSectionHeader("Recent")
 
-                let titlesByPath = RecentHistory.menuTitles(for: recentWatchedFolders)
-                ForEach(recentWatchedFolders) { entry in
+                let titlesByPath = RecentHistory.menuTitles(for: state.recentWatchedFolders)
+                ForEach(state.recentWatchedFolders) { entry in
                     Button {
                         isMenuPresented = false
                         onAction(.startRecentFolderWatch(entry))
@@ -202,7 +198,7 @@ struct FolderWatchToolbarButton: View {
                 .contentShape(Rectangle())
             }
 
-            if favoriteWatchedFolders.isEmpty && recentWatchedFolders.isEmpty {
+            if state.favoriteWatchedFolders.isEmpty && state.recentWatchedFolders.isEmpty {
                 Text("No favorites or recent watches")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)

--- a/minimark/Views/Content/ToolbarFolderWatchState.swift
+++ b/minimark/Views/Content/ToolbarFolderWatchState.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 struct ToolbarFolderWatchState: Equatable {
     let activeFolderWatch: FolderWatchSession?
     let isInitialScanInProgress: Bool

--- a/minimark/Views/Content/ToolbarFolderWatchState.swift
+++ b/minimark/Views/Content/ToolbarFolderWatchState.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ToolbarFolderWatchState: Equatable {
+    let activeFolderWatch: FolderWatchSession?
+    let isInitialScanInProgress: Bool
+    let didInitialScanFail: Bool
+    let favoriteWatchedFolders: [FavoriteWatchedFolder]
+    let recentWatchedFolders: [RecentWatchedFolder]
+}

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -79,11 +79,13 @@ struct WindowRootView: View {
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 FolderWatchToolbarButton(
-                    activeFolderWatch: nil,
-                    isInitialScanInProgress: false,
-                    didInitialScanFail: false,
-                    favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
-                    recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
+                    state: ToolbarFolderWatchState(
+                        activeFolderWatch: nil,
+                        isInitialScanInProgress: false,
+                        didInitialScanFail: false,
+                        favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
+                        recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders
+                    ),
                     onAction: { _ in },
                     compact: true
                 )
@@ -339,11 +341,13 @@ struct WindowRootView: View {
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 FolderWatchToolbarButton(
-                    activeFolderWatch: folderWatchFlowController.sharedFolderWatchSession,
-                    isInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
-                    didInitialScanFail: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
-                    favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
-                    recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
+                    state: ToolbarFolderWatchState(
+                        activeFolderWatch: folderWatchFlowController.sharedFolderWatchSession,
+                        isInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
+                        didInitialScanFail: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
+                        favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
+                        recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders
+                    ),
                     onAction: { action in
                         if case .activate = action {
                             promptForFolderWatch()

--- a/minimarkTests/Core/DocumentStatusBannerStateTests.swift
+++ b/minimarkTests/Core/DocumentStatusBannerStateTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import minimark
+
+struct DocumentStatusBannerStateTests {
+    @Test
+    func equatableReflectsAllFields() {
+        let a = DocumentStatusBannerState(
+            isCurrentFileMissing: false,
+            fileDisplayName: "x",
+            errorMessage: nil,
+            needsImageDirectoryAccess: false
+        )
+        let b = DocumentStatusBannerState(
+            isCurrentFileMissing: true,
+            fileDisplayName: "x",
+            errorMessage: nil,
+            needsImageDirectoryAccess: false
+        )
+        #expect(a != b)
+    }
+
+    @Test
+    func fieldsRoundTrip() {
+        let state = DocumentStatusBannerState(
+            isCurrentFileMissing: true,
+            fileDisplayName: "README.md",
+            errorMessage: "File no longer exists",
+            needsImageDirectoryAccess: true
+        )
+
+        #expect(state.isCurrentFileMissing)
+        #expect(state.fileDisplayName == "README.md")
+        #expect(state.errorMessage == "File no longer exists")
+        #expect(state.needsImageDirectoryAccess)
+    }
+}

--- a/minimarkTests/Core/DocumentSurfaceContentTests.swift
+++ b/minimarkTests/Core/DocumentSurfaceContentTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import minimark
+
+struct DocumentSurfaceContentTests {
+    @Test
+    func loadingCasePreservesOverlayState() {
+        let overlay = LoadingOverlayState(headline: "Loading\u{2026}", subtitle: "Parsing")
+        let content: DocumentSurfaceContent = .loading(overlay)
+
+        guard case .loading(let payload) = content else {
+            Issue.record("expected .loading")
+            return
+        }
+        #expect(payload.headline == "Loading\u{2026}")
+        #expect(payload.subtitle == "Parsing")
+    }
+
+    @Test
+    func emptyCasePreservesVariant() {
+        let variant: ContentEmptyStateView.Variant = .noDocument
+        let content: DocumentSurfaceContent = .empty(variant)
+
+        guard case .empty(let payload) = content else {
+            Issue.record("expected .empty")
+            return
+        }
+        #expect(payload == variant)
+    }
+
+    @Test
+    func documentCasePreservesViewMode() {
+        let content: DocumentSurfaceContent = .document(.split)
+
+        guard case .document(let mode) = content else {
+            Issue.record("expected .document")
+            return
+        }
+        #expect(mode == .split)
+    }
+}

--- a/minimarkTests/Core/ToolbarFolderWatchStateTests.swift
+++ b/minimarkTests/Core/ToolbarFolderWatchStateTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import Foundation
+@testable import minimark
+
+struct ToolbarFolderWatchStateTests {
+    @Test
+    func equatableReflectsAllFields() {
+        let a = ToolbarFolderWatchState(
+            activeFolderWatch: nil,
+            isInitialScanInProgress: false,
+            didInitialScanFail: false,
+            favoriteWatchedFolders: [],
+            recentWatchedFolders: []
+        )
+        let b = ToolbarFolderWatchState(
+            activeFolderWatch: nil,
+            isInitialScanInProgress: true,
+            didInitialScanFail: false,
+            favoriteWatchedFolders: [],
+            recentWatchedFolders: []
+        )
+        #expect(a != b)
+    }
+
+    @Test
+    func idleStateProducesExpectedShape() {
+        let state = ToolbarFolderWatchState(
+            activeFolderWatch: nil,
+            isInitialScanInProgress: false,
+            didInitialScanFail: false,
+            favoriteWatchedFolders: [],
+            recentWatchedFolders: []
+        )
+
+        #expect(state.activeFolderWatch == nil)
+        #expect(state.isInitialScanInProgress == false)
+        #expect(state.didInitialScanFail == false)
+        #expect(state.favoriteWatchedFolders.isEmpty)
+        #expect(state.recentWatchedFolders.isEmpty)
+    }
+}

--- a/minimarkTests/Core/ToolbarFolderWatchStateTests.swift
+++ b/minimarkTests/Core/ToolbarFolderWatchStateTests.swift
@@ -1,5 +1,4 @@
 import Testing
-import Foundation
 @testable import minimark
 
 struct ToolbarFolderWatchStateTests {


### PR DESCRIPTION
Closes #374. Part of tracking issue #376.

## Summary

Every `View` in `minimark/Views/Content/` now takes ≤ 6 non-env non-state stored params. Four targets bundled; one audited and left alone.

| View | Before | After | New type |
| --- | --- | --- | --- |
| `DocumentSurfaceLayoutView` | 10 | 5 | `DocumentSurfaceContent` (enum) + `LoadingOverlayState` |
| `ContentUtilityRail` | 8 | 4 | reuses existing `ContentUtilityRailState` |
| `FolderWatchToolbarButton` | 7 | 3 | `ToolbarFolderWatchState` |
| `ContentStatusBanner` | 6 | 3 | `DocumentStatusBannerState` |

`FolderWatchOptionsSheet` (6 params) audited — three `@Binding`s + two closures + a URL don't bundle into a cohesive concept; left as-is per the plan's non-goals.

## Design note: `DocumentSurfaceContent` is an enum, not two structs

The issue proposed bundling into `LoadingOverlayState + SurfaceChromeState`. That flat shape lands at 7 params. The three top-level states (loading / empty / document) are mutually exclusive in the existing body, so a discriminated enum is the honest model — and collapses to 5 params.

## Non-goals (kept)

- No VM facades.
- No grab-bag `Config` types. Every new type names a concept whose fields are consumed together.
- `SidebarDocumentRow` and `SidebarGroupHeader`-style private sibling views untouched where their constructors already fit.

## Test plan

- [x] `minimarkTests` full suite green
- [x] New state/enum unit tests: `DocumentSurfaceContentTests` (3), `ToolbarFolderWatchStateTests` (2), `DocumentStatusBannerStateTests` (2)
- [x] `minimarkUITests` green
- [ ] Manual smoke: trigger initial scan (loading overlay), close all docs (empty state), open doc (document surface), delete file externally (status banner), missing image dir (image-access banner)