### PR TITLE
Reduce constructor sprawl in window-coordination types (#373)

### DIFF
--- a/minimark/Views/Window/Coordination/FavoriteWorkspaceEventDispatcher.swift
+++ b/minimark/Views/Window/Coordination/FavoriteWorkspaceEventDispatcher.swift
@@ -1,0 +1,25 @@
+/// Persists favorite-workspace state changes. Merges the current locked
+/// appearance into the new state before writing to the settings store.
+@MainActor
+final class FavoriteWorkspaceEventDispatcher {
+    private let favoriteWorkspaceControllerProvider: () -> FavoriteWorkspaceController?
+    private let appearanceControllerProvider: () -> WindowAppearanceController?
+    private let settingsStore: SettingsStore
+
+    init(
+        favoriteWorkspaceControllerProvider: @escaping () -> FavoriteWorkspaceController?,
+        appearanceControllerProvider: @escaping () -> WindowAppearanceController?,
+        settingsStore: SettingsStore
+    ) {
+        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
+        self.appearanceControllerProvider = appearanceControllerProvider
+        self.settingsStore = settingsStore
+    }
+
+    func handleFavoriteWorkspaceStateChange(_ newState: FavoriteWorkspaceState?) {
+        guard let favoriteID = favoriteWorkspaceControllerProvider()?.activeFavoriteID,
+              var state = newState else { return }
+        state.lockedAppearance = appearanceControllerProvider()?.lockedAppearance
+        settingsStore.updateFavoriteWorkspaceState(id: favoriteID, workspaceState: state)
+    }
+}

--- a/minimark/Views/Window/Coordination/GroupStateEventDispatcher.swift
+++ b/minimark/Views/Window/Coordination/GroupStateEventDispatcher.swift
@@ -1,0 +1,47 @@
+/// Persists sidebar group state changes. Routes group/pinning/sort mutations
+/// to either the active favorite workspace (when one is active) or the
+/// settings store (the default persistence target).
+@MainActor
+final class GroupStateEventDispatcher {
+    private let favoriteWorkspaceControllerProvider: () -> FavoriteWorkspaceController?
+    private let settingsStore: SettingsStore
+
+    init(
+        favoriteWorkspaceControllerProvider: @escaping () -> FavoriteWorkspaceController?,
+        settingsStore: SettingsStore
+    ) {
+        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
+        self.settingsStore = settingsStore
+    }
+
+    func handleGroupStateChange(
+        oldSnapshot: SidebarGroupStateController.WorkspaceStateSnapshot,
+        newSnapshot: SidebarGroupStateController.WorkspaceStateSnapshot
+    ) {
+        if let favoriteController = favoriteWorkspaceControllerProvider(), favoriteController.isActive {
+            let needsUpdate =
+                favoriteController.activeFavoriteWorkspaceState?.pinnedGroupIDs != newSnapshot.pinnedGroupIDs ||
+                favoriteController.activeFavoriteWorkspaceState?.collapsedGroupIDs != newSnapshot.collapsedGroupIDs ||
+                favoriteController.activeFavoriteWorkspaceState?.groupSortMode != newSnapshot.sortMode ||
+                favoriteController.activeFavoriteWorkspaceState?.fileSortMode != newSnapshot.fileSortMode ||
+                favoriteController.activeFavoriteWorkspaceState?.manualGroupOrder != newSnapshot.manualGroupOrder
+
+            if needsUpdate {
+                favoriteController.updateGroupState(
+                    pinnedGroupIDs: newSnapshot.pinnedGroupIDs,
+                    collapsedGroupIDs: newSnapshot.collapsedGroupIDs,
+                    groupSortMode: newSnapshot.sortMode,
+                    fileSortMode: newSnapshot.fileSortMode,
+                    manualGroupOrder: newSnapshot.manualGroupOrder
+                )
+            }
+        } else {
+            if oldSnapshot.sortMode != newSnapshot.sortMode {
+                settingsStore.updateSidebarGroupSortMode(newSnapshot.sortMode)
+            }
+            if oldSnapshot.fileSortMode != newSnapshot.fileSortMode {
+                settingsStore.updateSidebarSortMode(newSnapshot.fileSortMode)
+            }
+        }
+    }
+}

--- a/minimark/Views/Window/Coordination/WindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowCoordinator.swift
@@ -75,11 +75,13 @@ final class WindowCoordinator {
             folderWatchSessionProvider: { [weak self] in
                 self?.folderWatchFlowController?.sharedFolderWatchSession
             },
-            applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
-            refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() },
-            prepareRecentFolderWatch: { [weak self] folderURL, options in
-                self?.folderWatchFlowController?.presentOptions(for: folderURL, options: options)
-            }
+            callbacks: WindowOpenCallbacks(
+                applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
+                refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() },
+                prepareRecentFolderWatch: { [weak self] folderURL, options in
+                    self?.folderWatchFlowController?.presentOptions(for: folderURL, options: options)
+                }
+            )
         )
         self.sidebarActions = SidebarDocumentActionRouter(
             sidebarDocumentController: sidebarDocumentController,

--- a/minimark/Views/Window/Coordination/WindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowCoordinator.swift
@@ -108,15 +108,27 @@ final class WindowCoordinator {
             refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() }
         )
         self.events = WindowEventBridge(
-            shell: shell,
-            folderWatchOpen: folderWatchOpen,
-            sidebarDocumentController: sidebarDocumentController,
-            settingsStore: settingsStore,
-            groupStateControllerProvider: { [weak self] in self?.groupStateController },
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
-            appearanceControllerProvider: { [weak self] in self?.appearanceController },
-            uiTestLaunchCoordinatorProvider: { [weak self] in self?.uiTestLaunchCoordinator },
-            refreshWindowShellState: { [weak self] in self?.refreshWindowShellState() }
+            hostLifecycle: WindowHostLifecycleDispatcher(
+                shell: shell,
+                folderWatchOpen: folderWatchOpen,
+                uiTestLaunchCoordinatorProvider: { [weak self] in self?.uiTestLaunchCoordinator },
+                refreshWindowShellState: { [weak self] in self?.refreshWindowShellState() }
+            ),
+            documentSync: WindowDocumentSyncDispatcher(
+                shell: shell,
+                sidebarDocumentController: sidebarDocumentController,
+                settingsStore: settingsStore,
+                groupStateControllerProvider: { [weak self] in self?.groupStateController }
+            ),
+            favoriteWorkspace: FavoriteWorkspaceEventDispatcher(
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+                appearanceControllerProvider: { [weak self] in self?.appearanceController },
+                settingsStore: settingsStore
+            ),
+            groupState: GroupStateEventDispatcher(
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+                settingsStore: settingsStore
+            )
         )
         self.contentActions = ContentViewActionRouter(
             documentOpen: documentOpen,

--- a/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
@@ -38,9 +38,7 @@ final class WindowDocumentOpenCoordinator {
     private let sidebarDocumentController: SidebarDocumentController
     private let settingsStore: SettingsStore
     private let folderWatchSessionProvider: () -> FolderWatchSession?
-    private let applyTitlePresentation: () -> Void
-    private let refreshWindowPresentation: () -> Void
-    private let prepareRecentFolderWatch: (URL, FolderWatchOptions) -> Void
+    private let callbacks: WindowOpenCallbacks
 
     init(
         fileOpenCoordinator: FileOpenCoordinator,
@@ -48,18 +46,14 @@ final class WindowDocumentOpenCoordinator {
         sidebarDocumentController: SidebarDocumentController,
         settingsStore: SettingsStore,
         folderWatchSessionProvider: @escaping () -> FolderWatchSession?,
-        applyTitlePresentation: @escaping () -> Void,
-        refreshWindowPresentation: @escaping () -> Void,
-        prepareRecentFolderWatch: @escaping (URL, FolderWatchOptions) -> Void
+        callbacks: WindowOpenCallbacks
     ) {
         self.fileOpenCoordinator = fileOpenCoordinator
         self.folderWatchOpen = folderWatchOpen
         self.sidebarDocumentController = sidebarDocumentController
         self.settingsStore = settingsStore
         self.folderWatchSessionProvider = folderWatchSessionProvider
-        self.applyTitlePresentation = applyTitlePresentation
-        self.refreshWindowPresentation = refreshWindowPresentation
-        self.prepareRecentFolderWatch = prepareRecentFolderWatch
+        self.callbacks = callbacks
     }
 
     /// Install the store-callback configurator on the sidebar document controller.
@@ -86,7 +80,7 @@ final class WindowDocumentOpenCoordinator {
 
     func openFileRequest(_ request: FileOpenRequest) {
         fileOpenCoordinator.open(request)
-        refreshWindowPresentation()
+        callbacks.refreshWindowPresentation()
     }
 
     func openIncomingURL(_ url: URL) {
@@ -99,7 +93,7 @@ final class WindowDocumentOpenCoordinator {
             origin: .manual,
             slotStrategy: .replaceSelectedSlot
         ))
-        applyTitlePresentation()
+        callbacks.applyTitlePresentation()
     }
 
     func openDocumentInCurrentWindow(_ fileURL: URL) {
@@ -109,7 +103,7 @@ final class WindowDocumentOpenCoordinator {
             folderWatchSession: folderWatchSessionProvider(),
             slotStrategy: .replaceSelectedSlot
         ))
-        applyTitlePresentation()
+        callbacks.applyTitlePresentation()
     }
 
     func openDocumentInSelectedSlot(
@@ -126,7 +120,7 @@ final class WindowDocumentOpenCoordinator {
             initialDiffBaselineMarkdownByURL: initialDiffBaselineMarkdown.map { [normalizedURL: $0] } ?? [:],
             slotStrategy: .replaceSelectedSlot
         ))
-        applyTitlePresentation()
+        callbacks.applyTitlePresentation()
     }
 
     func openAdditionalDocument(
@@ -173,7 +167,7 @@ final class WindowDocumentOpenCoordinator {
             initialDiffBaselineMarkdownByURL: initialDiffBaselineMarkdown.map { [normalizedFileURL: $0] } ?? [:],
             slotStrategy: .reuseEmptySlotForFirst
         ))
-        applyTitlePresentation()
+        callbacks.applyTitlePresentation()
     }
 
     func applyInitialSeedIfNeeded(seed: WindowSeed?) {
@@ -197,7 +191,7 @@ final class WindowDocumentOpenCoordinator {
                 settingsStore.resolvedRecentWatchedFolderURL(matching: entry.folderURL) ?? entry.folderURL
             },
             prepareRecentFolderWatch: { [weak self] folderURL, options in
-                self?.prepareRecentFolderWatch(folderURL, options)
+                self?.callbacks.prepareRecentFolderWatch(folderURL, options)
             }
         )
     }

