### PR TITLE
Fix disabled menu commands via focusedSceneValue (closes #384)

### DIFF
--- a/minimark/Support/HostedWindowController.swift
+++ b/minimark/Support/HostedWindowController.swift
@@ -1,38 +1,62 @@
 import AppKit
 import SwiftUI
 
+/// UI-test-only bootstrap. Creates a tiny off-screen `NSWindow` that hosts a
+/// SwiftUI view. The hosted view uses the `@Environment(\.openWindow)` action
+/// to spawn a real `WindowGroup`-backed window (a first-class SwiftUI Scene),
+/// then the bootstrap window closes itself.
+///
+/// This route matters for UI tests because scene-scoped focused values
+/// (`focusedSceneValue`) only publish when the observed window is a SwiftUI
+/// Scene. An `NSHostingController` inside a plain `NSWindow` wouldn't satisfy
+/// that — but by using it only to trigger `openWindow`, the ensuing window is
+/// a proper Scene and tests exercise the same path production uses.
 @MainActor
 final class HostedWindowController: NSWindowController {
-    init(settingsStore: SettingsStore) {
-        let hostingController = NSHostingController(
-            rootView: WindowRootView(
-                seed: nil,
-                settingsStore: settingsStore,
-                multiFileDisplayMode: settingsStore.currentSettings.multiFileDisplayMode
-            )
-        )
+    init() {
+        // Placeholder root view — replaced in the `super.init` tail with one
+        // that captures `self` so the bootstrap window can close itself once
+        // the spawned WindowGroup scene is up.
+        let hostingController = NSHostingController(rootView: HostedBootstrapRootView())
 
         let window = NSWindow(
-            contentRect: NSRect(
-                x: 0,
-                y: 0,
-                width: WindowDefaults.defaultWidth,
-                height: WindowDefaults.defaultHeight
-            ),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            contentRect: NSRect(x: -10000, y: -10000, width: 1, height: 1),
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
         window.contentViewController = hostingController
-        window.title = WindowTitleFormatter.appName
         window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+        window.ignoresMouseEvents = true
 
         super.init(window: window)
-        shouldCascadeWindows = true
+
+        hostingController.rootView = HostedBootstrapRootView(onReady: { [weak self] in
+            self?.close()
+        })
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private struct HostedBootstrapRootView: View {
+    var onReady: (() -> Void)?
+
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .task {
+                openWindow(value: WindowSeed())
+                // Let SwiftUI attach and key the spawned window before we tear
+                // down the bootstrap window.
+                try? await Task.sleep(for: .milliseconds(200))
+                onReady?()
+            }
     }
 }

--- a/minimark/Support/HostedWindowController.swift
+++ b/minimark/Support/HostedWindowController.swift
@@ -1,10 +1,10 @@
 import AppKit
 import SwiftUI
 
-/// UI-test-only bootstrap. Creates a tiny off-screen `NSWindow` that hosts a
-/// SwiftUI view. The hosted view uses the `@Environment(\.openWindow)` action
-/// to spawn a real `WindowGroup`-backed window (a first-class SwiftUI Scene),
-/// then the bootstrap window closes itself.
+/// UI-test-only bootstrap. Creates a tiny off-screen `NSWindow` whose content
+/// is a SwiftUI view that uses the `@Environment(\.openWindow)` action to
+/// spawn a real `WindowGroup`-backed window (a first-class SwiftUI Scene),
+/// then closes the bootstrap window.
 ///
 /// This route matters for UI tests because scene-scoped focused values
 /// (`focusedSceneValue`) only publish when the observed window is a SwiftUI
@@ -14,27 +14,27 @@ import SwiftUI
 @MainActor
 final class HostedWindowController: NSWindowController {
     init() {
-        // Placeholder root view — replaced in the `super.init` tail with one
-        // that captures `self` so the bootstrap window can close itself once
-        // the spawned WindowGroup scene is up.
-        let hostingController = NSHostingController(rootView: HostedBootstrapRootView())
-
         let window = NSWindow(
             contentRect: NSRect(x: -10000, y: -10000, width: 1, height: 1),
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
         )
-        window.contentViewController = hostingController
         window.isReleasedWhenClosed = false
         window.alphaValue = 0
         window.ignoresMouseEvents = true
 
         super.init(window: window)
 
-        hostingController.rootView = HostedBootstrapRootView(onReady: { [weak self] in
-            self?.close()
-        })
+        // Install the hosting controller *after* super.init so the root view
+        // can safely capture `self` — avoids a side-effectful placeholder
+        // view with a nil `onReady` that could spawn an orphan WindowGroup
+        // window if it ran before we swapped the root view.
+        window.contentViewController = NSHostingController(
+            rootView: HostedBootstrapRootView(onReady: { [weak self] in
+                self?.close()
+            })
+        )
     }
 
     @available(*, unavailable)
@@ -44,7 +44,7 @@ final class HostedWindowController: NSWindowController {
 }
 
 private struct HostedBootstrapRootView: View {
-    var onReady: (() -> Void)?
+    let onReady: () -> Void
 
     @Environment(\.openWindow) private var openWindow
 
@@ -56,7 +56,7 @@ private struct HostedBootstrapRootView: View {
                 // Let SwiftUI attach and key the spawned window before we tear
                 // down the bootstrap window.
                 try? await Task.sleep(for: .milliseconds(200))
-                onReady?()
+                onReady()
             }
     }
 }

--- a/minimark/Views/Content/ContentViewFocusedValues.swift
+++ b/minimark/Views/Content/ContentViewFocusedValues.swift
@@ -50,9 +50,13 @@ struct ContentViewFocusedValues: ViewModifier {
     }
 
     func body(content: Content) -> some View {
+        // Scene-scoped, not view-focused: commands need the values whenever this
+        // window is key, even when no descendant has keyboard focus. `focusedValue`
+        // would require a focused view in the chain, which leaves the menu items
+        // disabled on cold launch (issue #384).
         @Bindable var folderWatchFlow = folderWatchFlow
         return content
-            .focusedValue(
+            .focusedSceneValue(
                 \.openDocumentInCurrentWindow,
                 OpenDocumentInCurrentWindowAction { fileURL in
                     let normalizedURL = FileRouting.normalizedFileURL(fileURL)
@@ -68,27 +72,27 @@ struct ContentViewFocusedValues: ViewModifier {
                     )))
                 }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.openDocument,
                 OpenDocumentAction { fileURL in openOrAppendDocument(fileURL) }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.openAdditionalDocument,
                 OpenAdditionalDocumentAction { fileURL in openOrAppendDocument(fileURL) }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.watchFolder,
                 WatchFolderAction { folderURL in
                     onAction(.requestFolderWatch(folderURL))
                 }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.startRecentFolderWatch,
                 StartRecentFolderWatchAction { entry in
                     onAction(.startRecentFolderWatch(entry))
                 }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.stopFolderWatch,
                 StopFolderWatchAction {
                     guard folderWatchState.canStopFolderWatch else {
@@ -97,11 +101,11 @@ struct ContentViewFocusedValues: ViewModifier {
                     onAction(.stopFolderWatch)
                 }
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.hasActiveFolderWatch,
                 folderWatchState.canStopFolderWatch
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.documentViewModeContext,
                 DocumentViewModeContext(
                     currentMode: sourceEditing.documentViewMode,
@@ -114,7 +118,7 @@ struct ContentViewFocusedValues: ViewModifier {
                     }
                 )
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.sourceEditingContext,
                 SourceEditingContext(
                     canStartEditing: (document.hasOpenDocument && !document.isCurrentFileMissing && !sourceEditing.isSourceEditing),
@@ -131,11 +135,11 @@ struct ContentViewFocusedValues: ViewModifier {
                     }
                 )
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.changedRegionNavigation,
                 changedRegionNavigation
             )
-            .focusedValue(
+            .focusedSceneValue(
                 \.toggleTOC,
                 ToggleTOCAction(
                     canToggle: !toc.headings.isEmpty,

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -9,7 +9,6 @@ struct MarkdownObserverApp: App {
     init() {
         let settingsStore = SettingsStore()
         _settingsStore = State(wrappedValue: settingsStore)
-        UITestWindowBootstrapper.shared.configure(settingsStore: settingsStore)
 
         SystemNotifier.shared.configure()
 
@@ -74,12 +73,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
 private final class UITestWindowBootstrapper {
     static let shared = UITestWindowBootstrapper()
 
-    private var settingsStore: SettingsStore?
     private var windowController: HostedWindowController?
-
-    func configure(settingsStore: SettingsStore) {
-        self.settingsStore = settingsStore
-    }
 
     func openInitialWindowIfNeeded() {
         guard UITestLaunchConfiguration.current.isUITestModeEnabled else {
@@ -88,15 +82,14 @@ private final class UITestWindowBootstrapper {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self,
-                  let settingsStore = self.settingsStore,
-                  NSApp.windows.isEmpty else {
+                  NSApp.windows.allSatisfy({ !$0.isVisible }) else {
                 return
             }
 
-            let controller = HostedWindowController(settingsStore: settingsStore)
+            let controller = HostedWindowController()
             windowController = controller
             controller.showWindow(nil)
-            controller.window?.makeKeyAndOrderFront(nil)
+            controller.window?.orderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
         }
     }

--- a/minimarkUITests/minimarkUITests.swift
+++ b/minimarkUITests/minimarkUITests.swift
@@ -74,15 +74,21 @@ final class minimarkUITests: XCTestCase {
     // window is key, regardless of which view has keyboard focus.
     //
     // Uses the standard `uiTestModeArgument` launch flag; the UI-test bootstrap
-    // scene (see `UITestBootstrapScene`) opens a real `WindowGroup` window so
-    // the test exercises the same SwiftUI Scene path production uses.
+    // path (`UITestWindowBootstrapper` / `HostedWindowController`) opens a real
+    // `WindowGroup` window so the test exercises the same SwiftUI Scene path
+    // production uses.
     @MainActor
     func testFocusedSceneCommandsAreEnabledWhenWindowIsKey() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument]
         app.launch()
 
-        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        // Wait for the real WindowGroup scene window to be up — the off-screen
+        // bootstrap window also matches `app.windows.firstMatch`, so gate on a
+        // marker that only `ContentView` (inside the scene) renders.
+        let previewSummary = app.descendants(matching: .any)
+            .matching(identifier: previewSummaryIdentifier).firstMatch
+        XCTAssertTrue(previewSummary.waitForExistence(timeout: 10))
 
         let fileMenu = app.menuBars.menuBarItems["File"]
         XCTAssertTrue(fileMenu.waitForExistence(timeout: 2))
@@ -90,6 +96,7 @@ final class minimarkUITests: XCTestCase {
 
         let watchMenuItem = fileMenu.menuItems["Watch Folder..."]
         XCTAssertTrue(watchMenuItem.waitForExistence(timeout: 2))
+        pollUntilEnabled(watchMenuItem, timeout: 2)
         XCTAssertTrue(
             watchMenuItem.isEnabled,
             "File → Watch Folder... must be enabled when a window is key"
@@ -103,10 +110,18 @@ final class minimarkUITests: XCTestCase {
 
         let watchFolderInWatchMenu = watchMenu.menuItems["Watch Folder..."]
         XCTAssertTrue(watchFolderInWatchMenu.waitForExistence(timeout: 2))
+        pollUntilEnabled(watchFolderInWatchMenu, timeout: 2)
         XCTAssertTrue(
             watchFolderInWatchMenu.isEnabled,
             "Watch → Watch Folder... must be enabled when a window is key"
         )
+    }
+
+    private func pollUntilEnabled(_ element: XCUIElement, timeout: TimeInterval) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, !element.isEnabled {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
     }
 
     @MainActor

--- a/minimarkUITests/minimarkUITests.swift
+++ b/minimarkUITests/minimarkUITests.swift
@@ -67,6 +67,48 @@ final class minimarkUITests: XCTestCase {
         }
     }
 
+    // Regression for #384: `@FocusedValue`-gated menu commands (Watch Folder,
+    // Edit Source, Table of Contents, etc.) were all disabled on cold launch
+    // because `focusedValue` requires a focused descendant. They must be
+    // published as `focusedSceneValue` so they're available whenever the
+    // window is key, regardless of which view has keyboard focus.
+    //
+    // Uses the standard `uiTestModeArgument` launch flag; the UI-test bootstrap
+    // scene (see `UITestBootstrapScene`) opens a real `WindowGroup` window so
+    // the test exercises the same SwiftUI Scene path production uses.
+    @MainActor
+    func testFocusedSceneCommandsAreEnabledWhenWindowIsKey() throws {
+        let app = XCUIApplication()
+        app.launchArguments += [uiTestModeArgument]
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+
+        let fileMenu = app.menuBars.menuBarItems["File"]
+        XCTAssertTrue(fileMenu.waitForExistence(timeout: 2))
+        fileMenu.click()
+
+        let watchMenuItem = fileMenu.menuItems["Watch Folder..."]
+        XCTAssertTrue(watchMenuItem.waitForExistence(timeout: 2))
+        XCTAssertTrue(
+            watchMenuItem.isEnabled,
+            "File → Watch Folder... must be enabled when a window is key"
+        )
+
+        fileMenu.click()
+
+        let watchMenu = app.menuBars.menuBarItems["Watch"]
+        XCTAssertTrue(watchMenu.waitForExistence(timeout: 2))
+        watchMenu.click()
+
+        let watchFolderInWatchMenu = watchMenu.menuItems["Watch Folder..."]
+        XCTAssertTrue(watchFolderInWatchMenu.waitForExistence(timeout: 2))
+        XCTAssertTrue(
+            watchFolderInWatchMenu.isEnabled,
+            "Watch → Watch Folder... must be enabled when a window is key"
+        )
+    }
+
     @MainActor
     func testWatchedFolderAutoOpensNewMarkdownFileAndReflectsLaterEdit() throws {
         let app = XCUIApplication()


### PR DESCRIPTION
## Summary

Every `@FocusedValue`-gated command in `AppCommands` was permanently disabled on cold launch — `Watch Folder…`, `⌘E` / `⌘S` / `⌘T`, `Show Preview/Split/Source`, `Previous/Next Change`, `Cycle Document View`. The values were published via `.focusedValue`, which requires a focused descendant view in the key window's focus chain. On cold launch nothing is focused, so every reader resolved to `nil`.

Switch the 11 publishers in `ContentViewFocusedValues` to `.focusedSceneValue` so commands are available whenever the scene is key, independent of view focus — the correct semantic for window-scoped menu-bar items. Reader side (`@FocusedValue` in `AppCommands`) is unchanged; scene publishers populate the same `FocusedValues` environment.

## UI test infrastructure

`HostedWindowController` used to host `WindowRootView` inside a plain `NSWindow` (not a SwiftUI Scene), which can't publish scene-scoped focused values. It now hosts a 1×1 off-screen invisible view that uses `@Environment(\.openWindow)` to spawn a real `WindowGroup`-backed window, then closes itself. UI tests now exercise the same SwiftUI Scene path production uses.

## Regression test

`testFocusedSceneCommandsAreEnabledWhenWindowIsKey` asserts `File → Watch Folder…` and `Watch → Watch Folder…` are enabled when a window is key. Verified it fails against the unfixed `.focusedValue` code and passes after the fix.

## Test plan

- [x] `xcodebuild test -only-testing:minimarkTests` — all unit tests pass
- [x] `xcodebuild test -scheme minimarkUITests` — all 13 UI tests pass
- [x] Manual: cold-launch app → File menu → `Watch Folder…` enabled, `⌥⌘W` fires the folder picker
- [x] Manual: with a document open, `⌘E` enters edit mode, `⌘T` toggles TOC, Show Split/Source enabled
- [x] Regression test fails against pre-fix code (confirmed by temporarily reverting `.focusedSceneValue` → `.focusedValue`)