### PR TITLE
Fix missing Watch Folder toolbar button on single-file windows (#385)

### DIFF
--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -80,18 +80,80 @@ struct WindowRootView: View {
     }
 
     var body: some View {
-        Group {
+        // `ZStack` (not `Group`) is load-bearing: on windows SwiftUI creates
+        // in response to external file opens, an `if/else` inside a `Group`
+        // causes `.toolbar` items to never register with the NSToolbar —
+        // see #385. A stable outer container keeps the single `.toolbar`
+        // modifier attached across the shell→rootContent phase transition.
+        ZStack {
             if windowCoordinator.hasCompletedWindowPhase {
                 commandNotificationAwareView(windowLifecycleChangeObservers(windowLifecycleBaseView(rootContent)))
             } else {
                 windowShell
             }
         }
+        .toolbar { windowToolbarItems }
         .environment(settingsStore)
         .environment(appearanceController)
         .environment(sidebarDocumentController)
         .environment(folderWatchFlowController)
         .environment(groupStateController)
+    }
+
+    @ToolbarContentBuilder
+    private var windowToolbarItems: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            FolderWatchToolbarButton(
+                state: currentToolbarFolderWatchState,
+                onAction: { action in
+                    if case .activate = action {
+                        promptForFolderWatch()
+                    } else {
+                        windowCoordinator.contentActions.handle(action)
+                    }
+                },
+                compact: true
+            )
+            .disabled(!windowCoordinator.hasCompletedWindowPhase)
+            .allowsHitTesting(windowCoordinator.hasCompletedWindowPhase)
+            .padding(.trailing, 8)
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            if windowCoordinator.hasCompletedWindowPhase && sidebarDocumentController.documents.count > 1 {
+                Button(action: {
+                    windowCoordinator.sidebarActions.toggleSidebarPlacement(currentMultiFileDisplayMode: multiFileDisplayMode)
+                }) {
+                    Image(systemName: sidebarPlacement == .left ? "sidebar.right" : "sidebar.left")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .help(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
+                .accessibilityLabel(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
+                .accessibilityIdentifier(.sidebarPlacementToggle)
+            }
+        }
+    }
+
+    private var currentToolbarFolderWatchState: ToolbarFolderWatchState {
+        let settings = settingsStore.currentSettings
+        guard windowCoordinator.hasCompletedWindowPhase else {
+            return ToolbarFolderWatchState(
+                activeFolderWatch: nil,
+                isInitialScanInProgress: false,
+                didInitialScanFail: false,
+                favoriteWatchedFolders: settings.favoriteWatchedFolders,
+                recentWatchedFolders: settings.recentWatchedFolders
+            )
+        }
+        let folderWatchCoordinator = sidebarDocumentController.folderWatchCoordinator
+        return ToolbarFolderWatchState(
+            activeFolderWatch: folderWatchFlowController.sharedFolderWatchSession,
+            isInitialScanInProgress: folderWatchCoordinator.isFolderWatchInitialScanInProgress,
+            didInitialScanFail: folderWatchCoordinator.didFolderWatchInitialScanFail,
+            favoriteWatchedFolders: settings.favoriteWatchedFolders,
+            recentWatchedFolders: settings.recentWatchedFolders
+        )
     }
 
     private var windowShell: some View {
@@ -104,24 +166,6 @@ struct WindowRootView: View {
                 .colorScheme(theme.kind.isDark ? .dark : .light)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                FolderWatchToolbarButton(
-                    state: ToolbarFolderWatchState(
-                        activeFolderWatch: nil,
-                        isInitialScanInProgress: false,
-                        didInitialScanFail: false,
-                        favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
-                        recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders
-                    ),
-                    onAction: { _ in },
-                    compact: true
-                )
-                .disabled(true)
-                .allowsHitTesting(false)
-                .padding(.trailing, 8)
-            }
-        }
         .navigationTitle(WindowTitleFormatter.appName)
         .task {
             await Task.yield()
@@ -347,43 +391,6 @@ struct WindowRootView: View {
                 }
             )
         )
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                FolderWatchToolbarButton(
-                    state: ToolbarFolderWatchState(
-                        activeFolderWatch: folderWatchFlowController.sharedFolderWatchSession,
-                        isInitialScanInProgress: sidebarDocumentController.folderWatchCoordinator.isFolderWatchInitialScanInProgress,
-                        didInitialScanFail: sidebarDocumentController.folderWatchCoordinator.didFolderWatchInitialScanFail,
-                        favoriteWatchedFolders: settingsStore.currentSettings.favoriteWatchedFolders,
-                        recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders
-                    ),
-                    onAction: { action in
-                        if case .activate = action {
-                            promptForFolderWatch()
-                        } else {
-                            windowCoordinator.contentActions.handle(action)
-                        }
-                    },
-                    compact: true
-                )
-                .padding(.trailing, 8)
-            }
-
-            ToolbarItem(placement: .primaryAction) {
-                if sidebarDocumentController.documents.count > 1 {
-                    Button(action: {
-                        windowCoordinator.sidebarActions.toggleSidebarPlacement(currentMultiFileDisplayMode: multiFileDisplayMode)
-                    }) {
-                        Image(systemName: sidebarPlacement == .left ? "sidebar.right" : "sidebar.left")
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                    }
-                    .help(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
-                    .accessibilityLabel(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
-                    .accessibilityIdentifier(.sidebarPlacementToggle)
-                }
-            }
-        }
     }
 
     private func contentView(for store: DocumentStore) -> some View {


### PR DESCRIPTION
## Summary

- Fixes #385: `WindowRootView.body` wrapped the `shell ↔ rootContent` phase switch in a `Group` with each branch owning its own `.toolbar { … }`. For windows SwiftUI creates in response to external file-open URLs (`open -a MarkdownObserver file.md` while the app is running), that phase-transition teardown/re-add drops the NSToolbar registration — Watch Folder pill, sidebar placement toggle, any future toolbar items never appear. Cold-launched windows worked by timing coincidence.
- Swapped the outer `Group` → `ZStack` for stable view identity, consolidated all toolbar items into a single `@ToolbarContentBuilder` property anchored on the outer container. Items conditionally disable during the shell phase instead of being torn down and re-added.

## Test plan

- [x] Build passes (`xcodebuild -scheme minimark -destination 'platform=macOS' build`)
- [x] 1083 unit tests pass (`xcodebuild test -only-testing:minimarkTests`)
- [x] AX inspection confirms toolbar items populate on both paths:
  - Blank window (cold launch): `toolbar items = 1`
  - Single-file window (hot open via `open -a …`): `toolbar items = 1`
  - Cold-launch-with-file: `toolbar items = 1`
- [x] Screenshot verification: "Watch Folder" pill visible on `file.md - MarkdownObserver` window