### PR TITLE
Fix blank source pane in Split mode (closes #388)

### DIFF
--- a/minimark/Views/Content/ContentAreaObservationCoordinator.swift
+++ b/minimark/Views/Content/ContentAreaObservationCoordinator.swift
@@ -77,6 +77,15 @@ final class ContentAreaObservationCoordinator {
         let task = Task { [weak viewModel] in
             while !Task.isCancelled {
                 guard let currentVM = viewModel else { return }
+                // Close the gap between capturing `previous` and registering observation
+                // tracking: a mutation can happen in that window (e.g. file load during
+                // VM init) and `withObservationTracking` only fires on subsequent writes.
+                let current = read(currentVM)
+                if current != previous {
+                    previous = current
+                    react(currentVM, current)
+                    continue
+                }
                 let cancelled = await ObservationAsyncChange.next {
                     _ = read(currentVM)
                 }

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -172,6 +172,47 @@ struct ContentAreaViewModelObservationTests {
         #expect(!viewModel.surfaceViewModel.sourceHTMLCache.document.isEmpty)
     }
 
+    // Regression test for #388: the observation coordinator captured `previous = read(vm)`
+    // synchronously in `init`, then spawned a Task whose first `withObservationTracking`
+    // registration ran on a later main-actor tick. If `sourceEditorSeedMarkdown` was
+    // written in that interval (as happens during file-load right after VM construction),
+    // the write landed before tracking was registered and the reaction never fired —
+    // the split-mode source pane then rendered an empty CodeMirror editor.
+    @Test @MainActor
+    func seedMarkdownChangedBeforeObservationSetupStillRefreshesCache() async {
+        let (viewModel, _, _, sourceEditing) = makeTestViewModel()
+        // Mutate synchronously before awaiting — mimics applyLoadedState racing the
+        // observation Task's first tracking registration during file-open.
+        let seedMarkdown = "# Hello\n\nfrom bug 388"
+        sourceEditing.sourceEditorSeedMarkdown = seedMarkdown
+
+        await settle()
+
+        let html = viewModel.surfaceViewModel.sourceHTMLCache.document
+        #expect(!html.isEmpty)
+        // The bootstrap payload must encode the seed markdown; if the observation
+        // reaction misses the pre-setup write, the CodeMirror payload still wraps "".
+        #expect(Self.decodePayloadMarkdown(from: html) == seedMarkdown)
+    }
+
+    private static func decodePayloadMarkdown(from html: String) -> String? {
+        // Payload is interpolated into the bootstrap script as: .bootstrap("<base64>")
+        guard let range = html.range(of: #"MinimarkCodeMirrorSourceView\.bootstrap\("([^"]+)"\)"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(html[range])
+        guard let openQuote = match.firstIndex(of: "\""),
+              let closeQuote = match.lastIndex(of: "\""),
+              openQuote < closeQuote
+        else { return nil }
+        let base64 = String(match[match.index(after: openQuote)..<closeQuote])
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let markdown = json["markdown"] as? String
+        else { return nil }
+        return markdown
+    }
+
     @Test @MainActor
     func previewFallbackClearsPreviewDropTargeting() async {
         let (viewModel, _, _, _) = makeTestViewModel()

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -197,15 +197,14 @@ struct ContentAreaViewModelObservationTests {
 
     private static func decodePayloadMarkdown(from html: String) -> String? {
         // Payload is interpolated into the bootstrap script as: .bootstrap("<base64>")
-        guard let range = html.range(of: #"MinimarkCodeMirrorSourceView\.bootstrap\("([^"]+)"\)"#, options: .regularExpression) else {
-            return nil
-        }
-        let match = String(html[range])
-        guard let openQuote = match.firstIndex(of: "\""),
-              let closeQuote = match.lastIndex(of: "\""),
-              openQuote < closeQuote
+        let pattern = #"MinimarkCodeMirrorSourceView\.bootstrap\("([^"]+)"\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let searchRange = NSRange(html.startIndex..<html.endIndex, in: html)
+        guard let match = regex.firstMatch(in: html, range: searchRange),
+              match.numberOfRanges > 1,
+              let base64Range = Range(match.range(at: 1), in: html)
         else { return nil }
-        let base64 = String(match[match.index(after: openQuote)..<closeQuote])
+        let base64 = String(html[base64Range])
         guard let data = Data(base64Encoded: base64),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let markdown = json["markdown"] as? String


### PR DESCRIPTION
Closes #388.

## Summary

In Split mode, the right-hand source pane showed only `1` in the line-number gutter — the CodeMirror editor loaded, but its document was empty. Entering Edit Source populated the pane, proving the file had loaded; exiting edit mode made it go blank again.

## Root cause

Observation race in `ContentAreaObservationCoordinator.track`. `var previous = read(vm)` ran synchronously in `ensureSetup()` during `ContentAreaViewModel.init`. The spawned `Task` registered `withObservationTracking` only on a later main-actor tick. When opening a file, `DocumentPresenter.applyLoadedState` wrote `sourceEditorSeedMarkdown = loaded.markdown` in that gap — before tracking was registered. `withObservationTracking` only fires on *subsequent* writes, so the reaction was lost forever; `sourceHTMLCache` kept its initial empty-markdown HTML, and CodeMirror rendered an empty document.

## Fix

Re-read the tracked value at the top of each loop iteration and fire the reaction if it differs from `previous`, then `continue` without awaiting. This closes the window between sync-init capture and the Task's tracking registration.

## Test plan

- [x] Added `seedMarkdownChangedBeforeObservationSetupStillRefreshesCache` — mutates seed markdown immediately after VM init, decodes the CodeMirror bootstrap payload, asserts the seed reached the view. Fails without the fix.
- [x] Full unit suite green (1084 tests).
- [x] Manual: launch Debug build, open a markdown file, click Split mode — source pane now shows the file content with line numbers and syntax highlighting.