### PR TITLE
Split ContentViewActionRouter (15 params) into three focused routers (#372)

### DIFF
--- a/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
+++ b/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
@@ -1,124 +1,80 @@
 import Foundation
 
-/// Reduces three action enums (`ContentViewAction`, `FolderWatchToolbarAction`,
-/// `EditFavoritesAction`) by dispatching each case to the appropriate
-/// collaborator. Holds no state of its own — every case forwards to one of the
-/// extracted controllers, the settings store, or one of the composite
-/// callbacks that the window coordinator owns (folder-watch confirm/stop,
-/// favorite watch start, sidebar-flag toggles).
+/// Thin composite over three focused routers: `DocumentActionRouter`,
+/// `FolderWatchActionRouter`, `FavoriteActionRouter`. Each inbound action is
+/// switched on by case and dispatched to the matching sub-router method.
 @MainActor
 final class ContentViewActionRouter {
-    private let documentOpen: WindowDocumentOpenCoordinator
-    private let appearanceLock: AppearanceLockCoordinator
-    private let sidebarDocumentController: SidebarDocumentController
-    private let settingsStore: SettingsStore
-    private let folderWatchFlowControllerProvider: () -> FolderWatchFlowController?
-    private let favoriteWorkspaceControllerProvider: () -> FavoriteWorkspaceController?
-    private let recentHistoryCoordinatorProvider: () -> RecentHistoryCoordinator?
-    private let fileOpenCoordinator: FileOpenCoordinator
-    private let sidebarWidthProvider: () -> CGFloat
-    private let applyTitlePresentation: () -> Void
-    private let confirmFolderWatch: (FolderWatchOptions) -> Void
-    private let stopFolderWatch: () -> Void
-    private let startFavoriteWatch: (FavoriteWatchedFolder) -> Void
-    private let setEditingSubfolders: (Bool) -> Void
-    private let setEditingFavorites: (Bool) -> Void
+    private let document: DocumentActionRouter
+    private let folderWatch: FolderWatchActionRouter
+    private let favorite: FavoriteActionRouter
 
     init(
-        documentOpen: WindowDocumentOpenCoordinator,
-        appearanceLock: AppearanceLockCoordinator,
-        sidebarDocumentController: SidebarDocumentController,
-        settingsStore: SettingsStore,
-        folderWatchFlowControllerProvider: @escaping () -> FolderWatchFlowController?,
-        favoriteWorkspaceControllerProvider: @escaping () -> FavoriteWorkspaceController?,
-        recentHistoryCoordinatorProvider: @escaping () -> RecentHistoryCoordinator?,
-        fileOpenCoordinator: FileOpenCoordinator,
-        sidebarWidthProvider: @escaping () -> CGFloat,
-        applyTitlePresentation: @escaping () -> Void,
-        confirmFolderWatch: @escaping (FolderWatchOptions) -> Void,
-        stopFolderWatch: @escaping () -> Void,
-        startFavoriteWatch: @escaping (FavoriteWatchedFolder) -> Void,
-        setEditingSubfolders: @escaping (Bool) -> Void,
-        setEditingFavorites: @escaping (Bool) -> Void
+        document: DocumentActionRouter,
+        folderWatch: FolderWatchActionRouter,
+        favorite: FavoriteActionRouter
     ) {
-        self.documentOpen = documentOpen
-        self.appearanceLock = appearanceLock
-        self.sidebarDocumentController = sidebarDocumentController
-        self.settingsStore = settingsStore
-        self.folderWatchFlowControllerProvider = folderWatchFlowControllerProvider
-        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
-        self.recentHistoryCoordinatorProvider = recentHistoryCoordinatorProvider
-        self.fileOpenCoordinator = fileOpenCoordinator
-        self.sidebarWidthProvider = sidebarWidthProvider
-        self.applyTitlePresentation = applyTitlePresentation
-        self.confirmFolderWatch = confirmFolderWatch
-        self.stopFolderWatch = stopFolderWatch
-        self.startFavoriteWatch = startFavoriteWatch
-        self.setEditingSubfolders = setEditingSubfolders
-        self.setEditingFavorites = setEditingFavorites
+        self.document = document
+        self.folderWatch = folderWatch
+        self.favorite = favorite
     }
 
     func handle(_ action: ContentViewAction) {
         switch action {
         case .requestFileOpen(let request):
-            documentOpen.openFileRequest(request)
+            document.requestFileOpen(request)
         case .requestFolderWatch(let url):
-            folderWatchFlowControllerProvider()?.prepareOptions(for: url)
+            folderWatch.requestFolderWatch(url)
         case .confirmFolderWatch(let options):
-            confirmFolderWatch(options)
+            folderWatch.confirmFolderWatch(options)
         case .cancelFolderWatch:
-            folderWatchFlowControllerProvider()?.cancelPendingWatch()
+            folderWatch.cancelFolderWatch()
         case .stopFolderWatch:
-            stopFolderWatch()
+            folderWatch.stopFolderWatch()
         case .saveFolderWatchAsFavorite(let name):
-            favoriteWorkspaceControllerProvider()?.saveAsFavorite(name: name, currentSidebarWidth: sidebarWidthProvider())
+            favorite.saveFolderWatchAsFavorite(name: name)
         case .removeCurrentWatchFromFavorites:
-            favoriteWorkspaceControllerProvider()?.removeFromFavorites()
+            favorite.removeCurrentWatchFromFavorites()
         case .toggleAppearanceLock:
-            appearanceLock.toggleLock()
+            document.toggleAppearanceLock()
         case .startFavoriteWatch(let fav):
-            startFavoriteWatch(fav)
+            favorite.startFavoriteWatch(fav)
         case .clearFavoriteWatchedFolders:
-            favoriteWorkspaceControllerProvider()?.clearAll()
+            favorite.clearFavoriteWatchedFolders()
         case .renameFavoriteWatchedFolder(let id, let name):
-            settingsStore.renameFavoriteWatchedFolder(id: id, newName: name)
+            favorite.renameFavoriteWatchedFolder(id: id, name: name)
         case .removeFavoriteWatchedFolder(let id):
-            settingsStore.removeFavoriteWatchedFolder(id: id)
+            favorite.removeFavoriteWatchedFolder(id: id)
         case .reorderFavoriteWatchedFolders(let ids):
-            settingsStore.reorderFavoriteWatchedFolders(orderedIDs: ids)
+            favorite.reorderFavoriteWatchedFolders(orderedIDs: ids)
         case .startRecentManuallyOpenedFile(let entry):
-            recentHistoryCoordinatorProvider()?.openRecentFile(
-                entry,
-                using: fileOpenCoordinator,
-                session: folderWatchFlowControllerProvider()?.sharedFolderWatchSession
-            )
-            applyTitlePresentation()
+            favorite.startRecentManuallyOpenedFile(entry)
         case .startRecentFolderWatch(let entry):
-            recentHistoryCoordinatorProvider()?.startRecentFolderWatch(entry)
+            favorite.startRecentFolderWatch(entry)
         case .clearRecentWatchedFolders:
-            recentHistoryCoordinatorProvider()?.clearRecentWatchedFolders()
+            favorite.clearRecentWatchedFolders()
         case .clearRecentManuallyOpenedFiles:
-            recentHistoryCoordinatorProvider()?.clearRecentManuallyOpenedFiles()
+            favorite.clearRecentManuallyOpenedFiles()
         case .editSubfolders:
-            setEditingSubfolders(true)
+            folderWatch.editSubfolders()
         case .saveSourceDraft:
-            sidebarDocumentController.selectedDocumentStore.editingFlow.save()
+            document.saveSourceDraft()
         case .discardSourceDraft:
-            sidebarDocumentController.selectedDocumentStore.editingFlow.discard()
+            document.discardSourceDraft()
         case .startSourceEditing:
-            sidebarDocumentController.selectedDocumentStore.editingFlow.startEditing()
+            document.startSourceEditing()
         case .updateSourceDraft(let markdown):
-            sidebarDocumentController.selectedDocumentStore.editingFlow.updateDraft(markdown)
+            document.updateSourceDraft(markdown)
         case .grantImageDirectoryAccess(let url):
-            sidebarDocumentController.selectedDocumentStore.persister.grantImageDirectoryAccess(folderURL: url)
+            document.grantImageDirectoryAccess(url)
         case .openInApplication(let app):
-            sidebarDocumentController.selectedDocumentStore.document.openInApplication(app)
+            document.openInApplication(app)
         case .revealInFinder:
-            sidebarDocumentController.selectedDocumentStore.document.revealInFinder()
+            document.revealInFinder()
         case .presentError(let error):
-            sidebarDocumentController.selectedDocumentStore.document.handle(error)
+            document.presentError(error)
         case .updateTOCHeadings(let headings):
-            sidebarDocumentController.selectedDocumentStore.toc.updateHeadings(headings)
+            document.updateTOCHeadings(headings)
         }
     }
 
@@ -127,26 +83,26 @@ final class ContentViewActionRouter {
         case .activate:
             break // Handled by view (requires modal panel)
         case .startFavoriteWatch(let favorite):
-            startFavoriteWatch(favorite)
+            self.favorite.startFavoriteWatch(favorite)
         case .startRecentFolderWatch(let recent):
-            recentHistoryCoordinatorProvider()?.startRecentFolderWatch(recent)
+            favorite.startRecentFolderWatch(recent)
         case .editFavoriteWatchedFolders:
-            setEditingFavorites(true)
+            favorite.editFavoriteWatchedFolders()
         case .clearRecentWatchedFolders:
-            recentHistoryCoordinatorProvider()?.clearRecentWatchedFolders()
+            favorite.clearRecentWatchedFolders()
         }
     }
 
     func handle(_ action: EditFavoritesAction) {
         switch action {
         case .rename(let id, let name):
-            settingsStore.renameFavoriteWatchedFolder(id: id, newName: name)
+            favorite.renameFavoriteWatchedFolder(id: id, name: name)
         case .delete(let id):
-            settingsStore.removeFavoriteWatchedFolder(id: id)
+            favorite.removeFavoriteWatchedFolder(id: id)
         case .reorder(let ids):
-            settingsStore.reorderFavoriteWatchedFolders(orderedIDs: ids)
+            favorite.reorderFavoriteWatchedFolders(orderedIDs: ids)
         case .dismiss:
-            setEditingFavorites(false)
+            favorite.dismissEditFavorites()
         }
     }
 }

