### PR TITLE
Replace two-phase configure with provider-based DI (#375)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -232,7 +232,10 @@ struct ContentView: View {
     let appearanceController = WindowAppearanceController(settingsStore: settingsStore)
     let folderWatchFlow = FolderWatchFlowController(
         settingsStore: settingsStore,
-        sidebarDocumentController: sidebarDocumentController
+        sidebarDocumentController: sidebarDocumentController,
+        favoriteWorkspaceControllerProvider: { nil },
+        groupStateControllerProvider: { nil },
+        appearanceControllerProvider: { nil }
     )
 
     return ContentView(

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -6,31 +6,29 @@ import Observation
 final class FavoriteWorkspaceController {
     private let settingsStore: any SettingsReading & FavoriteWriting
 
-    // Cross-references (set via configure())
-    private weak var sidebarDocumentController: SidebarDocumentController?
-    private weak var folderWatchFlowController: FolderWatchFlowController?
-    private weak var groupStateController: SidebarGroupStateController?
-    private weak var appearanceController: WindowAppearanceController?
+    // Cross-references (injected as providers to resolve construction-order cycles).
+    private let sidebarDocumentControllerProvider: @MainActor () -> SidebarDocumentController?
+    private let folderWatchFlowControllerProvider: @MainActor () -> FolderWatchFlowController?
+    private let groupStateControllerProvider: @MainActor () -> SidebarGroupStateController?
+    private let appearanceControllerProvider: @MainActor () -> WindowAppearanceController?
 
     private(set) var activeFavoriteID: UUID?
     private(set) var activeFavoriteWorkspaceState: FavoriteWorkspaceState?
 
     var isActive: Bool { activeFavoriteID != nil }
 
-    init(settingsStore: some SettingsReading & FavoriteWriting) {
-        self.settingsStore = settingsStore
-    }
-
-    func configure(
-        sidebarDocumentController: SidebarDocumentController,
-        folderWatchFlowController: FolderWatchFlowController,
-        groupStateController: SidebarGroupStateController,
-        appearanceController: WindowAppearanceController
+    init(
+        settingsStore: some SettingsReading & FavoriteWriting,
+        sidebarDocumentControllerProvider: @escaping @MainActor () -> SidebarDocumentController?,
+        folderWatchFlowControllerProvider: @escaping @MainActor () -> FolderWatchFlowController?,
+        groupStateControllerProvider: @escaping @MainActor () -> SidebarGroupStateController?,
+        appearanceControllerProvider: @escaping @MainActor () -> WindowAppearanceController?
     ) {
-        self.sidebarDocumentController = sidebarDocumentController
-        self.folderWatchFlowController = folderWatchFlowController
-        self.groupStateController = groupStateController
-        self.appearanceController = appearanceController
+        self.settingsStore = settingsStore
+        self.sidebarDocumentControllerProvider = sidebarDocumentControllerProvider
+        self.folderWatchFlowControllerProvider = folderWatchFlowControllerProvider
+        self.groupStateControllerProvider = groupStateControllerProvider
+        self.appearanceControllerProvider = appearanceControllerProvider
     }
 
     // MARK: - State Mutations
@@ -83,7 +81,7 @@ final class FavoriteWorkspaceController {
     }
 
     func matchingCurrentSession() -> FavoriteWatchedFolder? {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession else { return nil }
+        guard let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession else { return nil }
         return matchingFavorite(
             folderURL: session.folderURL,
             options: session.options,
@@ -98,7 +96,7 @@ final class FavoriteWorkspaceController {
     // MARK: - Open Document URLs
 
     func openDocumentFileURLs() -> [URL] {
-        sidebarDocumentController?.documents.compactMap { $0.documentStore.document.fileURL } ?? []
+        sidebarDocumentControllerProvider()?.documents.compactMap { $0.documentStore.document.fileURL } ?? []
     }
 
     // MARK: - Persistence
@@ -115,8 +113,8 @@ final class FavoriteWorkspaceController {
     // MARK: - Favorite Lifecycle
 
     func saveAsFavorite(name: String, currentSidebarWidth: CGFloat) {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession,
-              let groupStateController else { return }
+        guard let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession,
+              let groupStateController = groupStateControllerProvider() else { return }
         let groupSnapshot = groupStateController.persistenceSnapshot
         var workspaceState = FavoriteWorkspaceState.from(
             settings: settingsStore.currentSettings,
@@ -126,7 +124,7 @@ final class FavoriteWorkspaceController {
         )
         workspaceState.fileSortMode = groupSnapshot.fileSortMode
         workspaceState.groupSortMode = groupSnapshot.sortMode
-        workspaceState.lockedAppearance = appearanceController?.lockedAppearance
+        workspaceState.lockedAppearance = appearanceControllerProvider()?.lockedAppearance
         workspaceState.manualGroupOrder = groupSnapshot.manualGroupOrder
         settingsStore.addFavoriteWatchedFolder(
             name: name,
@@ -151,30 +149,30 @@ final class FavoriteWorkspaceController {
     func startFavoriteWatch(_ entry: FavoriteWatchedFolder) -> CGFloat {
         // Restore appearance FIRST
         if let lockedAppearance = entry.workspaceState.lockedAppearance {
-            appearanceController?.restore(from: lockedAppearance)
-        } else if appearanceController?.isLocked == true {
-            appearanceController?.unlock()
+            appearanceControllerProvider()?.restore(from: lockedAppearance)
+        } else if appearanceControllerProvider()?.isLocked == true {
+            appearanceControllerProvider()?.unlock()
         }
 
         // Activate and restore workspace state
         activate(id: entry.id, workspaceState: entry.workspaceState)
-        groupStateController?.applyWorkspaceState(entry.workspaceState)
+        groupStateControllerProvider()?.applyWorkspaceState(entry.workspaceState)
 
         // Start watching folder (via FWFC)
         let resolvedURL = settingsStore.resolvedFavoriteWatchedFolderURL(for: entry)
-        folderWatchFlowController?.startWatchingFolder(
+        folderWatchFlowControllerProvider()?.startWatchingFolder(
             folderURL: resolvedURL,
             options: entry.options,
             performInitialAutoOpen: false
         )
         // Refresh shared state so sharedFolderWatchSession is available
         // for file opening and document sync below.
-        folderWatchFlowController?.refreshSharedState()
+        folderWatchFlowControllerProvider()?.refreshSharedState()
 
         // Open restored files
         let restoredFileURLs = entry.existingOpenDocumentFileURLs(relativeTo: resolvedURL)
-        if let session = folderWatchFlowController?.sharedFolderWatchSession,
-           let fileOpenCoordinator = sidebarDocumentController?.fileOpenCoordinator,
+        if let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession,
+           let fileOpenCoordinator = sidebarDocumentControllerProvider()?.fileOpenCoordinator,
            !restoredFileURLs.isEmpty {
             fileOpenCoordinator.open(FileOpenRequest(
                 fileURLs: restoredFileURLs,
@@ -198,7 +196,7 @@ final class FavoriteWorkspaceController {
     }
 
     func syncOpenDocumentsIfNeeded() {
-        guard let session = folderWatchFlowController?.sharedFolderWatchSession,
+        guard let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession,
               let favorite = matchingCurrentSession() else { return }
 
         let currentURLs = openDocumentFileURLs()
@@ -223,10 +221,10 @@ final class FavoriteWorkspaceController {
         _ entry: FavoriteWatchedFolder,
         resolvedFolderURL: URL
     ) {
-        sidebarDocumentController?.folderWatchCoordinator.scanCurrentMarkdownFiles { [weak self] scannedURLs in
+        sidebarDocumentControllerProvider()?.folderWatchCoordinator.scanCurrentMarkdownFiles { [weak self] scannedURLs in
             guard let self,
-                  let session = folderWatchFlowController?.sharedFolderWatchSession,
-                  let fileOpenCoordinator = sidebarDocumentController?.fileOpenCoordinator else {
+                  let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession,
+                  let fileOpenCoordinator = sidebarDocumentControllerProvider()?.fileOpenCoordinator else {
                 return
             }
 
@@ -239,7 +237,7 @@ final class FavoriteWorkspaceController {
                     slotStrategy: .alwaysAppend,
                     materializationStrategy: .deferOnly
                 ))
-                sidebarDocumentController?.selectDocumentWithNewestModificationDate()
+                sidebarDocumentControllerProvider()?.selectDocumentWithNewestModificationDate()
             }
 
             settingsStore.updateFavoriteWatchedFolderKnownDocuments(

--- a/minimark/Stores/FavoriteWorkspaceController.swift
+++ b/minimark/Stores/FavoriteWorkspaceController.swift
@@ -147,11 +147,15 @@ final class FavoriteWorkspaceController {
 
     /// Returns the sidebar width from the favorite's workspace state (so the caller can apply it to window state).
     func startFavoriteWatch(_ entry: FavoriteWatchedFolder) -> CGFloat {
+        let appearanceController = appearanceControllerProvider()
+        let folderWatchFlowController = folderWatchFlowControllerProvider()
+        let sidebarDocumentController = sidebarDocumentControllerProvider()
+
         // Restore appearance FIRST
         if let lockedAppearance = entry.workspaceState.lockedAppearance {
-            appearanceControllerProvider()?.restore(from: lockedAppearance)
-        } else if appearanceControllerProvider()?.isLocked == true {
-            appearanceControllerProvider()?.unlock()
+            appearanceController?.restore(from: lockedAppearance)
+        } else if appearanceController?.isLocked == true {
+            appearanceController?.unlock()
         }
 
         // Activate and restore workspace state
@@ -160,19 +164,19 @@ final class FavoriteWorkspaceController {
 
         // Start watching folder (via FWFC)
         let resolvedURL = settingsStore.resolvedFavoriteWatchedFolderURL(for: entry)
-        folderWatchFlowControllerProvider()?.startWatchingFolder(
+        folderWatchFlowController?.startWatchingFolder(
             folderURL: resolvedURL,
             options: entry.options,
             performInitialAutoOpen: false
         )
         // Refresh shared state so sharedFolderWatchSession is available
         // for file opening and document sync below.
-        folderWatchFlowControllerProvider()?.refreshSharedState()
+        folderWatchFlowController?.refreshSharedState()
 
         // Open restored files
         let restoredFileURLs = entry.existingOpenDocumentFileURLs(relativeTo: resolvedURL)
-        if let session = folderWatchFlowControllerProvider()?.sharedFolderWatchSession,
-           let fileOpenCoordinator = sidebarDocumentControllerProvider()?.fileOpenCoordinator,
+        if let session = folderWatchFlowController?.sharedFolderWatchSession,
+           let fileOpenCoordinator = sidebarDocumentController?.fileOpenCoordinator,
            !restoredFileURLs.isEmpty {
             fileOpenCoordinator.open(FileOpenRequest(
                 fileURLs: restoredFileURLs,

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -138,16 +138,18 @@ final class FolderWatchFlowController {
     ) -> Bool {
         var didDeactivateFavorite = false
 
-        if favoriteWorkspaceControllerProvider()?.activeFavoriteID != nil {
+        let favoriteWorkspaceController = favoriteWorkspaceControllerProvider()
+        if let activeFavoriteID = favoriteWorkspaceController?.activeFavoriteID {
             let normalizedPath = FileRouting.normalizedFileURL(folderURL).path
             let matchesActiveFavorite = settingsStore.currentSettings.favoriteWatchedFolders.contains {
-                $0.id == favoriteWorkspaceControllerProvider()?.activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
+                $0.id == activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
             }
             if !matchesActiveFavorite {
-                favoriteWorkspaceControllerProvider()?.persistFinalState(to: settingsStore)
-                favoriteWorkspaceControllerProvider()?.deactivate()
-                groupStateControllerProvider()?.pinnedGroupIDs = []
-                groupStateControllerProvider()?.collapsedGroupIDs = []
+                let groupStateController = groupStateControllerProvider()
+                favoriteWorkspaceController?.persistFinalState(to: settingsStore)
+                favoriteWorkspaceController?.deactivate()
+                groupStateController?.pinnedGroupIDs = []
+                groupStateController?.collapsedGroupIDs = []
                 didDeactivateFavorite = true
                 Task { @MainActor [appearanceController = appearanceControllerProvider()] in
                     if appearanceController?.isLocked == true {
@@ -174,10 +176,12 @@ final class FolderWatchFlowController {
     /// Does NOT reset `sidebarWidth` or call `refreshWindowPresentation()` — the caller handles those.
     func stopFolderWatchSession() {
         dismissAutoOpenWarning()
-        favoriteWorkspaceControllerProvider()?.persistFinalState(to: settingsStore)
-        favoriteWorkspaceControllerProvider()?.deactivate()
-        groupStateControllerProvider()?.pinnedGroupIDs = []
-        groupStateControllerProvider()?.collapsedGroupIDs = []
+        let favoriteWorkspaceController = favoriteWorkspaceControllerProvider()
+        let groupStateController = groupStateControllerProvider()
+        favoriteWorkspaceController?.persistFinalState(to: settingsStore)
+        favoriteWorkspaceController?.deactivate()
+        groupStateController?.pinnedGroupIDs = []
+        groupStateController?.collapsedGroupIDs = []
         sidebarDocumentController.folderWatchCoordinator.stopFolderWatch()
         cancelPendingWatch()
     }

--- a/minimark/Stores/FolderWatchFlowController.swift
+++ b/minimark/Stores/FolderWatchFlowController.swift
@@ -25,24 +25,23 @@ final class FolderWatchFlowController {
     private let settingsStore: SettingsStore
     private let sidebarDocumentController: SidebarDocumentController
 
-    // Cross-references (set via configure())
-    private(set) weak var favoriteWorkspaceController: FavoriteWorkspaceController?
-    private(set) weak var groupStateController: SidebarGroupStateController?
-    private(set) weak var appearanceController: WindowAppearanceController?
+    // Cross-references (injected as providers to resolve construction-order cycles).
+    private let favoriteWorkspaceControllerProvider: @MainActor () -> FavoriteWorkspaceController?
+    private let groupStateControllerProvider: @MainActor () -> SidebarGroupStateController?
+    private let appearanceControllerProvider: @MainActor () -> WindowAppearanceController?
 
-    init(settingsStore: SettingsStore, sidebarDocumentController: SidebarDocumentController) {
+    init(
+        settingsStore: SettingsStore,
+        sidebarDocumentController: SidebarDocumentController,
+        favoriteWorkspaceControllerProvider: @escaping @MainActor () -> FavoriteWorkspaceController?,
+        groupStateControllerProvider: @escaping @MainActor () -> SidebarGroupStateController?,
+        appearanceControllerProvider: @escaping @MainActor () -> WindowAppearanceController?
+    ) {
         self.settingsStore = settingsStore
         self.sidebarDocumentController = sidebarDocumentController
-    }
-
-    func configure(
-        favoriteWorkspaceController: FavoriteWorkspaceController,
-        groupStateController: SidebarGroupStateController,
-        appearanceController: WindowAppearanceController
-    ) {
-        self.favoriteWorkspaceController = favoriteWorkspaceController
-        self.groupStateController = groupStateController
-        self.appearanceController = appearanceController
+        self.favoriteWorkspaceControllerProvider = favoriteWorkspaceControllerProvider
+        self.groupStateControllerProvider = groupStateControllerProvider
+        self.appearanceControllerProvider = appearanceControllerProvider
     }
 
     // MARK: - Presentation State
@@ -139,18 +138,18 @@ final class FolderWatchFlowController {
     ) -> Bool {
         var didDeactivateFavorite = false
 
-        if favoriteWorkspaceController?.activeFavoriteID != nil {
+        if favoriteWorkspaceControllerProvider()?.activeFavoriteID != nil {
             let normalizedPath = FileRouting.normalizedFileURL(folderURL).path
             let matchesActiveFavorite = settingsStore.currentSettings.favoriteWatchedFolders.contains {
-                $0.id == favoriteWorkspaceController?.activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
+                $0.id == favoriteWorkspaceControllerProvider()?.activeFavoriteID && $0.matches(folderPath: normalizedPath, options: options)
             }
             if !matchesActiveFavorite {
-                favoriteWorkspaceController?.persistFinalState(to: settingsStore)
-                favoriteWorkspaceController?.deactivate()
-                groupStateController?.pinnedGroupIDs = []
-                groupStateController?.collapsedGroupIDs = []
+                favoriteWorkspaceControllerProvider()?.persistFinalState(to: settingsStore)
+                favoriteWorkspaceControllerProvider()?.deactivate()
+                groupStateControllerProvider()?.pinnedGroupIDs = []
+                groupStateControllerProvider()?.collapsedGroupIDs = []
                 didDeactivateFavorite = true
-                Task { @MainActor [appearanceController] in
+                Task { @MainActor [appearanceController = appearanceControllerProvider()] in
                     if appearanceController?.isLocked == true {
                         appearanceController?.unlock()
                     }
@@ -175,10 +174,10 @@ final class FolderWatchFlowController {
     /// Does NOT reset `sidebarWidth` or call `refreshWindowPresentation()` — the caller handles those.
     func stopFolderWatchSession() {
         dismissAutoOpenWarning()
-        favoriteWorkspaceController?.persistFinalState(to: settingsStore)
-        favoriteWorkspaceController?.deactivate()
-        groupStateController?.pinnedGroupIDs = []
-        groupStateController?.collapsedGroupIDs = []
+        favoriteWorkspaceControllerProvider()?.persistFinalState(to: settingsStore)
+        favoriteWorkspaceControllerProvider()?.deactivate()
+        groupStateControllerProvider()?.pinnedGroupIDs = []
+        groupStateControllerProvider()?.collapsedGroupIDs = []
         sidebarDocumentController.folderWatchCoordinator.stopFolderWatch()
         cancelPendingWatch()
     }
@@ -238,7 +237,7 @@ final class FolderWatchFlowController {
     }
 
     private func syncFavoriteExclusionsIfNeeded(_ excludedPaths: [String]) {
-        guard let favoriteID = favoriteWorkspaceController?.activeFavoriteID else { return }
+        guard let favoriteID = favoriteWorkspaceControllerProvider()?.activeFavoriteID else { return }
         settingsStore.updateFavoriteWatchedFolderExclusions(
             id: favoriteID,
             excludedSubdirectoryPaths: excludedPaths

--- a/minimark/Support/WeakBox.swift
+++ b/minimark/Support/WeakBox.swift
@@ -1,0 +1,12 @@
+/// Forward-reference cell used when constructing a graph of objects that
+/// need to point back at each other. The owning side stores a strong
+/// reference; the forward-referring side reads the cell via a closure so
+/// that both objects can be constructed before the cycle is wired.
+@MainActor
+final class WeakBox<T: AnyObject> {
+    weak var value: T?
+
+    init(_ value: T? = nil) {
+        self.value = value
+    }
+}

--- a/minimark/Views/Window/Coordination/WindowCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowCoordinator.swift
@@ -3,10 +3,21 @@ import Foundation
 import Observation
 
 @MainActor
+struct WindowCoordinatorDependencies {
+    let appearanceController: @MainActor () -> WindowAppearanceController?
+    let groupStateController: @MainActor () -> SidebarGroupStateController?
+    let favoriteWorkspaceController: @MainActor () -> FavoriteWorkspaceController?
+    let folderWatchFlowController: @MainActor () -> FolderWatchFlowController?
+    let uiTestLaunchCoordinator: @MainActor () -> UITestLaunchCoordinator?
+    let recentHistoryCoordinator: @MainActor () -> RecentHistoryCoordinator?
+}
+
+@MainActor
 @Observable
 final class WindowCoordinator {
     private let settingsStore: SettingsStore
     private let sidebarDocumentController: SidebarDocumentController
+    private let dependencies: WindowCoordinatorDependencies
     private(set) var folderWatchOpen: WindowFolderWatchOpenController!
     private(set) var shell: WindowShellController!
     private(set) var documentOpen: WindowDocumentOpenCoordinator!
@@ -23,43 +34,18 @@ final class WindowCoordinator {
     var isTitlebarEditingFavorites = false
     var isEditingSubfolders = false
 
-    // Controller references (set via configure())
-    private var appearanceController: WindowAppearanceController?
-    private var groupStateController: SidebarGroupStateController?
-    private var favoriteWorkspaceController: FavoriteWorkspaceController?
-    private var folderWatchFlowController: FolderWatchFlowController?
-    private var uiTestLaunchCoordinator: UITestLaunchCoordinator?
-    private var recentHistoryCoordinator: RecentHistoryCoordinator?
-
-    func configure(
-        appearanceController: WindowAppearanceController,
-        groupStateController: SidebarGroupStateController,
-        favoriteWorkspaceController: FavoriteWorkspaceController,
-        folderWatchFlowController: FolderWatchFlowController,
-        uiTestLaunchCoordinator: UITestLaunchCoordinator,
-        recentHistoryCoordinator: RecentHistoryCoordinator
-    ) {
-        self.appearanceController = appearanceController
-        self.groupStateController = groupStateController
-        self.favoriteWorkspaceController = favoriteWorkspaceController
-        self.folderWatchFlowController = folderWatchFlowController
-        self.uiTestLaunchCoordinator = uiTestLaunchCoordinator
-        self.recentHistoryCoordinator = recentHistoryCoordinator
-        documentOpen.configureStoreCallbacks(
-            lockedAppearanceProvider: { [weak appearanceController] in appearanceController?.lockedAppearance }
-        )
-    }
-
     init(
         settingsStore: SettingsStore,
-        sidebarDocumentController: SidebarDocumentController
+        sidebarDocumentController: SidebarDocumentController,
+        dependencies: WindowCoordinatorDependencies
     ) {
         self.settingsStore = settingsStore
         self.sidebarDocumentController = sidebarDocumentController
+        self.dependencies = dependencies
         self.shell = WindowShellController(
             sidebarDocumentController: sidebarDocumentController,
             folderWatchSessionProvider: { [weak self] in
-                self?.folderWatchFlowController?.sharedFolderWatchSession
+                self?.dependencies.folderWatchFlowController()?.sharedFolderWatchSession
             }
         )
         self.folderWatchOpen = WindowFolderWatchOpenController(
@@ -73,36 +59,36 @@ final class WindowCoordinator {
             sidebarDocumentController: sidebarDocumentController,
             settingsStore: settingsStore,
             folderWatchSessionProvider: { [weak self] in
-                self?.folderWatchFlowController?.sharedFolderWatchSession
+                self?.dependencies.folderWatchFlowController()?.sharedFolderWatchSession
             },
             callbacks: WindowOpenCallbacks(
                 applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
                 refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() },
                 prepareRecentFolderWatch: { [weak self] folderURL, options in
-                    self?.folderWatchFlowController?.presentOptions(for: folderURL, options: options)
+                    self?.dependencies.folderWatchFlowController()?.presentOptions(for: folderURL, options: options)
                 }
             )
         )
         self.sidebarActions = SidebarDocumentActionRouter(
             sidebarDocumentController: sidebarDocumentController,
             settingsStore: settingsStore,
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+            favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
             sidebarWidthProvider: { [weak self] in self?.sidebarMetrics.width ?? SidebarWorkspaceMetrics.sidebarIdealWidth },
             refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() }
         )
         self.appearanceLock = AppearanceLockCoordinator(
-            appearanceControllerProvider: { [weak self] in self?.appearanceController },
+            appearanceControllerProvider: { [weak self] in self?.dependencies.appearanceController() },
             sidebarDocumentController: sidebarDocumentController,
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController }
+            favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() }
         )
         self.sidebarMetrics = WindowSidebarMetricsController(
             sidebarDocumentController: sidebarDocumentController,
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+            favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
             hostWindowProvider: { [weak self] in self?.shell.hostWindow }
         )
         self.folderWatchSession = WindowFolderWatchSessionFlow(
-            folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
-            favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+            folderWatchFlowControllerProvider: { [weak self] in self?.dependencies.folderWatchFlowController() },
+            favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
             sidebarMetrics: sidebarMetrics,
             hostWindowProvider: { [weak self] in self?.shell.hostWindow },
             refreshWindowPresentation: { [weak self] in self?.refreshWindowPresentation() }
@@ -111,22 +97,22 @@ final class WindowCoordinator {
             hostLifecycle: WindowHostLifecycleDispatcher(
                 shell: shell,
                 folderWatchOpen: folderWatchOpen,
-                uiTestLaunchCoordinatorProvider: { [weak self] in self?.uiTestLaunchCoordinator },
+                uiTestLaunchCoordinatorProvider: { [weak self] in self?.dependencies.uiTestLaunchCoordinator() },
                 refreshWindowShellState: { [weak self] in self?.refreshWindowShellState() }
             ),
             documentSync: WindowDocumentSyncDispatcher(
                 shell: shell,
                 sidebarDocumentController: sidebarDocumentController,
                 settingsStore: settingsStore,
-                groupStateControllerProvider: { [weak self] in self?.groupStateController }
+                groupStateControllerProvider: { [weak self] in self?.dependencies.groupStateController() }
             ),
             favoriteWorkspace: FavoriteWorkspaceEventDispatcher(
-                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
-                appearanceControllerProvider: { [weak self] in self?.appearanceController },
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
+                appearanceControllerProvider: { [weak self] in self?.dependencies.appearanceController() },
                 settingsStore: settingsStore
             ),
             groupState: GroupStateEventDispatcher(
-                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
                 settingsStore: settingsStore
             )
         )
@@ -137,7 +123,7 @@ final class WindowCoordinator {
                 sidebarDocumentController: sidebarDocumentController
             ),
             folderWatch: FolderWatchActionRouter(
-                folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
+                folderWatchFlowControllerProvider: { [weak self] in self?.dependencies.folderWatchFlowController() },
                 callbacks: FolderWatchRouterCallbacks(
                     confirmFolderWatch: { [weak self] options in self?.folderWatchSession.confirm(options) },
                     stopFolderWatch: { [weak self] in self?.folderWatchSession.stop() },
@@ -145,11 +131,11 @@ final class WindowCoordinator {
                 )
             ),
             favorite: FavoriteActionRouter(
-                favoriteWorkspaceControllerProvider: { [weak self] in self?.favoriteWorkspaceController },
-                recentHistoryCoordinatorProvider: { [weak self] in self?.recentHistoryCoordinator },
+                favoriteWorkspaceControllerProvider: { [weak self] in self?.dependencies.favoriteWorkspaceController() },
+                recentHistoryCoordinatorProvider: { [weak self] in self?.dependencies.recentHistoryCoordinator() },
                 settingsStore: settingsStore,
                 fileOpenCoordinator: sidebarDocumentController.fileOpenCoordinator,
-                folderWatchFlowControllerProvider: { [weak self] in self?.folderWatchFlowController },
+                folderWatchFlowControllerProvider: { [weak self] in self?.dependencies.folderWatchFlowController() },
                 callbacks: FavoriteRouterCallbacks(
                     startFavoriteWatch: { [weak self] favorite in self?.folderWatchSession.startFavoriteWatch(favorite) },
                     applyTitlePresentation: { [weak self] in self?.shell.applyTitlePresentation() },
@@ -158,12 +144,15 @@ final class WindowCoordinator {
                 )
             )
         )
+        documentOpen.configureStoreCallbacks(
+            lockedAppearanceProvider: { [dependencies] in dependencies.appearanceController()?.lockedAppearance }
+        )
     }
 
     // MARK: - Composite refresh
 
     private func refreshSharedFolderWatchState() {
-        folderWatchFlowController?.refreshSharedState()
+        dependencies.folderWatchFlowController()?.refreshSharedState()
     }
 
     func refreshWindowPresentation() {

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -49,20 +49,28 @@ struct WindowRootView: View {
         )
         favoriteBox.value = favoriteWorkspaceController
 
+        let recentHistoryCoordinator = RecentHistoryCoordinator(settingsStore: settingsStore)
+
         _sidebarDocumentController = State(wrappedValue: sidebarDocumentController)
         _groupStateController = State(wrappedValue: groupStateController)
         _appearanceController = State(wrappedValue: appearanceController)
         _uiTestLaunchCoordinator = State(wrappedValue: uiTestLaunchCoordinator)
         _folderWatchFlowController = State(wrappedValue: folderWatchFlowController)
         _favoriteWorkspaceController = State(wrappedValue: favoriteWorkspaceController)
+        _recentHistoryCoordinator = State(wrappedValue: recentHistoryCoordinator)
         _windowCoordinator = State(
             wrappedValue: WindowCoordinator(
                 settingsStore: settingsStore,
-                sidebarDocumentController: sidebarDocumentController
+                sidebarDocumentController: sidebarDocumentController,
+                dependencies: WindowCoordinatorDependencies(
+                    appearanceController: { [weak appearanceController] in appearanceController },
+                    groupStateController: { [weak groupStateController] in groupStateController },
+                    favoriteWorkspaceController: { [weak favoriteWorkspaceController] in favoriteWorkspaceController },
+                    folderWatchFlowController: { [weak folderWatchFlowController] in folderWatchFlowController },
+                    uiTestLaunchCoordinator: { [weak uiTestLaunchCoordinator] in uiTestLaunchCoordinator },
+                    recentHistoryCoordinator: { [weak recentHistoryCoordinator] in recentHistoryCoordinator }
+                )
             )
-        )
-        _recentHistoryCoordinator = State(
-            wrappedValue: RecentHistoryCoordinator(settingsStore: settingsStore)
         )
     }
 
@@ -278,14 +286,6 @@ struct WindowRootView: View {
             }
         ))
         recentHistoryCoordinator.configure(folderWatchFlowController: folderWatchFlowController)
-        windowCoordinator.configure(
-            appearanceController: appearanceController,
-            groupStateController: groupStateController,
-            favoriteWorkspaceController: favoriteWorkspaceController,
-            folderWatchFlowController: folderWatchFlowController,
-            uiTestLaunchCoordinator: uiTestLaunchCoordinator,
-            recentHistoryCoordinator: recentHistoryCoordinator
-        )
         windowCoordinator.documentOpen.applyInitialSeedIfNeeded(seed: seed)
         folderWatchFlowController.refreshSharedState()
         // Now that all controllers are wired, try to apply the UI-test launch

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -10,11 +10,11 @@ struct WindowRootView: View {
     @State var sidebarDocumentController: SidebarDocumentController
     @State var windowCoordinator: WindowCoordinator
     @State var appearanceController: WindowAppearanceController
-    @State var groupStateController = SidebarGroupStateController()
+    @State var groupStateController: SidebarGroupStateController
     @State var favoriteWorkspaceController: FavoriteWorkspaceController
     @State var folderWatchFlowController: FolderWatchFlowController
     @State var recentHistoryCoordinator: RecentHistoryCoordinator
-    @State var uiTestLaunchCoordinator = UITestLaunchCoordinator()
+    @State var uiTestLaunchCoordinator: UITestLaunchCoordinator
 
     init(
         seed: WindowSeed?,
@@ -24,22 +24,42 @@ struct WindowRootView: View {
         self.seed = seed
         self.settingsStore = settingsStore
         self.multiFileDisplayMode = multiFileDisplayMode
+
         let sidebarDocumentController = SidebarDocumentController(settingsStore: settingsStore)
+        let groupStateController = SidebarGroupStateController()
+        let appearanceController = WindowAppearanceController(settingsStore: settingsStore)
+        let uiTestLaunchCoordinator = UITestLaunchCoordinator()
+
+        let favoriteBox = WeakBox<FavoriteWorkspaceController>()
+
+        let folderWatchFlowController = FolderWatchFlowController(
+            settingsStore: settingsStore,
+            sidebarDocumentController: sidebarDocumentController,
+            favoriteWorkspaceControllerProvider: { favoriteBox.value },
+            groupStateControllerProvider: { [weak groupStateController] in groupStateController },
+            appearanceControllerProvider: { [weak appearanceController] in appearanceController }
+        )
+
+        let favoriteWorkspaceController = FavoriteWorkspaceController(
+            settingsStore: settingsStore,
+            sidebarDocumentControllerProvider: { [weak sidebarDocumentController] in sidebarDocumentController },
+            folderWatchFlowControllerProvider: { [weak folderWatchFlowController] in folderWatchFlowController },
+            groupStateControllerProvider: { [weak groupStateController] in groupStateController },
+            appearanceControllerProvider: { [weak appearanceController] in appearanceController }
+        )
+        favoriteBox.value = favoriteWorkspaceController
+
         _sidebarDocumentController = State(wrappedValue: sidebarDocumentController)
+        _groupStateController = State(wrappedValue: groupStateController)
+        _appearanceController = State(wrappedValue: appearanceController)
+        _uiTestLaunchCoordinator = State(wrappedValue: uiTestLaunchCoordinator)
+        _folderWatchFlowController = State(wrappedValue: folderWatchFlowController)
+        _favoriteWorkspaceController = State(wrappedValue: favoriteWorkspaceController)
         _windowCoordinator = State(
             wrappedValue: WindowCoordinator(
                 settingsStore: settingsStore,
                 sidebarDocumentController: sidebarDocumentController
             )
-        )
-        _appearanceController = State(
-            wrappedValue: WindowAppearanceController(settingsStore: settingsStore)
-        )
-        _favoriteWorkspaceController = State(
-            wrappedValue: FavoriteWorkspaceController(settingsStore: settingsStore)
-        )
-        _folderWatchFlowController = State(
-            wrappedValue: FolderWatchFlowController(settingsStore: settingsStore, sidebarDocumentController: sidebarDocumentController)
         )
         _recentHistoryCoordinator = State(
             wrappedValue: RecentHistoryCoordinator(settingsStore: settingsStore)
@@ -257,17 +277,6 @@ struct WindowRootView: View {
                 folderWatchFlowController?.sharedFolderWatchSession != nil
             }
         ))
-        favoriteWorkspaceController.configure(
-            sidebarDocumentController: sidebarDocumentController,
-            folderWatchFlowController: folderWatchFlowController,
-            groupStateController: groupStateController,
-            appearanceController: appearanceController
-        )
-        folderWatchFlowController.configure(
-            favoriteWorkspaceController: favoriteWorkspaceController,
-            groupStateController: groupStateController,
-            appearanceController: appearanceController
-        )
         recentHistoryCoordinator.configure(folderWatchFlowController: folderWatchFlowController)
         windowCoordinator.configure(
             appearanceController: appearanceController,

--- a/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
+++ b/minimarkTests/Core/FavoriteWorkspaceControllerTests.swift
@@ -6,7 +6,13 @@ import Testing
 struct FavoriteWorkspaceControllerTests {
     @MainActor private func makeController() -> FavoriteWorkspaceController {
         let store = TestSettingsStore(autoRefreshOnExternalChange: false)
-        return FavoriteWorkspaceController(settingsStore: store)
+        return FavoriteWorkspaceController(
+            settingsStore: store,
+            sidebarDocumentControllerProvider: { nil },
+            folderWatchFlowControllerProvider: { nil },
+            groupStateControllerProvider: { nil },
+            appearanceControllerProvider: { nil }
+        )
     }
 
     @Test @MainActor func initialStateIsInactive() {
@@ -120,7 +126,13 @@ struct FavoriteWorkspaceControllerTests {
 
     @Test @MainActor func persistFinalStateWritesToSettingsStore() {
         let store = TestSettingsStore(autoRefreshOnExternalChange: false)
-        let controller = FavoriteWorkspaceController(settingsStore: store)
+        let controller = FavoriteWorkspaceController(
+            settingsStore: store,
+            sidebarDocumentControllerProvider: { nil },
+            folderWatchFlowControllerProvider: { nil },
+            groupStateControllerProvider: { nil },
+            appearanceControllerProvider: { nil }
+        )
         store.addFavoriteWatchedFolder(name: "Persist", folderURL: URL(fileURLWithPath: "/tmp/persist"), options: .default)
         let favoriteID = store.currentSettings.favoriteWatchedFolders.first!.id
         var workspaceState = FavoriteWorkspaceState.from(
@@ -137,7 +149,13 @@ struct FavoriteWorkspaceControllerTests {
 
     @Test @MainActor func persistFinalStateIsNoOpWhenInactive() {
         let store = TestSettingsStore(autoRefreshOnExternalChange: false)
-        let controller = FavoriteWorkspaceController(settingsStore: store)
+        let controller = FavoriteWorkspaceController(
+            settingsStore: store,
+            sidebarDocumentControllerProvider: { nil },
+            folderWatchFlowControllerProvider: { nil },
+            groupStateControllerProvider: { nil },
+            appearanceControllerProvider: { nil }
+        )
         store.addFavoriteWatchedFolder(name: "NoOp", folderURL: URL(fileURLWithPath: "/tmp/no-persist"), options: .default)
         controller.persistFinalState(to: store)
         let persisted = store.currentSettings.favoriteWatchedFolders.first!

--- a/minimarkTests/Core/WindowShellStateTests.swift
+++ b/minimarkTests/Core/WindowShellStateTests.swift
@@ -16,7 +16,15 @@ struct WindowShellStateTests {
         let harness = try SidebarControllerTestHarness()
         let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
+            sidebarDocumentController: harness.controller,
+            dependencies: WindowCoordinatorDependencies(
+                appearanceController: { nil },
+                groupStateController: { nil },
+                favoriteWorkspaceController: { nil },
+                folderWatchFlowController: { nil },
+                uiTestLaunchCoordinator: { nil },
+                recentHistoryCoordinator: { nil }
+            )
         )
         return (coordinator, harness)
     }

--- a/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
+++ b/minimarkTests/FolderWatch/FolderWatchCoordinationTests.swift
@@ -844,7 +844,15 @@ struct FolderWatchCoordinationTests {
 
         let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
+            sidebarDocumentController: harness.controller,
+            dependencies: WindowCoordinatorDependencies(
+                appearanceController: { nil },
+                groupStateController: { nil },
+                favoriteWorkspaceController: { nil },
+                folderWatchFlowController: { nil },
+                uiTestLaunchCoordinator: { nil },
+                recentHistoryCoordinator: { nil }
+            )
         )
 
         coordinator.shell.applyTitlePresentation()
@@ -863,7 +871,15 @@ struct FolderWatchCoordinationTests {
 
         let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
+            sidebarDocumentController: harness.controller,
+            dependencies: WindowCoordinatorDependencies(
+                appearanceController: { nil },
+                groupStateController: { nil },
+                favoriteWorkspaceController: { nil },
+                folderWatchFlowController: { nil },
+                uiTestLaunchCoordinator: { nil },
+                recentHistoryCoordinator: { nil }
+            )
         )
         let queuedURL = URL(fileURLWithPath: "/tmp/queued-from-window-coordinator.md")
         let queuedEvent = FolderWatchChangeEvent(

--- a/minimarkTests/Sidebar/SidebarDocumentControllerTests.swift
+++ b/minimarkTests/Sidebar/SidebarDocumentControllerTests.swift
@@ -855,7 +855,15 @@ struct SidebarDocumentControllerTests {
         // Wire up the coordinator the same way the real app does
         let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
+            sidebarDocumentController: harness.controller,
+            dependencies: WindowCoordinatorDependencies(
+                appearanceController: { nil },
+                groupStateController: { nil },
+                favoriteWorkspaceController: { nil },
+                folderWatchFlowController: { nil },
+                uiTestLaunchCoordinator: { nil },
+                recentHistoryCoordinator: { nil }
+            )
         )
         coordinator.documentOpen.configureStoreCallbacks(
             lockedAppearanceProvider: { lockedAppearance }
@@ -883,7 +891,15 @@ struct SidebarDocumentControllerTests {
         // No locked appearance
         let coordinator = WindowCoordinator(
             settingsStore: harness.settingsStore,
-            sidebarDocumentController: harness.controller
+            sidebarDocumentController: harness.controller,
+            dependencies: WindowCoordinatorDependencies(
+                appearanceController: { nil },
+                groupStateController: { nil },
+                favoriteWorkspaceController: { nil },
+                folderWatchFlowController: { nil },
+                uiTestLaunchCoordinator: { nil },
+                recentHistoryCoordinator: { nil }
+            )
         )
         coordinator.documentOpen.configureStoreCallbacks(lockedAppearanceProvider: { nil })
 


### PR DESCRIPTION
## Summary
- Removes the `configure(...)` second-phase wiring step from `FavoriteWorkspaceController`, `FolderWatchFlowController`, and `WindowCoordinator` in favor of provider closures supplied at init.
- Adds `WeakBox<T: AnyObject>` so the favorite↔folder-watch cross-reference cycle can be resolved during graph construction without a retain cycle.
- Introduces `WindowCoordinatorDependencies` — a struct-of-closures passed to `WindowCoordinator.init` — reducing its constructor surface and removing six mutable cross-ref properties.

Closes #375.

## Why
Two-phase construction (`init` then `configure`) forced cross-ref properties to be optional mutable vars, making it unclear whether an access would return a real controller or `nil`. Providers resolve lazily, avoiding that footgun while keeping construction-order independence.

## Test plan
- [x] `xcodebuild test -scheme minimark -only-testing:minimarkTests` — green
- [x] `xcodebuild test -scheme minimarkUITests` — all 12 UI tests green (after clearing stale `sidebarGroupSortMode` in the sandboxed prefs plist)
- [x] Manual: app launches, folder-watch flows, favorites, group state all behave as before