--- a/minimark/Views/Window/Coordination/WindowDocumentSyncDispatcher.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentSyncDispatcher.swift
@@ -1,0 +1,51 @@
+/// Syncs the sidebar document list + group state on window appear, disappear,
+/// and whenever the document list itself changes. Owns the window's
+/// `OpenDocumentPathTracker` because only this dispatcher mutates it.
+@MainActor
+final class WindowDocumentSyncDispatcher {
+    let openDocumentPathTracker = OpenDocumentPathTracker()
+
+    private let shell: WindowShellController
+    private let sidebarDocumentController: SidebarDocumentController
+    private let settingsStore: SettingsStore
+    private let groupStateControllerProvider: () -> SidebarGroupStateController?
+
+    init(
+        shell: WindowShellController,
+        sidebarDocumentController: SidebarDocumentController,
+        settingsStore: SettingsStore,
+        groupStateControllerProvider: @escaping () -> SidebarGroupStateController?
+    ) {
+        self.shell = shell
+        self.sidebarDocumentController = sidebarDocumentController
+        self.settingsStore = settingsStore
+        self.groupStateControllerProvider = groupStateControllerProvider
+    }
+
+    func handleWindowAppear() {
+        let groupState = groupStateControllerProvider()
+        groupState?.configureSortModes(
+            sortMode: settingsStore.currentSettings.sidebarGroupSortMode,
+            fileSortMode: settingsStore.currentSettings.sidebarSortMode
+        )
+        groupState?.updateDocuments(
+            sidebarDocumentController.documents,
+            rowStates: sidebarDocumentController.rowStates
+        )
+        groupState?.observeRowStates(from: sidebarDocumentController)
+        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
+        shell.configureDockTile()
+    }
+
+    func handleWindowDisappear() {
+        shell.clearDockTile()
+    }
+
+    func handleDocumentListChange() {
+        groupStateControllerProvider()?.updateDocuments(
+            sidebarDocumentController.documents,
+            rowStates: sidebarDocumentController.rowStates
+        )
+        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
+    }
+}