--- a/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
+++ b/minimark/Views/Window/Coordination/ContentViewActionRouter.swift
@@ -82,8 +82,8 @@ final class ContentViewActionRouter {
         switch action {
         case .activate:
             break // Handled by view (requires modal panel)
-        case .startFavoriteWatch(let favorite):
-            self.favorite.startFavoriteWatch(favorite)
+        case .startFavoriteWatch(let fav):
+            favorite.startFavoriteWatch(fav)
         case .startRecentFolderWatch(let recent):
             favorite.startRecentFolderWatch(recent)
         case .editFavoriteWatchedFolders:

--- a/minimark/Views/Window/Coordination/DocumentActionRouter.swift
+++ b/minimark/Views/Window/Coordination/DocumentActionRouter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Routes `ContentViewAction` cases that concern the active document:
+/// opens, editing-flow mutations, TOC updates, and appearance lock.
+@MainActor
+final class DocumentActionRouter {
+    private let documentOpen: WindowDocumentOpenCoordinator
+    private let appearanceLock: AppearanceLockCoordinator
+    private let sidebarDocumentController: SidebarDocumentController
+
+    init(
+        documentOpen: WindowDocumentOpenCoordinator,
+        appearanceLock: AppearanceLockCoordinator,
+        sidebarDocumentController: SidebarDocumentController
+    ) {
+        self.documentOpen = documentOpen
+        self.appearanceLock = appearanceLock
+        self.sidebarDocumentController = sidebarDocumentController
+    }
+
+    func requestFileOpen(_ request: FileOpenRequest) {
+        documentOpen.openFileRequest(request)
+    }
+
+    func toggleAppearanceLock() {
+        appearanceLock.toggleLock()
+    }
+
+    func saveSourceDraft() {
+        sidebarDocumentController.selectedDocumentStore.editingFlow.save()
+    }
+
+    func discardSourceDraft() {
+        sidebarDocumentController.selectedDocumentStore.editingFlow.discard()
+    }
+
+    func startSourceEditing() {
+        sidebarDocumentController.selectedDocumentStore.editingFlow.startEditing()
+    }
+
+    func updateSourceDraft(_ markdown: String) {
+        sidebarDocumentController.selectedDocumentStore.editingFlow.updateDraft(markdown)
+    }
+
+    func grantImageDirectoryAccess(_ url: URL) {
+        sidebarDocumentController.selectedDocumentStore.persister.grantImageDirectoryAccess(folderURL: url)
+    }
+
+    func openInApplication(_ app: ExternalApplication?) {
+        sidebarDocumentController.selectedDocumentStore.document.openInApplication(app)
+    }
+
+    func revealInFinder() {
+        sidebarDocumentController.selectedDocumentStore.document.revealInFinder()
+    }
+
+    func presentError(_ error: Error) {
+        sidebarDocumentController.selectedDocumentStore.document.handle(error)
+    }
+
+    func updateTOCHeadings(_ headings: [TOCHeading]) {
+        sidebarDocumentController.selectedDocumentStore.toc.updateHeadings(headings)
+    }
+}

--- a/minimark/Views/Window/Coordination/FavoriteActionRouter.swift
+++ b/minimark/Views/Window/Coordination/FavoriteActionRouter.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Routes favorite-watched-folder and recent-history actions, plus the
+/// edit-favorites flag.
+@MainActor
+final class FavoriteActionRouter {
+    private let favoriteWorkspaceControllerProvider: () -> FavoriteWorkspaceController?
+    private let recentHistoryCoordinatorProvider: () -> RecentHistoryCoordinator?
+    private let settingsStore: SettingsStore
+    private let fileOpenCoordinator: FileOpenCoordinator
+    private let folderWatchFlowControllerProvider: () -> FolderWatchFlowController?
+    private let callbacks: FavoriteRouterCallbacks
+
+    init(
+        favoriteWorkspaceControllerProvider: @escaping () -> FavoriteWorkspaceController?,
+        recentHistoryCoordinatorProvider: @escaping () -> RecentHistoryCoordinator?,
+        settingsStore: SettingsStore,
+        fileOpenCoordinator: FileOpenCoordinator,
+        folderWatchFlowControllerProvider: @escaping () -> FolderWatchFlowController?,
+        callbacks: FavoriteRouterCallbacks
+    ) {
+        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
+        self.recentHistoryCoordinatorProvider = recentHistoryCoordinatorProvider
+        self.settingsStore = settingsStore
+        self.fileOpenCoordinator = fileOpenCoordinator
+        self.folderWatchFlowControllerProvider = folderWatchFlowControllerProvider
+        self.callbacks = callbacks
+    }
+
+    func saveFolderWatchAsFavorite(name: String) {
+        favoriteWorkspaceControllerProvider()?.saveAsFavorite(
+            name: name,
+            currentSidebarWidth: callbacks.sidebarWidthProvider()
+        )
+    }
+
+    func removeCurrentWatchFromFavorites() {
+        favoriteWorkspaceControllerProvider()?.removeFromFavorites()
+    }
+
+    func startFavoriteWatch(_ favorite: FavoriteWatchedFolder) {
+        callbacks.startFavoriteWatch(favorite)
+    }
+
+    func clearFavoriteWatchedFolders() {
+        favoriteWorkspaceControllerProvider()?.clearAll()
+    }
+
+    func renameFavoriteWatchedFolder(id: UUID, name: String) {
+        settingsStore.renameFavoriteWatchedFolder(id: id, newName: name)
+    }
+
+    func removeFavoriteWatchedFolder(id: UUID) {
+        settingsStore.removeFavoriteWatchedFolder(id: id)
+    }
+
+    func reorderFavoriteWatchedFolders(orderedIDs: [UUID]) {
+        settingsStore.reorderFavoriteWatchedFolders(orderedIDs: orderedIDs)
+    }
+
+    func startRecentManuallyOpenedFile(_ entry: RecentOpenedFile) {
+        recentHistoryCoordinatorProvider()?.openRecentFile(
+            entry,
+            using: fileOpenCoordinator,
+            session: folderWatchFlowControllerProvider()?.sharedFolderWatchSession
+        )
+        callbacks.applyTitlePresentation()
+    }
+
+    func startRecentFolderWatch(_ entry: RecentWatchedFolder) {
+        recentHistoryCoordinatorProvider()?.startRecentFolderWatch(entry)
+    }
+
+    func clearRecentWatchedFolders() {
+        recentHistoryCoordinatorProvider()?.clearRecentWatchedFolders()
+    }
+
+    func clearRecentManuallyOpenedFiles() {
+        recentHistoryCoordinatorProvider()?.clearRecentManuallyOpenedFiles()
+    }
+
+    func editFavoriteWatchedFolders() {
+        callbacks.setEditingFavorites(true)
+    }
+
+    func dismissEditFavorites() {
+        callbacks.setEditingFavorites(false)
+    }
+}

--- a/minimark/Views/Window/Coordination/FavoriteRouterCallbacks.swift
+++ b/minimark/Views/Window/Coordination/FavoriteRouterCallbacks.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Window-scoped callbacks threaded into `FavoriteActionRouter`. Always
+/// constructed together at `WindowCoordinator`.
+@MainActor
+struct FavoriteRouterCallbacks {
+    let startFavoriteWatch: (FavoriteWatchedFolder) -> Void
+    let applyTitlePresentation: () -> Void
+    let sidebarWidthProvider: () -> CGFloat
+    let setEditingFavorites: (Bool) -> Void
+}

--- a/minimark/Views/Window/Coordination/FolderWatchActionRouter.swift
+++ b/minimark/Views/Window/Coordination/FolderWatchActionRouter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Routes folder-watch lifecycle actions: request/confirm/cancel/stop plus
+/// the edit-subfolders flag.
+@MainActor
+final class FolderWatchActionRouter {
+    private let folderWatchFlowControllerProvider: () -> FolderWatchFlowController?
+    private let callbacks: FolderWatchRouterCallbacks
+
+    init(
+        folderWatchFlowControllerProvider: @escaping () -> FolderWatchFlowController?,
+        callbacks: FolderWatchRouterCallbacks
+    ) {
+        self.folderWatchFlowControllerProvider = folderWatchFlowControllerProvider
+        self.callbacks = callbacks
+    }
+
+    func requestFolderWatch(_ url: URL) {
+        folderWatchFlowControllerProvider()?.prepareOptions(for: url)
+    }
+
+    func confirmFolderWatch(_ options: FolderWatchOptions) {
+        callbacks.confirmFolderWatch(options)
+    }
+
+    func cancelFolderWatch() {
+        folderWatchFlowControllerProvider()?.cancelPendingWatch()
+    }
+
+    func stopFolderWatch() {
+        callbacks.stopFolderWatch()
+    }
+
+    func editSubfolders() {
+        callbacks.setEditingSubfolders(true)
+    }
+}

--- a/minimark/Views/Window/Coordination/FolderWatchRouterCallbacks.swift
+++ b/minimark/Views/Window/Coordination/FolderWatchRouterCallbacks.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Window-scoped callbacks threaded into `FolderWatchActionRouter`. Always
+/// constructed together at `WindowCoordinator`.
+@MainActor
+struct FolderWatchRouterCallbacks {
+    let confirmFolderWatch: (FolderWatchOptions) -> Void
+    let stopFolderWatch: () -> Void
+    let setEditingSubfolders: (Bool) -> Void
+}

--- a/minimark/Views/Window/Coordination/WindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowCoordinator.swift
@@ -131,21 +131,32 @@ final class WindowCoordinator {
             )
         )
         self.contentActions = ContentViewActionRouter(
-            documentOpen: documentOpen,
-            appearanceLock: appearanceLock,
-            sidebarDocumentController: sidebarDocumentController,
-            settingsStore: settingsStore,
-            folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
-            recentHistoryCoordinatorProvider: { [weak self] in self?.recentHistoryCoordinator },
-            fileOpenCoordinator: sidebarDocumentController.fileOpenCoordinator,
-            sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? SidebarWorkspaceMetrics.sidebarIdealWidth },
-            applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
-            confirmFolderWatch: { [weak self] options in self?.folderWatchSession.confirm(options) },
-            stopFolderWatch: { [weak self] in self?.folderWatchSession.stop() },
-            startFavoriteWatch: { [weak self] favorite in self?.folderWatchSession.startFavoriteWatch(favorite) },
-            setEditingSubfolders: { [weak self] value in self?.isEditingSubfolders = value },
-            setEditingFavorites: { [weak self] value in self?.isTitlebarEditingFavorites = value }
+            document: DocumentActionRouter(
+                documentOpen: documentOpen,
+                appearanceLock: appearanceLock,
+                sidebarDocumentController: sidebarDocumentController
+            ),
+            folderWatch: FolderWatchActionRouter(
+                folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
+                callbacks: FolderWatchRouterCallbacks(
+                    confirmFolderWatch: { [weak self] options in self?.folderWatchSession.confirm(options) },
+                    stopFolderWatch: { [weak self] in self?.folderWatchSession.stop() },
+                    setEditingSubfolders: { [weak self] value in self?.isEditingSubfolders = value }
+                )
+            ),
+            favorite: FavoriteActionRouter(
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+                recentHistoryCoordinatorProvider: { [weak self] in self?.recentHistoryCoordinator },
+                settingsStore: settingsStore,
+                fileOpenCoordinator: sidebarDocumentController.fileOpenCoordinator,
+                folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
+                callbacks: FavoriteRouterCallbacks(
+                    startFavoriteWatch: { [weak self] favorite in self?.folderWatchSession.startFavoriteWatch(favorite) },
+                    applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
+                    sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? SidebarWorkspaceMetrics.sidebarIdealWidth },
+                    setEditingFavorites: { [weak self] value in self?.isTitlebarEditingFavorites = value }
+                )
+            )
         )
     }
 

