### PR TITLE
Sandbox test runs from installed app's UserDefaults (#392)

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -177,7 +177,7 @@ struct ContentView: View {
 }
 
 #Preview {
-    let settingsStore = SettingsStore()
+    let settingsStore = SettingsStore.makeDefault()
     let securityScopeResolver = SecurityScopeResolver(
         securityScope: SecurityScopedResourceAccess(),
         settingsStore: settingsStore,

--- a/minimark/Support/SettingsKeyValueStoring.swift
+++ b/minimark/Support/SettingsKeyValueStoring.swift
@@ -6,3 +6,15 @@ protocol SettingsKeyValueStoring: AnyObject {
 }
 
 extension UserDefaults: SettingsKeyValueStoring {}
+
+final class InMemorySettingsKeyValueStorage: SettingsKeyValueStoring {
+    private var storedValues: [String: Data] = [:]
+
+    func data(forKey defaultName: String) -> Data? {
+        storedValues[defaultName]
+    }
+
+    func set(_ value: Any?, forKey defaultName: String) {
+        storedValues[defaultName] = value as? Data
+    }
+}

--- a/minimark/Support/SettingsStorageEnvironment.swift
+++ b/minimark/Support/SettingsStorageEnvironment.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum SettingsStorageEnvironment {
+    static let ephemeralDefaultsEnvironmentKey = "MINIMARK_EPHEMERAL_DEFAULTS"
+
+    static func resolveStorage(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SettingsKeyValueStoring {
+        if let value = environment[ephemeralDefaultsEnvironmentKey],
+           !value.isEmpty,
+           value != "0" {
+            return InMemorySettingsKeyValueStorage()
+        }
+        return UserDefaults.standard
+    }
+}
+
+extension SettingsStore {
+    @MainActor
+    static func makeDefault() -> SettingsStore {
+        SettingsStore(storage: SettingsStorageEnvironment.resolveStorage())
+    }
+}

--- a/minimark/minimarkApp.swift
+++ b/minimark/minimarkApp.swift
@@ -7,7 +7,7 @@ struct MarkdownObserverApp: App {
     @State private var settingsStore: SettingsStore
 
     init() {
-        let settingsStore = SettingsStore()
+        let settingsStore = SettingsStore.makeDefault()
         _settingsStore = State(wrappedValue: settingsStore)
 
         SystemNotifier.shared.configure()

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -6,7 +6,7 @@ import Testing
 private func makeTestViewModel(
     folderWatchState: ContentViewFolderWatchState = .testEmpty
 ) -> (ContentAreaViewModel, DocumentController, RenderingController, SourceEditingController) {
-    let settingsStore = SettingsStore()
+    let settingsStore = SettingsStore(storage: InMemorySettingsKeyValueStorage())
     let settler = AutoOpenSettler(settlingInterval: 1.0)
     let securityScopeResolver = SecurityScopeResolver(
         securityScope: SecurityScopedResourceAccess(),
@@ -238,7 +238,7 @@ struct ContentAreaViewModelDropRoutingTests {
 
     @Test @MainActor func handleDroppedMarkdownFiresRequestFileOpen() {
         var captured: [ContentViewAction] = []
-        let settingsStore = SettingsStore()
+        let settingsStore = SettingsStore(storage: InMemorySettingsKeyValueStorage())
         let settler = AutoOpenSettler(settlingInterval: 1.0)
         let securityScopeResolver = SecurityScopeResolver(
             securityScope: SecurityScopedResourceAccess(),

--- a/minimarkUITests/UITestSandbox.swift
+++ b/minimarkUITests/UITestSandbox.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+/// Sandbox isolation for UI test runs.
+///
+/// UI tests launch the real `MarkdownObserver.app` bundle. Without this helper the app
+/// would read and write the installed user's `UserDefaults` domain (favorites, recents,
+/// settings) because local builds share `APP_BUNDLE_IDENTIFIER` with the installed app.
+/// Setting `MINIMARK_EPHEMERAL_DEFAULTS=1` makes the app back its `SettingsStore` with
+/// an in-memory key-value store for the life of the launched process.
+enum UITestSandbox {
+    static let ephemeralDefaultsEnvironmentKey = "MINIMARK_EPHEMERAL_DEFAULTS"
+
+    static func apply(to app: XCUIApplication) {
+        app.launchEnvironment[ephemeralDefaultsEnvironmentKey] = "1"
+    }
+}
+
+extension XCUIApplication {
+    /// Launch the app with test state sandboxed from the installed app's `UserDefaults`.
+    /// Use this in place of `launch()` in every UI test.
+    func launchSandboxed() {
+        UITestSandbox.apply(to: self)
+        launch()
+    }
+}

--- a/minimarkUITests/minimarkUITests.swift
+++ b/minimarkUITests/minimarkUITests.swift
@@ -35,7 +35,7 @@ final class minimarkUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, presentWatchFolderSheetArgument]
         app.launchEnvironment[watchFolderPathEnvironmentKey] = folderURL.path
-        app.launch()
+        app.launchSandboxed()
 
         let sheet = app.descendants(matching: .any).matching(identifier: watchFolderSheetIdentifier).firstMatch
         XCTAssertTrue(sheet.waitForExistence(timeout: 5))
@@ -63,7 +63,7 @@ final class minimarkUITests: XCTestCase {
     @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            XCUIApplication().launchSandboxed()
         }
     }
 
@@ -81,7 +81,7 @@ final class minimarkUITests: XCTestCase {
     func testFocusedSceneCommandsAreEnabledWhenWindowIsKey() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument]
-        app.launch()
+        app.launchSandboxed()
 
         // Wait for the real WindowGroup scene window to be up — the off-screen
         // bootstrap window also matches `app.windows.firstMatch`, so gate on a
@@ -128,7 +128,7 @@ final class minimarkUITests: XCTestCase {
     func testWatchedFolderAutoOpensNewMarkdownFileAndReflectsLaterEdit() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, simulateAutoOpenWatchFlowArgument]
-        app.launch()
+        app.launchSandboxed()
 
         let preview = app.descendants(matching: .any).matching(identifier: previewSummaryIdentifier).firstMatch
         XCTAssertTrue(preview.waitForExistence(timeout: 5))
@@ -158,7 +158,7 @@ final class minimarkUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, presentWatchFolderSheetArgument]
         app.launchEnvironment[watchFolderPathEnvironmentKey] = folderURL.path
-        app.launch()
+        app.launchSandboxed()
 
         let sheet = app.descendants(matching: .any).matching(identifier: watchFolderSheetIdentifier).firstMatch
         XCTAssertTrue(sheet.waitForExistence(timeout: 5))
@@ -184,7 +184,7 @@ final class minimarkUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, presentWatchFolderSheetArgument]
         app.launchEnvironment[watchFolderPathEnvironmentKey] = folderURL.path
-        app.launch()
+        app.launchSandboxed()
 
         let sheet = app.descendants(matching: .any).matching(identifier: watchFolderSheetIdentifier).firstMatch
         XCTAssertTrue(sheet.waitForExistence(timeout: 5))
@@ -223,7 +223,7 @@ final class minimarkUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, presentWatchFolderSheetArgument]
         app.launchEnvironment[watchFolderPathEnvironmentKey] = folderURL.path
-        app.launch()
+        app.launchSandboxed()
 
         let sheet = app.descendants(matching: .any).matching(identifier: watchFolderSheetIdentifier).firstMatch
         XCTAssertTrue(sheet.waitForExistence(timeout: 5))
@@ -245,7 +245,7 @@ final class minimarkUITests: XCTestCase {
     func testGroupedSidebarShowsDocumentsFromMultipleSubdirectories() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
-        app.launch()
+        app.launchSandboxed()
 
         let groupToggles = app.buttons.matching(identifier: sidebarGroupToggleIdentifier)
         waitForCondition(timeout: 8) {
@@ -276,7 +276,7 @@ final class minimarkUITests: XCTestCase {
     func testGroupedSidebarExposesCustomGroupToggleButtons() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
-        app.launch()
+        app.launchSandboxed()
 
         let customToggle = app.buttons.matching(identifier: sidebarGroupToggleIdentifier).firstMatch
         XCTAssertTrue(customToggle.waitForExistence(timeout: 8), "Grouped sidebar should expose custom group toggle buttons")
@@ -288,7 +288,7 @@ final class minimarkUITests: XCTestCase {
     func testGroupedSidebarDisplaysExpectedGroupsInOrder() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
-        app.launch()
+        app.launchSandboxed()
 
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 10), "Window should appear")
@@ -324,7 +324,7 @@ final class minimarkUITests: XCTestCase {
     func testSidebarWidthRemainsStableWhenWindowIsResized() throws {
         let app = XCUIApplication()
         app.launchArguments += [uiTestModeArgument, simulateGroupedSidebarArgument]
-        app.launch()
+        app.launchSandboxed()
 
         let sidebar = app.scrollViews.matching(identifier: sidebarColumnIdentifier).firstMatch
         XCTAssertTrue(sidebar.waitForExistence(timeout: 8), "Sidebar should appear")

--- a/minimarkUITests/minimarkUITestsLaunchTests.swift
+++ b/minimarkUITests/minimarkUITestsLaunchTests.swift
@@ -19,7 +19,7 @@ final class minimarkUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         let app = XCUIApplication()
-        app.launch()
+        app.launchSandboxed()
 
         // Insert steps here to perform after app launch but before taking a screenshot,
         // such as logging into a test account or navigating somewhere in the app


### PR DESCRIPTION
Closes #392.

## Summary

Local builds share `APP_BUNDLE_IDENTIFIER` with the installed app (via `Signing.local.xcconfig`), so `SettingsStore()` reached the same `UserDefaults` domain the daily-driver app uses. Running unit or UI tests mutated the user's favorites, recents, and settings.

Only bleed surface in the codebase: `UserDefaults.standard` at key `reader.settings.v1`. No caches, app-support files, `NSDocumentController` recents, or `@AppStorage`. One mechanism closes the leak.

## Approach

- `InMemorySettingsKeyValueStorage` promoted into the main module alongside the existing `SettingsKeyValueStoring` protocol.
- `SettingsStore.makeDefault()` factory reads `MINIMARK_EPHEMERAL_DEFAULTS` from the environment. Set → in-memory store. Unset → `UserDefaults.standard` (production is byte-identical to today).
- `minimarkApp.init()` and the `ContentView` preview now call `makeDefault()`.
- UI tests launch via a new `XCUIApplication.launchSandboxed()` helper that sets the env var on every launch. Helper-based so it's impossible to forget on a new test.
- Two bare `SettingsStore()` calls in `ContentAreaViewModelTests` now use the in-memory storage — hermetic regardless of host defaults.

Screenshot automation uses `-minimark-ui-test` but never sets `MINIMARK_EPHEMERAL_DEFAULTS`, so curated-state screenshot runs remain unaffected.

## Verification

- `xcodebuild test -scheme minimark` → **TEST SUCCEEDED**
- `xcodebuild test -scheme minimarkUITests` → **TEST SUCCEEDED** (all 15 UI tests + 2 launch tests)
- `~/Library/Preferences/lars-pohlmann.minimark.plist` mtime unchanged after both runs (still 29 Mär, from before today's runs) — confirms no writes to the installed app's defaults.

## Test plan

- [x] Unit test suite passes
- [x] UI test suite passes
- [x] Installed app's defaults plist untouched after full test runs
- [x] No schema change, no migration path required