--- a/minimark/Views/Window/Coordination/WindowEventBridge.swift
+++ b/minimark/Views/Window/Coordination/WindowEventBridge.swift
@@ -3,123 +3,56 @@ import Foundation
 
 /// Translates SwiftUI window events (.background WindowAccessor, .onAppear,
 /// .onDisappear, .onChange of various properties) into mutations on the
-/// extracted controllers. Holds no business logic of its own — every method
-/// is a thin reducer dispatching to one or more collaborators.
-///
-/// Bundled here because every method is the same shape: a SwiftUI hook fires,
-/// the bridge decides which collaborators need to know. Splitting one method
-/// per file would just disperse that uniform pattern.
+/// extracted controllers. A thin composite over four focused dispatchers —
+/// each dispatcher owns its own slice of deps (see #373).
 @MainActor
 final class WindowEventBridge {
-    let openDocumentPathTracker = OpenDocumentPathTracker()
-
-    private let shell: WindowShellController
-    private let folderWatchOpen: WindowFolderWatchOpenController
-    private let sidebarDocumentController: SidebarDocumentController
-    private let settingsStore: SettingsStore
-    private let groupStateControllerProvider: () -> SidebarGroupStateController?
-    private let favoriteWorkspaceControllerProvider: () -> FavoriteWorkspaceController?
-    private let appearanceControllerProvider: () -> WindowAppearanceController?
-    private let uiTestLaunchCoordinatorProvider: () -> UITestLaunchCoordinator?
-    private let refreshWindowShellState: () -> Void
+    let hostLifecycle: WindowHostLifecycleDispatcher
+    let documentSync: WindowDocumentSyncDispatcher
+    let favoriteWorkspace: FavoriteWorkspaceEventDispatcher
+    let groupState: GroupStateEventDispatcher
 
     init(
-        shell: WindowShellController,
-        folderWatchOpen: WindowFolderWatchOpenController,
-        sidebarDocumentController: SidebarDocumentController,
-        settingsStore: SettingsStore,
-        groupStateControllerProvider: @escaping () -> SidebarGroupStateController?,
-        favoriteWorkspaceControllerProvider: @escaping () -> FavoriteWorkspaceController?,
-        appearanceControllerProvider: @escaping () -> WindowAppearanceController?,
-        uiTestLaunchCoordinatorProvider: @escaping () -> UITestLaunchCoordinator?,
-        refreshWindowShellState: @escaping () -> Void
+        hostLifecycle: WindowHostLifecycleDispatcher,
+        documentSync: WindowDocumentSyncDispatcher,
+        favoriteWorkspace: FavoriteWorkspaceEventDispatcher,
+        groupState: GroupStateEventDispatcher
     ) {
-        self.shell = shell
-        self.folderWatchOpen = folderWatchOpen
-        self.sidebarDocumentController = sidebarDocumentController
-        self.settingsStore = settingsStore
-        self.groupStateControllerProvider = groupStateControllerProvider
-        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
-        self.appearanceControllerProvider = appearanceControllerProvider
-        self.uiTestLaunchCoordinatorProvider = uiTestLaunchCoordinatorProvider
-        self.refreshWindowShellState = refreshWindowShellState
+        self.hostLifecycle = hostLifecycle
+        self.documentSync = documentSync
+        self.favoriteWorkspace = favoriteWorkspace
+        self.groupState = groupState
     }
+
+    /// Read-through surface kept for `WindowRootView` consumers. The tracker
+    /// itself is owned by `documentSync`, which is the only dispatcher that
+    /// mutates it.
+    var openDocumentPathTracker: OpenDocumentPathTracker { documentSync.openDocumentPathTracker }
 
     func handleWindowAccessorUpdate(_ window: NSWindow?) {
-        guard shell.updateHostWindow(window) else { return }
-        handleHostWindowChange()
-    }
-
-    private func handleHostWindowChange() {
-        refreshWindowShellState()
-        uiTestLaunchCoordinatorProvider()?.applyConfigurationIfNeeded()
-        if shell.hostWindow != nil, folderWatchOpen.hasPendingEvents {
-            folderWatchOpen.flush()
-        }
+        hostLifecycle.handleWindowAccessorUpdate(window)
     }
 
     func handleWindowAppear() {
-        let groupState = groupStateControllerProvider()
-        groupState?.configureSortModes(
-            sortMode: settingsStore.currentSettings.sidebarGroupSortMode,
-            fileSortMode: settingsStore.currentSettings.sidebarSortMode
-        )
-        groupState?.updateDocuments(
-            sidebarDocumentController.documents,
-            rowStates: sidebarDocumentController.rowStates
-        )
-        groupState?.observeRowStates(from: sidebarDocumentController)
-        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
-        shell.configureDockTile()
+        documentSync.handleWindowAppear()
     }
 
     func handleWindowDisappear() {
-        shell.clearDockTile()
+        documentSync.handleWindowDisappear()
     }
 
     func handleDocumentListChange() {
-        groupStateControllerProvider()?.updateDocuments(
-            sidebarDocumentController.documents,
-            rowStates: sidebarDocumentController.rowStates
-        )
-        openDocumentPathTracker.update(from: sidebarDocumentController.documents)
+        documentSync.handleDocumentListChange()
     }
 
     func handleFavoriteWorkspaceStateChange(_ newState: FavoriteWorkspaceState?) {
-        guard let favoriteID = favoriteWorkspaceControllerProvider()?.activeFavoriteID,
-              var state = newState else { return }
-        state.lockedAppearance = appearanceControllerProvider()?.lockedAppearance
-        settingsStore.updateFavoriteWorkspaceState(id: favoriteID, workspaceState: state)
+        favoriteWorkspace.handleFavoriteWorkspaceStateChange(newState)
     }
 
     func handleGroupStateChange(
         oldSnapshot: SidebarGroupStateController.WorkspaceStateSnapshot,
         newSnapshot: SidebarGroupStateController.WorkspaceStateSnapshot
     ) {
-        if let favoriteController = favoriteWorkspaceControllerProvider(), favoriteController.isActive {
-            let needsUpdate =
-                favoriteController.activeFavoriteWorkspaceState?.pinnedGroupIDs != newSnapshot.pinnedGroupIDs ||
-                favoriteController.activeFavoriteWorkspaceState?.collapsedGroupIDs != newSnapshot.collapsedGroupIDs ||
-                favoriteController.activeFavoriteWorkspaceState?.groupSortMode != newSnapshot.sortMode ||
-                favoriteController.activeFavoriteWorkspaceState?.fileSortMode != newSnapshot.fileSortMode ||
-                favoriteController.activeFavoriteWorkspaceState?.manualGroupOrder != newSnapshot.manualGroupOrder
-
-            if needsUpdate {
-                favoriteController.updateGroupState(
-                    pinnedGroupIDs: newSnapshot.pinnedGroupIDs,
-                    collapsedGroupIDs: newSnapshot.collapsedGroupIDs,
-                    groupSortMode: newSnapshot.sortMode,
-                    fileSortMode: newSnapshot.fileSortMode,
-                    manualGroupOrder: newSnapshot.manualGroupOrder
-                )
-            }
-        } else {
-            if oldSnapshot.sortMode != newSnapshot.sortMode {
-                settingsStore.updateSidebarGroupSortMode(newSnapshot.sortMode)
-            }
-            if oldSnapshot.fileSortMode != newSnapshot.fileSortMode {
-                settingsStore.updateSidebarSortMode(newSnapshot.fileSortMode)
-            }
-        }
+        groupState.handleGroupStateChange(oldSnapshot: oldSnapshot, newSnapshot: newSnapshot)
     }
 }