--- a/minimarkTests/Core/ContentViewActionRouterTests.swift
+++ b/minimarkTests/Core/ContentViewActionRouterTests.swift
@@ -50,21 +50,32 @@ struct ContentViewActionRouterTests {
             // Box mutable state in a class so init-time closures can write to it.
             let state = MutableState()
             self.router = ContentViewActionRouter(
-                documentOpen: documentOpen,
-                appearanceLock: appearanceLock,
-                sidebarDocumentController: harness.controller,
-                settingsStore: harness.settingsStore,
-                folderWatchFlowControllerProvider: { nil },
-                favoriteWorkspaceControllerProvider: { nil },
-                recentHistoryCoordinatorProvider: { nil },
-                fileOpenCoordinator: harness.controller.fileOpenCoordinator,
-                sidebarWidthProvider: { 320 },
-                applyTitlePresentation: { state.applyTitleCalls += 1 },
-                confirmFolderWatch: { state.confirmFolderWatchCalls.append($0) },
-                stopFolderWatch: { state.stopFolderWatchCalls += 1 },
-                startFavoriteWatch: { state.startFavoriteWatchCalls.append($0) },
-                setEditingSubfolders: { state.setEditingSubfoldersCalls.append($0) },
-                setEditingFavorites: { state.setEditingFavoritesCalls.append($0) }
+                document: DocumentActionRouter(
+                    documentOpen: documentOpen,
+                    appearanceLock: appearanceLock,
+                    sidebarDocumentController: harness.controller
+                ),
+                folderWatch: FolderWatchActionRouter(
+                    folderWatchFlowControllerProvider: { nil },
+                    callbacks: FolderWatchRouterCallbacks(
+                        confirmFolderWatch: { state.confirmFolderWatchCalls.append($0) },
+                        stopFolderWatch: { state.stopFolderWatchCalls += 1 },
+                        setEditingSubfolders: { state.setEditingSubfoldersCalls.append($0) }
+                    )
+                ),
+                favorite: FavoriteActionRouter(
+                    favoriteWorkspaceControllerProvider: { nil },
+                    recentHistoryCoordinatorProvider: { nil },
+                    settingsStore: harness.settingsStore,
+                    fileOpenCoordinator: harness.controller.fileOpenCoordinator,
+                    folderWatchFlowControllerProvider: { nil },
+                    callbacks: FavoriteRouterCallbacks(
+                        startFavoriteWatch: { state.startFavoriteWatchCalls.append($0) },
+                        applyTitlePresentation: { state.applyTitleCalls += 1 },
+                        sidebarWidthProvider: { 320 },
+                        setEditingFavorites: { state.setEditingFavoritesCalls.append($0) }
+                    )
+                )
             )
             self.state = state
         }