--- a/minimark/Views/Window/Coordination/WindowEventBridge.swift
+++ b/minimark/Views/Window/Coordination/WindowEventBridge.swift
@@ -7,10 +7,10 @@ import Foundation
 /// each dispatcher owns its own slice of deps (see #373).
 @MainActor
 final class WindowEventBridge {
-    let hostLifecycle: WindowHostLifecycleDispatcher
-    let documentSync: WindowDocumentSyncDispatcher
-    let favoriteWorkspace: FavoriteWorkspaceEventDispatcher
-    let groupState: GroupStateEventDispatcher
+    private let hostLifecycle: WindowHostLifecycleDispatcher
+    private let documentSync: WindowDocumentSyncDispatcher
+    private let favoriteWorkspace: FavoriteWorkspaceEventDispatcher
+    private let groupState: GroupStateEventDispatcher
 
     init(
         hostLifecycle: WindowHostLifecycleDispatcher,

--- a/minimark/Views/Window/Coordination/WindowHostLifecycleDispatcher.swift
+++ b/minimark/Views/Window/Coordination/WindowHostLifecycleDispatcher.swift
@@ -1,0 +1,37 @@
+import AppKit
+
+/// Bridges the SwiftUI `.background(WindowAccessor)` callback into the window
+/// shell. When the host `NSWindow` attaches/changes, refreshes shell state,
+/// applies the UI-test configuration, and flushes pending folder-watch opens.
+@MainActor
+final class WindowHostLifecycleDispatcher {
+    private let shell: WindowShellController
+    private let folderWatchOpen: WindowFolderWatchOpenController
+    private let uiTestLaunchCoordinatorProvider: () -> UITestLaunchCoordinator?
+    private let refreshWindowShellState: () -> Void
+
+    init(
+        shell: WindowShellController,
+        folderWatchOpen: WindowFolderWatchOpenController,
+        uiTestLaunchCoordinatorProvider: @escaping () -> UITestLaunchCoordinator?,
+        refreshWindowShellState: @escaping () -> Void
+    ) {
+        self.shell = shell
+        self.folderWatchOpen = folderWatchOpen
+        self.uiTestLaunchCoordinatorProvider = uiTestLaunchCoordinatorProvider
+        self.refreshWindowShellState = refreshWindowShellState
+    }
+
+    func handleWindowAccessorUpdate(_ window: NSWindow?) {
+        guard shell.updateHostWindow(window) else { return }
+        handleHostWindowChange()
+    }
+
+    private func handleHostWindowChange() {
+        refreshWindowShellState()
+        uiTestLaunchCoordinatorProvider()?.applyConfigurationIfNeeded()
+        if shell.hostWindow != nil, folderWatchOpen.hasPendingEvents {
+            folderWatchOpen.flush()
+        }
+    }
+}

--- a/minimark/Views/Window/Coordination/WindowOpenCallbacks.swift
+++ b/minimark/Views/Window/Coordination/WindowOpenCallbacks.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Callbacks the window asks the document-open coordinator to invoke after
+/// each kind of open. Always constructed together at `WindowCoordinator`.
+@MainActor
+struct WindowOpenCallbacks {
+    let applyTitlePresentation: () -> Void
+    let refreshWindowPresentation: () -> Void
+    let prepareRecentFolderWatch: (URL, FolderWatchOptions) -> Void
+}

--- a/minimarkTests/Core/ContentViewActionRouterTests.swift
+++ b/minimarkTests/Core/ContentViewActionRouterTests.swift
@@ -35,9 +35,11 @@ struct ContentViewActionRouterTests {
                 sidebarDocumentController: harness.controller,
                 settingsStore: harness.settingsStore,
                 folderWatchSessionProvider: { nil },
-                applyTitlePresentation: {},
-                refreshWindowPresentation: {},
-                prepareRecentFolderWatch: { _, _ in }
+                callbacks: WindowOpenCallbacks(
+                    applyTitlePresentation: {},
+                    refreshWindowPresentation: {},
+                    prepareRecentFolderWatch: { _, _ in }
+                )
             )
             self.appearanceLock = AppearanceLockCoordinator(
                 appearanceControllerProvider: { [appearanceController] in appearanceController },

--- a/minimarkTests/Core/WindowDocumentOpenCoordinatorTests.swift
+++ b/minimarkTests/Core/WindowDocumentOpenCoordinatorTests.swift
@@ -25,9 +25,11 @@ struct WindowDocumentOpenCoordinatorTests {
             sidebarDocumentController: harness.controller,
             settingsStore: harness.settingsStore,
             folderWatchSessionProvider: { folderWatchSession },
-            applyTitlePresentation: onAfterTitle,
-            refreshWindowPresentation: onAfterRefresh,
-            prepareRecentFolderWatch: onPrepareRecentFolderWatch
+            callbacks: WindowOpenCallbacks(
+                applyTitlePresentation: onAfterTitle,
+                refreshWindowPresentation: onAfterRefresh,
+                prepareRecentFolderWatch: onPrepareRecentFolderWatch
+            )
         )
         return (coordinator, folderWatchOpen, harness)
     }


### PR DESCRIPTION
Closes #373. Part of tracking issue #376.

## Summary

Brings every type in `minimark/Views/Window/Coordination/` to ≤ 6 constructor params.

| Type | Before | After |
| --- | --- | --- |
| `WindowDocumentOpenCoordinator` | 8 | 6 |
| `WindowEventBridge` | 9 | 4 |

### `WindowDocumentOpenCoordinator` — 8 → 6 (commit 1)
Three forwarded callbacks (`applyTitlePresentation`, `refreshWindowPresentation`, `prepareRecentFolderWatch`) bundled into a new `WindowOpenCallbacks` value type.

### `WindowEventBridge` — 9 → 4 (commit 2)
Split into four orthogonal `@MainActor final class` dispatchers, each holding only the deps it uses:

- `WindowHostLifecycleDispatcher` (4 deps) — `WindowAccessor` / host-window attachment.
- `WindowDocumentSyncDispatcher` (4 deps + owned `OpenDocumentPathTracker`) — window-appear, disappear, document-list sync.
- `FavoriteWorkspaceEventDispatcher` (3 deps) — favorite-workspace state persistence.
- `GroupStateEventDispatcher` (2 deps) — sidebar group/sort mutation persistence.

`WindowEventBridge` becomes a thin composite holding the 4 dispatchers. The `windowCoordinator.events.handleX(...)` surface used by `WindowRootView` at ~6 `.onChange`/`.onAppear` sites is preserved — no call-site churn outside `WindowCoordinator.init`. `openDocumentPathTracker` is exposed as a computed passthrough to the sync dispatcher that now owns it.

## Non-goals (kept)

- No VM facades.
- Dispatcher bodies are byte-for-byte copies of the original bridge methods — no logic changes.
- Tests: `WindowDocumentOpenCoordinator` had direct-construction tests that required updating for the new signature; `WindowEventBridge` has no direct unit tests, so test files for it were untouched.

## Test plan

- [x] `minimarkTests` full suite green
- [x] `minimarkUITests` green (1084 cases)
- [ ] Manual smoke: open a window, drag in a file, activate/deactivate a favorite workspace, reorder a group, close the window

## Follow-up note

With `WindowEventBridge` now a thin composite whose forwarders exist only to keep `WindowRootView` call sites stable, a future cleanup could dissolve it entirely and have `WindowCoordinator` expose the four dispatchers directly. Out of scope for #373's acceptance.