### PR DESCRIPTION
Closes #372. Part of tracking issue #376.

## Summary

Splits the 15-param `ContentViewActionRouter` god class into three `@MainActor final class` sub-routers, each holding only the deps it actually uses. The top-level router becomes a thin composite whose three `handle(_:)` overloads switch + delegate to named sub-router methods.

| Type | Deps |
| --- | --- |
| `DocumentActionRouter` | 3 (documentOpen, appearanceLock, sidebarDocumentController) |
| `FolderWatchActionRouter` | 2 (folderWatchFlowControllerProvider, `FolderWatchRouterCallbacks`) |
| `FavoriteActionRouter` | 6 (favoriteWorkspaceControllerProvider, recentHistoryCoordinatorProvider, settingsStore, fileOpenCoordinator, folderWatchFlowControllerProvider, `FavoriteRouterCallbacks`) |
| `ContentViewActionRouter` (composite) | 3 |

Public API (`.handle(_ action:)` overloads for `ContentViewAction`, `FolderWatchToolbarAction`, `EditFavoritesAction`) is unchanged — no call-site churn at `WindowRootView` or the `minimark/Views/Content/` views.

## Non-goals

- No VM facades.
- Sub-router bodies copied verbatim from the original switch cases — no behaviour changes.
- `FavoriteActionRouter` intentionally covers both favorites + recents per the issue spec (5 settings/recent actions cluster on the same state-writing path).

## Commits

1. `298cb64` — Add `DocumentActionRouter` (3 deps)
2. `4af7977` — Add `FolderWatchActionRouter` + `FolderWatchRouterCallbacks`
3. `ce2d6c3` — Add `FavoriteActionRouter` + `FavoriteRouterCallbacks`
4. `901cc99` — Rewrite `ContentViewActionRouter` as thin composite + update `WindowCoordinator` callsite + test harness

## Test plan

- [x] `minimarkTests` full suite green (5 `ContentViewActionRouterTests` still pass against the new composite)
- [x] `minimarkUITests` green (1084 cases)