### PR TITLE
feat: reader theme color overrides

### DIFF
--- a/minimark/ContentView.swift
+++ b/minimark/ContentView.swift
@@ -213,7 +213,8 @@ struct ContentView: View {
         recentWatchedFolders: [],
         recentManuallyOpenedFiles: [],
         isAppearanceLocked: false,
-        effectiveReaderTheme: .blackOnWhite
+        effectiveReaderTheme: .blackOnWhite,
+        effectiveReaderThemeOverride: nil
     )
 
     let viewModel = ContentAreaViewModel(

--- a/minimark/Models/LockedAppearance.swift
+++ b/minimark/Models/LockedAppearance.swift
@@ -4,4 +4,32 @@ nonisolated struct LockedAppearance: Equatable, Hashable, Codable, Sendable {
     let readerTheme: ThemeKind
     let baseFontSize: Double
     let syntaxTheme: SyntaxThemeKind
+    let readerThemeOverride: ThemeOverride?
+
+    init(
+        readerTheme: ThemeKind,
+        baseFontSize: Double,
+        syntaxTheme: SyntaxThemeKind,
+        readerThemeOverride: ThemeOverride? = nil
+    ) {
+        self.readerTheme = readerTheme
+        self.baseFontSize = baseFontSize
+        self.syntaxTheme = syntaxTheme
+        self.readerThemeOverride = readerThemeOverride
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case readerTheme
+        case baseFontSize
+        case syntaxTheme
+        case readerThemeOverride
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        readerTheme = try container.decode(ThemeKind.self, forKey: .readerTheme)
+        baseFontSize = try container.decode(Double.self, forKey: .baseFontSize)
+        syntaxTheme = try container.decode(SyntaxThemeKind.self, forKey: .syntaxTheme)
+        readerThemeOverride = try container.decodeIfPresent(ThemeOverride.self, forKey: .readerThemeOverride)
+    }
 }

--- a/minimark/Models/Theme.swift
+++ b/minimark/Models/Theme.swift
@@ -482,3 +482,31 @@ nonisolated struct Theme: Equatable, Codable, Sendable {
         """
     }
 }
+
+extension Theme {
+    func applyingOverride(_ override: ThemeOverride?) -> Theme {
+        guard let override, override.themeKind == kind else { return self }
+        let newBackground = override.backgroundHex ?? backgroundHex
+        let newForeground = override.foregroundHex ?? foregroundHex
+        if newBackground == backgroundHex && newForeground == foregroundHex {
+            return self
+        }
+        return Theme(
+            kind: kind,
+            backgroundHex: newBackground,
+            foregroundHex: newForeground,
+            secondaryForegroundHex: secondaryForegroundHex,
+            codeBackgroundHex: codeBackgroundHex,
+            borderHex: borderHex,
+            linkHex: linkHex,
+            changedBlockHex: changedBlockHex,
+            changeAddedHex: changeAddedHex,
+            changeEditedHex: changeEditedHex,
+            changeDeletedHex: changeDeletedHex,
+            hasLightBackground: hasLightBackground,
+            h1Hex: h1Hex,
+            h2Hex: h2Hex,
+            h3Hex: h3Hex
+        )
+    }
+}

--- a/minimark/Models/Theme.swift
+++ b/minimark/Models/Theme.swift
@@ -503,10 +503,19 @@ extension Theme {
             changeAddedHex: changeAddedHex,
             changeEditedHex: changeEditedHex,
             changeDeletedHex: changeDeletedHex,
-            hasLightBackground: hasLightBackground,
+            hasLightBackground: Self.isLightHex(newBackground),
             h1Hex: h1Hex,
             h2Hex: h2Hex,
             h3Hex: h3Hex
         )
+    }
+
+    private static func isLightHex(_ hex: String) -> Bool {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        guard cleaned.count == 6, let int = Int(cleaned, radix: 16) else { return true }
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        return (0.299 * r + 0.587 * g + 0.114 * b) > 0.5
     }
 }

--- a/minimark/Models/ThemeOverride.swift
+++ b/minimark/Models/ThemeOverride.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+nonisolated struct ThemeOverride: Equatable, Hashable, Codable, Sendable {
+    var themeKind: ThemeKind
+    var backgroundHex: String?
+    var foregroundHex: String?
+}

--- a/minimark/Models/ThemeOverride.swift
+++ b/minimark/Models/ThemeOverride.swift
@@ -4,4 +4,8 @@ nonisolated struct ThemeOverride: Equatable, Hashable, Codable, Sendable {
     var themeKind: ThemeKind
     var backgroundHex: String?
     var foregroundHex: String?
+
+    var isEmpty: Bool {
+        backgroundHex == nil && foregroundHex == nil
+    }
 }

--- a/minimark/Services/MarkdownRenderingService.swift
+++ b/minimark/Services/MarkdownRenderingService.swift
@@ -13,7 +13,8 @@ protocol MarkdownRendering {
         unsavedChangedRegions: [ChangedRegion],
         theme: ThemeDefinition,
         syntaxTheme: SyntaxThemeKind,
-        baseFontSize: Double
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
     ) throws -> RenderedMarkdown
 }
 
@@ -38,7 +39,8 @@ struct MarkdownRenderingService: MarkdownRendering {
         unsavedChangedRegions: [ChangedRegion],
         theme: ThemeDefinition,
         syntaxTheme: SyntaxThemeKind,
-        baseFontSize: Double
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
     ) throws -> RenderedMarkdown {
         let runtimeAssets = try runtimeAssetResolver.requiredRuntimeAssets()
         let payloadBase64 = try payloadEncoder.makePayloadBase64(
@@ -46,7 +48,12 @@ struct MarkdownRenderingService: MarkdownRendering {
             changedRegions: changedRegions,
             unsavedChangedRegions: unsavedChangedRegions
         )
-        let css = cssFactory.makeCSS(theme: theme, syntaxTheme: syntaxTheme, baseFontSize: baseFontSize)
+        let css = cssFactory.makeCSS(
+            theme: theme,
+            syntaxTheme: syntaxTheme,
+            baseFontSize: baseFontSize,
+            readerThemeOverride: readerThemeOverride
+        )
         let htmlDocument = cssFactory.makeHTMLDocument(
             css: css,
             payloadBase64: payloadBase64,

--- a/minimark/Stores/RenderingController.swift
+++ b/minimark/Stores/RenderingController.swift
@@ -138,6 +138,7 @@ final class RenderingController {
         let effectiveThemeKind = appearanceOverride?.readerTheme ?? settings.readerTheme
         let effectiveFontSize = appearanceOverride?.baseFontSize ?? settings.baseFontSize
         let effectiveSyntaxTheme = appearanceOverride?.syntaxTheme ?? settings.syntaxTheme
+        let effectiveReaderThemeOverride = appearanceOverride?.readerThemeOverride ?? settings.readerThemeOverride
         let theme = effectiveThemeKind.themeDefinition
 
         let docDir = fileURL?.deletingLastPathComponent()
@@ -158,7 +159,8 @@ final class RenderingController {
             unsavedChangedRegions: unsavedChangedRegions,
             theme: theme,
             syntaxTheme: effectiveSyntaxTheme,
-            baseFontSize: effectiveFontSize
+            baseFontSize: effectiveFontSize,
+            readerThemeOverride: effectiveReaderThemeOverride
         )
 
         renderedHTMLDocument = rendered.htmlDocument

--- a/minimark/Stores/Settings/PreferencesStore.swift
+++ b/minimark/Stores/Settings/PreferencesStore.swift
@@ -46,6 +46,9 @@ nonisolated struct PreferencesSlice: Equatable, Sendable {
     func updateTheme(_ kind: ThemeKind) {
         mutate(coalescePersistence: true) { slice in
             slice.readerTheme = kind
+            if let override = slice.readerThemeOverride, override.themeKind != kind {
+                slice.readerThemeOverride = nil
+            }
         }
     }
 

--- a/minimark/Stores/Settings/PreferencesStore.swift
+++ b/minimark/Stores/Settings/PreferencesStore.swift
@@ -14,6 +14,7 @@ nonisolated struct PreferencesSlice: Equatable, Sendable {
     var sidebarGroupSortMode: SidebarSortMode
     var diffBaselineLookback: DiffBaselineLookback
     var dismissedHints: Set<FirstUseHint>
+    var readerThemeOverride: ThemeOverride?
 }
 
 @MainActor @Observable final class PreferencesStore: ThemeWriting, PreferencesWriting, HintWriting {
@@ -45,6 +46,12 @@ nonisolated struct PreferencesSlice: Equatable, Sendable {
     func updateTheme(_ kind: ThemeKind) {
         mutate(coalescePersistence: true) { slice in
             slice.readerTheme = kind
+        }
+    }
+
+    func updateReaderThemeOverride(_ override: ThemeOverride?) {
+        mutate(coalescePersistence: true) { slice in
+            slice.readerThemeOverride = override
         }
     }
 

--- a/minimark/Stores/SettingsStore.swift
+++ b/minimark/Stores/SettingsStore.swift
@@ -19,6 +19,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
     var trustedImageFolders: [TrustedImageFolder]
     var diffBaselineLookback: DiffBaselineLookback
     var dismissedHints: Set<FirstUseHint>
+    var readerThemeOverride: ThemeOverride?
 
     init(
         appAppearance: AppAppearance,
@@ -35,7 +36,8 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         recentManuallyOpenedFiles: [RecentOpenedFile],
         trustedImageFolders: [TrustedImageFolder] = [],
         diffBaselineLookback: DiffBaselineLookback = .twoMinutes,
-        dismissedHints: Set<FirstUseHint> = []
+        dismissedHints: Set<FirstUseHint> = [],
+        readerThemeOverride: ThemeOverride? = nil
     ) {
         self.appAppearance = appAppearance
         self.readerTheme = readerTheme
@@ -52,6 +54,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         self.trustedImageFolders = trustedImageFolders
         self.diffBaselineLookback = diffBaselineLookback
         self.dismissedHints = dismissedHints
+        self.readerThemeOverride = readerThemeOverride
     }
 
     enum CodingKeys: String, CodingKey {
@@ -70,6 +73,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         case trustedImageFolders
         case diffBaselineLookback
         case dismissedHints
+        case readerThemeOverride
     }
 
     static let `default` = Settings(
@@ -87,7 +91,8 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         recentManuallyOpenedFiles: [],
         trustedImageFolders: [],
         diffBaselineLookback: .twoMinutes,
-        dismissedHints: []
+        dismissedHints: [],
+        readerThemeOverride: nil
     )
 
     init(from decoder: Decoder) throws {
@@ -107,6 +112,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         trustedImageFolders = try container.decodeIfPresent([TrustedImageFolder].self, forKey: .trustedImageFolders) ?? []
         diffBaselineLookback = try container.decodeIfPresent(DiffBaselineLookback.self, forKey: .diffBaselineLookback) ?? .twoMinutes
         dismissedHints = try container.decodeIfPresent(Set<FirstUseHint>.self, forKey: .dismissedHints) ?? []
+        readerThemeOverride = try container.decodeIfPresent(ThemeOverride.self, forKey: .readerThemeOverride)
 
         // Migrate legacy favorites: replace hardcoded-default workspace state with decoded global settings
         let legacyDefaultState = FavoriteWorkspaceState.from(
@@ -150,6 +156,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
     func increaseFontSize(step: Double)
     func decreaseFontSize(step: Double)
     func resetFontSize()
+    func updateReaderThemeOverride(_ override: ThemeOverride?)
 }
 
 @MainActor protocol PreferencesWriting: AnyObject {
@@ -298,7 +305,8 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
                 sidebarSortMode: initialSettings.sidebarSortMode,
                 sidebarGroupSortMode: initialSettings.sidebarGroupSortMode,
                 diffBaselineLookback: initialSettings.diffBaselineLookback,
-                dismissedHints: initialSettings.dismissedHints
+                dismissedHints: initialSettings.dismissedHints,
+                readerThemeOverride: initialSettings.readerThemeOverride
             )
         )
         self.favorites = FavoriteWatchedFoldersStore(
@@ -362,7 +370,8 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
             recentManuallyOpenedFiles: recentOpenedFiles.currentRecentOpenedFiles,
             trustedImageFolders: trustedImageFolders.currentTrustedFolders,
             diffBaselineLookback: prefs.diffBaselineLookback,
-            dismissedHints: prefs.dismissedHints
+            dismissedHints: prefs.dismissedHints,
+            readerThemeOverride: prefs.readerThemeOverride
         )
     }
 
@@ -375,6 +384,9 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
     func increaseFontSize(step: Double = 1.0) { preferences.increaseFontSize(step: step) }
     func decreaseFontSize(step: Double = 1.0) { preferences.decreaseFontSize(step: step) }
     func resetFontSize() { preferences.resetFontSize() }
+    func updateReaderThemeOverride(_ override: ThemeOverride?) {
+        preferences.updateReaderThemeOverride(override)
+    }
 
     // MARK: - PreferencesWriting
 

--- a/minimark/Stores/WindowAppearanceController.swift
+++ b/minimark/Stores/WindowAppearanceController.swift
@@ -29,7 +29,8 @@ final class WindowAppearanceController {
         self.effectiveAppearance = LockedAppearance(
             readerTheme: current.readerTheme,
             baseFontSize: current.baseFontSize,
-            syntaxTheme: current.syntaxTheme
+            syntaxTheme: current.syntaxTheme,
+            readerThemeOverride: current.readerThemeOverride
         )
 
         cancellable = settingsStore.settingsPublisher
@@ -40,7 +41,8 @@ final class WindowAppearanceController {
                 let newAppearance = LockedAppearance(
                     readerTheme: settings.readerTheme,
                     baseFontSize: settings.baseFontSize,
-                    syntaxTheme: settings.syntaxTheme
+                    syntaxTheme: settings.syntaxTheme,
+                    readerThemeOverride: settings.readerThemeOverride
                 )
                 if self.effectiveAppearance != newAppearance {
                     self.effectiveAppearance = newAppearance
@@ -71,7 +73,8 @@ final class WindowAppearanceController {
         effectiveAppearance = LockedAppearance(
             readerTheme: current.readerTheme,
             baseFontSize: current.baseFontSize,
-            syntaxTheme: current.syntaxTheme
+            syntaxTheme: current.syntaxTheme,
+            readerThemeOverride: current.readerThemeOverride
         )
     }
 

--- a/minimark/Support/CSSFactory.swift
+++ b/minimark/Support/CSSFactory.swift
@@ -10,8 +10,18 @@ struct CSSFactory {
             : ""
     }
 
-    func makeCSS(theme: ThemeDefinition, syntaxTheme: SyntaxThemeKind, baseFontSize: Double) -> String {
-        CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: syntaxTheme, baseFontSize: baseFontSize)
+    func makeCSS(
+        theme: ThemeDefinition,
+        syntaxTheme: SyntaxThemeKind,
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
+    ) -> String {
+        CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: syntaxTheme,
+            baseFontSize: baseFontSize,
+            readerThemeOverride: readerThemeOverride
+        )
     }
 
     func makeHTMLDocument(

--- a/minimark/Support/CSSThemeGenerator.swift
+++ b/minimark/Support/CSSThemeGenerator.swift
@@ -2,23 +2,40 @@ import Foundation
 
 enum CSSThemeGenerator {
     // All production callers reach this via @MainActor DocumentStore → MarkdownRenderingService.
-    private nonisolated(unsafe) static var cache: (theme: ThemeDefinition, syntaxTheme: SyntaxThemeKind, baseFontSize: Double, css: String)?
+    private nonisolated(unsafe) static var cache: (theme: ThemeDefinition, syntaxTheme: SyntaxThemeKind, baseFontSize: Double, override: ThemeOverride?, css: String)?
 
-    static func makeCSS(theme: ThemeDefinition, syntaxTheme: SyntaxThemeKind, baseFontSize: Double) -> String {
+    static func makeCSS(
+        theme: ThemeDefinition,
+        syntaxTheme: SyntaxThemeKind,
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
+    ) -> String {
         if let cache,
            cache.theme == theme,
            cache.syntaxTheme == syntaxTheme,
-           cache.baseFontSize == baseFontSize {
+           cache.baseFontSize == baseFontSize,
+           cache.override == readerThemeOverride {
             return cache.css
         }
 
-        let css = generateCSS(theme: theme, syntaxTheme: syntaxTheme, baseFontSize: baseFontSize)
-        cache = (theme, syntaxTheme, baseFontSize, css)
+        let css = generateCSS(
+            theme: theme,
+            syntaxTheme: syntaxTheme,
+            baseFontSize: baseFontSize,
+            readerThemeOverride: readerThemeOverride
+        )
+        cache = (theme, syntaxTheme, baseFontSize, readerThemeOverride, css)
         return css
     }
 
-    private static func generateCSS(theme: ThemeDefinition, syntaxTheme: SyntaxThemeKind, baseFontSize: Double) -> String {
-        let variables = theme.colors.cssVariables(baseFontSize: baseFontSize)
+    private static func generateCSS(
+        theme: ThemeDefinition,
+        syntaxTheme: SyntaxThemeKind,
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
+    ) -> String {
+        let effectiveColors = theme.colors.applyingOverride(readerThemeOverride)
+        let variables = effectiveColors.cssVariables(baseFontSize: baseFontSize)
         let syntaxLayer = theme.providesSyntaxHighlighting ? (theme.syntaxCSS ?? syntaxTheme.css) : syntaxTheme.css
         let themeLayer = theme.customCSS ?? ""
 

--- a/minimark/Support/MarkdownSourceHTMLRenderer.swift
+++ b/minimark/Support/MarkdownSourceHTMLRenderer.swift
@@ -25,7 +25,7 @@ enum MarkdownSourceHTMLRenderer {
     }
 
     static func makeHTMLDocument(markdown: String, settings: Settings, isEditable: Bool) -> String {
-        let theme = Theme.theme(for: settings.readerTheme)
+        let theme = Theme.theme(for: settings.readerTheme).applyingOverride(settings.readerThemeOverride)
         let baseCSS = theme.cssVariables(baseFontSize: settings.baseFontSize)
         let codeMirrorScriptPath = BundledAssets.availableCodeMirrorSourceViewScriptPath()
         let payloadBase64 = makePayloadBase64(

--- a/minimark/Views/Content/ContentAreaViewModel.swift
+++ b/minimark/Views/Content/ContentAreaViewModel.swift
@@ -66,7 +66,9 @@ final class ContentAreaViewModel {
     }
 
     var currentReaderTheme: Theme {
-        Theme.theme(for: folderWatchState.effectiveReaderTheme)
+        Theme
+            .theme(for: folderWatchState.effectiveReaderTheme)
+            .applyingOverride(folderWatchState.effectiveReaderThemeOverride)
     }
 
     var overlayColorScheme: ColorScheme {

--- a/minimark/Views/Content/ContentViewAdapter.swift
+++ b/minimark/Views/Content/ContentViewAdapter.swift
@@ -32,7 +32,8 @@ struct ContentViewAdapter: View {
             recentWatchedFolders: settingsStore.currentSettings.recentWatchedFolders,
             recentManuallyOpenedFiles: settingsStore.currentSettings.recentManuallyOpenedFiles,
             isAppearanceLocked: appearanceController.isLocked,
-            effectiveReaderTheme: appearanceController.effectiveAppearance.readerTheme
+            effectiveReaderTheme: appearanceController.effectiveAppearance.readerTheme,
+            effectiveReaderThemeOverride: appearanceController.effectiveAppearance.readerThemeOverride
         )
 
         ContentAreaHost(

--- a/minimark/Views/Content/ContentViewFolderWatchState.swift
+++ b/minimark/Views/Content/ContentViewFolderWatchState.swift
@@ -12,4 +12,5 @@ struct ContentViewFolderWatchState: Equatable {
     let recentManuallyOpenedFiles: [RecentOpenedFile]
     let isAppearanceLocked: Bool
     let effectiveReaderTheme: ThemeKind
+    let effectiveReaderThemeOverride: ThemeOverride?
 }

--- a/minimark/Views/SettingsView.swift
+++ b/minimark/Views/SettingsView.swift
@@ -294,7 +294,7 @@ struct ThemePreviewCard: View {
     let settings: Settings
 
     private var theme: Theme {
-        Theme.theme(for: settings.readerTheme)
+        Theme.theme(for: settings.readerTheme).applyingOverride(settings.readerThemeOverride)
     }
 
     private var syntaxPalette: SyntaxThemePreviewPalette {

--- a/minimark/Views/Support/ColorHexConversion.swift
+++ b/minimark/Views/Support/ColorHexConversion.swift
@@ -1,0 +1,17 @@
+import AppKit
+import SwiftUI
+
+enum ColorHexConversion {
+    static func hexString(from color: Color) -> String {
+        let nsColor = NSColor(color)
+        let srgb = nsColor.usingColorSpace(.sRGB) ?? nsColor
+        let r = Int((srgb.redComponent * 255.0).rounded())
+        let g = Int((srgb.greenComponent * 255.0).rounded())
+        let b = Int((srgb.blueComponent * 255.0).rounded())
+        return String(format: "#%02X%02X%02X", clamp(r), clamp(g), clamp(b))
+    }
+
+    private static func clamp(_ value: Int) -> Int {
+        max(0, min(255, value))
+    }
+}

--- a/minimark/Views/ThemeColorOverrideRow.swift
+++ b/minimark/Views/ThemeColorOverrideRow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ThemeColorOverrideRow: View {
     let themeKind: ThemeKind
     @Binding var override: ThemeOverride?
+    @State private var hasPositionedPanel = false
 
     private var themeDefaults: Theme { Theme.theme(for: themeKind) }
 
@@ -70,8 +71,10 @@ struct ThemeColorOverrideRow: View {
             GeometryReader { geo in
                 Color.clear
                     .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
-                        guard let panel = notification.object as? NSWindow,
+                        guard !hasPositionedPanel,
+                              let panel = notification.object as? NSWindow,
                               panel === NSColorPanel.shared else { return }
+                        hasPositionedPanel = true
                         let rowFrame = geo.frame(in: .global)
                         let panelSize = panel.frame.size
                         panel.setFrameOrigin(NSPoint(
@@ -85,7 +88,7 @@ struct ThemeColorOverrideRow: View {
 
     private var backgroundBinding: Binding<Color> {
         Binding(
-            get: { Color(hex: effectiveBackgroundHex) ?? .clear },
+            get: { Color(hex: effectiveBackgroundHex) ?? Color(hex: themeDefaults.backgroundHex) ?? .clear },
             set: { setBackground($0) }
         )
     }

--- a/minimark/Views/ThemeColorOverrideRow.swift
+++ b/minimark/Views/ThemeColorOverrideRow.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+struct ThemeColorOverrideRow: View {
+    let themeKind: ThemeKind
+    @Binding var override: ThemeOverride?
+
+    private var themeDefaults: Theme { Theme.theme(for: themeKind) }
+
+    private var effectiveBackgroundHex: String {
+        (override?.themeKind == themeKind ? override?.backgroundHex : nil) ?? themeDefaults.backgroundHex
+    }
+
+    private var effectiveForegroundHex: String {
+        (override?.themeKind == themeKind ? override?.foregroundHex : nil) ?? themeDefaults.foregroundHex
+    }
+
+    private var hasOverride: Bool {
+        guard let override, override.themeKind == themeKind else { return false }
+        return override.backgroundHex != nil || override.foregroundHex != nil
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text("Customize colors")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                Text("Background")
+                    .foregroundStyle(.secondary)
+                ColorPicker(
+                    "Background",
+                    selection: backgroundBinding,
+                    supportsOpacity: false
+                )
+                .labelsHidden()
+                .accessibilityIdentifier("theme.override.background")
+            }
+
+            HStack(spacing: 8) {
+                Text("Text")
+                    .foregroundStyle(.secondary)
+                ColorPicker(
+                    "Text",
+                    selection: foregroundBinding,
+                    supportsOpacity: false
+                )
+                .labelsHidden()
+                .accessibilityIdentifier("theme.override.foreground")
+            }
+
+            Spacer(minLength: 0)
+
+            Button("Reset to theme defaults") {
+                override = nil
+            }
+            .disabled(!hasOverride)
+            .accessibilityIdentifier("theme.override.reset")
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var backgroundBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: effectiveBackgroundHex) ?? .clear },
+            set: { setBackground($0) }
+        )
+    }
+
+    private var foregroundBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: effectiveForegroundHex) ?? .primary },
+            set: { setForeground($0) }
+        )
+    }
+
+    private func setBackground(_ color: Color) {
+        let hex = ColorHexConversion.hexString(from: color)
+        let newBackgroundHex: String? = (hex == themeDefaults.backgroundHex) ? nil : hex
+        mutateOverride { $0.backgroundHex = newBackgroundHex }
+    }
+
+    private func setForeground(_ color: Color) {
+        let hex = ColorHexConversion.hexString(from: color)
+        let newForegroundHex: String? = (hex == themeDefaults.foregroundHex) ? nil : hex
+        mutateOverride { $0.foregroundHex = newForegroundHex }
+    }
+
+    private func mutateOverride(_ transform: (inout ThemeOverride) -> Void) {
+        var working: ThemeOverride
+        if let existing = override, existing.themeKind == themeKind {
+            working = existing
+        } else {
+            working = ThemeOverride(themeKind: themeKind, backgroundHex: nil, foregroundHex: nil)
+        }
+        transform(&working)
+        if working.backgroundHex == nil && working.foregroundHex == nil {
+            override = nil
+        } else {
+            override = working
+        }
+    }
+}

--- a/minimark/Views/ThemeColorOverrideRow.swift
+++ b/minimark/Views/ThemeColorOverrideRow.swift
@@ -7,17 +7,21 @@ struct ThemeColorOverrideRow: View {
 
     private var themeDefaults: Theme { Theme.theme(for: themeKind) }
 
+    private var matchedOverride: ThemeOverride? {
+        override?.themeKind == themeKind ? override : nil
+    }
+
     private var effectiveBackgroundHex: String {
-        (override?.themeKind == themeKind ? override?.backgroundHex : nil) ?? themeDefaults.backgroundHex
+        matchedOverride?.backgroundHex ?? themeDefaults.backgroundHex
     }
 
     private var effectiveForegroundHex: String {
-        (override?.themeKind == themeKind ? override?.foregroundHex : nil) ?? themeDefaults.foregroundHex
+        matchedOverride?.foregroundHex ?? themeDefaults.foregroundHex
     }
 
     private var hasOverride: Bool {
-        guard let override, override.themeKind == themeKind else { return false }
-        return override.backgroundHex != nil || override.foregroundHex != nil
+        guard let matched = matchedOverride else { return false }
+        return matched.backgroundHex != nil || matched.foregroundHex != nil
     }
 
     var body: some View {
@@ -106,17 +110,8 @@ struct ThemeColorOverrideRow: View {
     }
 
     private func mutateOverride(_ transform: (inout ThemeOverride) -> Void) {
-        var working: ThemeOverride
-        if let existing = override, existing.themeKind == themeKind {
-            working = existing
-        } else {
-            working = ThemeOverride(themeKind: themeKind, backgroundHex: nil, foregroundHex: nil)
-        }
+        var working = matchedOverride ?? ThemeOverride(themeKind: themeKind, backgroundHex: nil, foregroundHex: nil)
         transform(&working)
-        if working.backgroundHex == nil && working.foregroundHex == nil {
-            override = nil
-        } else {
-            override = working
-        }
+        override = (working.backgroundHex == nil && working.foregroundHex == nil) ? nil : working
     }
 }

--- a/minimark/Views/ThemeColorOverrideRow.swift
+++ b/minimark/Views/ThemeColorOverrideRow.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 struct ThemeColorOverrideRow: View {
@@ -61,6 +62,21 @@ struct ThemeColorOverrideRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .background(
+            GeometryReader { geo in
+                Color.clear
+                    .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
+                        guard let panel = notification.object as? NSWindow,
+                              panel === NSColorPanel.shared else { return }
+                        let rowFrame = geo.frame(in: .global)
+                        let panelSize = panel.frame.size
+                        panel.setFrameOrigin(NSPoint(
+                            x: rowFrame.maxX + 12,
+                            y: rowFrame.midY - panelSize.height / 2
+                        ))
+                    }
+            }
+        )
     }
 
     private var backgroundBinding: Binding<Color> {

--- a/minimark/Views/ThemeSelectorView.swift
+++ b/minimark/Views/ThemeSelectorView.swift
@@ -11,12 +11,14 @@ struct ThemeSelectorView: View {
 
     @State private var stagedReaderTheme: ThemeKind
     @State private var stagedSyntaxTheme: SyntaxThemeKind
+    @State private var stagedOverride: ThemeOverride?
     @State private var selectedBackgroundTab: BackgroundTab = .light
 
     init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
         self._stagedReaderTheme = State(initialValue: settingsStore.currentSettings.readerTheme)
         self._stagedSyntaxTheme = State(initialValue: settingsStore.currentSettings.syntaxTheme)
+        self._stagedOverride = State(initialValue: settingsStore.currentSettings.readerThemeOverride)
         self._selectedBackgroundTab = State(
             initialValue: settingsStore.currentSettings.readerTheme.isDark ? .dark : .light
         )
@@ -25,9 +27,16 @@ struct ThemeSelectorView: View {
     var body: some View {
         VStack(spacing: 0) {
             threeColumnLayout
+            ThemeColorOverrideRow(themeKind: stagedReaderTheme, override: $stagedOverride)
+                .padding(.top, 8)
             applyBar
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onChange(of: stagedReaderTheme) { _, newKind in
+            if let existing = stagedOverride, existing.themeKind != newKind {
+                stagedOverride = nil
+            }
+        }
     }
 
     private var threeColumnLayout: some View {
@@ -174,6 +183,7 @@ struct ThemeSelectorView: View {
             Button("Reset") {
                 stagedReaderTheme = appliedReaderTheme
                 stagedSyntaxTheme = appliedSyntaxTheme
+                stagedOverride = settingsStore.currentSettings.readerThemeOverride
                 selectedBackgroundTab = appliedReaderTheme.isDark ? .dark : .light
             }
             .disabled(!hasUnsavedChanges)
@@ -199,7 +209,9 @@ struct ThemeSelectorView: View {
     }
 
     private var hasUnsavedChanges: Bool {
-        stagedReaderTheme != appliedReaderTheme || stagedSyntaxTheme != appliedSyntaxTheme
+        stagedReaderTheme != appliedReaderTheme
+            || stagedSyntaxTheme != appliedSyntaxTheme
+            || stagedOverride != settingsStore.currentSettings.readerThemeOverride
     }
 
     private var appliedReaderTheme: ThemeKind {
@@ -214,6 +226,7 @@ struct ThemeSelectorView: View {
         var settings = settingsStore.currentSettings
         settings.readerTheme = stagedReaderTheme
         settings.syntaxTheme = stagedSyntaxTheme
+        settings.readerThemeOverride = stagedOverride
         return settings
     }
 
@@ -223,6 +236,10 @@ struct ThemeSelectorView: View {
         }
         if stagedSyntaxTheme != appliedSyntaxTheme {
             settingsStore.updateSyntaxTheme(stagedSyntaxTheme)
+        }
+        let normalizedOverride = stagedOverride.flatMap { $0.themeKind == stagedReaderTheme ? $0 : nil }
+        if normalizedOverride != settingsStore.currentSettings.readerThemeOverride {
+            settingsStore.updateReaderThemeOverride(normalizedOverride)
         }
     }
 }

--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -157,7 +157,7 @@ struct WindowRootView: View {
     }
 
     private var windowShell: some View {
-        let theme = Theme.theme(for: settingsStore.currentSettings.readerTheme)
+        let theme = Theme.theme(for: settingsStore.currentSettings.readerTheme).applyingOverride(settingsStore.currentSettings.readerThemeOverride)
         return ZStack {
             Rectangle()
                 .fill(Color(hex: theme.backgroundHex) ?? .clear)

--- a/minimarkTests/Core/ColorHexConversionTests.swift
+++ b/minimarkTests/Core/ColorHexConversionTests.swift
@@ -26,6 +26,13 @@ import Testing
 
         let hex = ColorHexConversion.hexString(from: color)
 
-        #expect(hex == expected)
+        let original = try #require(Color(hex: expected))
+        let roundTripped = try #require(Color(hex: hex))
+        let nsOriginal = NSColor(original).usingColorSpace(.sRGB) ?? NSColor(original)
+        let nsRoundTripped = NSColor(roundTripped).usingColorSpace(.sRGB) ?? NSColor(roundTripped)
+        let tolerance: Double = 1.0 / 255.0
+        #expect(abs(nsOriginal.redComponent - nsRoundTripped.redComponent) <= tolerance)
+        #expect(abs(nsOriginal.greenComponent - nsRoundTripped.greenComponent) <= tolerance)
+        #expect(abs(nsOriginal.blueComponent - nsRoundTripped.blueComponent) <= tolerance)
     }
 }

--- a/minimarkTests/Core/ColorHexConversionTests.swift
+++ b/minimarkTests/Core/ColorHexConversionTests.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import minimark
+
+@Suite struct ColorHexConversionTests {
+    @Test func hexStringFromColorRoundTripsSixDigitUppercase() {
+        let color = Color(red: 0x11 / 255.0, green: 0x22 / 255.0, blue: 0x33 / 255.0)
+        let hex = ColorHexConversion.hexString(from: color)
+        #expect(hex == "#112233")
+    }
+
+    @Test func hexStringNormalizesSaturatedWhite() {
+        let hex = ColorHexConversion.hexString(from: .white)
+        #expect(hex == "#FFFFFF")
+    }
+
+    @Test func hexStringNormalizesSaturatedBlack() {
+        let hex = ColorHexConversion.hexString(from: .black)
+        #expect(hex == "#000000")
+    }
+
+    @Test func hexStringRoundTripsThroughColorInit() throws {
+        let expected = "#4A89DC"
+        let color = try #require(Color(hex: expected))
+
+        let hex = ColorHexConversion.hexString(from: color)
+
+        #expect(hex == expected)
+    }
+}

--- a/minimarkTests/Core/ContentAreaViewModelTests.swift
+++ b/minimarkTests/Core/ContentAreaViewModelTests.swift
@@ -63,7 +63,8 @@ extension ContentViewFolderWatchState {
         recentWatchedFolders: [],
         recentManuallyOpenedFiles: [],
         isAppearanceLocked: false,
-        effectiveReaderTheme: .blackOnWhite
+        effectiveReaderTheme: .blackOnWhite,
+        effectiveReaderThemeOverride: nil
     )
 }
 
@@ -258,7 +259,8 @@ struct ContentAreaViewModelObservationTests {
             recentWatchedFolders: [],
             recentManuallyOpenedFiles: [],
             isAppearanceLocked: false,
-            effectiveReaderTheme: .blackOnWhite
+            effectiveReaderTheme: .blackOnWhite,
+            effectiveReaderThemeOverride: nil
         )
         viewModel.applyHostInputs(folderWatchState: nextState, onAction: { _ in })
         await settle()

--- a/minimarkTests/Core/LockedAppearanceCodableTests.swift
+++ b/minimarkTests/Core/LockedAppearanceCodableTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite struct LockedAppearanceCodableTests {
+    @Test func lockedAppearanceRoundTripsWithOverride() throws {
+        let locked = LockedAppearance(
+            readerTheme: .nord,
+            baseFontSize: 16,
+            syntaxTheme: .monokai,
+            readerThemeOverride: ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        )
+
+        let data = try JSONEncoder().encode(locked)
+        let decoded = try JSONDecoder().decode(LockedAppearance.self, from: data)
+
+        #expect(decoded == locked)
+    }
+
+    @Test func lockedAppearanceRoundTripsWithoutOverride() throws {
+        let locked = LockedAppearance(
+            readerTheme: .nord,
+            baseFontSize: 16,
+            syntaxTheme: .monokai,
+            readerThemeOverride: nil
+        )
+
+        let data = try JSONEncoder().encode(locked)
+        let decoded = try JSONDecoder().decode(LockedAppearance.self, from: data)
+
+        #expect(decoded == locked)
+    }
+
+    @Test func lockedAppearanceLegacyPayloadDecodesOverrideAsNil() throws {
+        let legacy: [String: Any] = [
+            "readerTheme": "nord",
+            "baseFontSize": 16,
+            "syntaxTheme": "monokai"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacy)
+
+        let decoded = try JSONDecoder().decode(LockedAppearance.self, from: data)
+
+        #expect(decoded.readerTheme == .nord)
+        #expect(decoded.baseFontSize == 16)
+        #expect(decoded.syntaxTheme == .monokai)
+        #expect(decoded.readerThemeOverride == nil)
+    }
+}

--- a/minimarkTests/Core/SettingsAndModelsTests.swift
+++ b/minimarkTests/Core/SettingsAndModelsTests.swift
@@ -1001,4 +1001,29 @@ struct SettingsAndModelsTests {
         #expect(store.currentSettings.readerThemeOverride == nil)
         #expect(store.currentSettings.readerTheme == .nord)
     }
+
+    @Test @MainActor func updateThemeClearsOverrideWhenKindChanges() {
+        let storage = TestSettingsKeyValueStorage()
+        let store = SettingsStore(storage: storage, storageKey: "reader.settings.clear-on-switch.tests")
+        store.updateTheme(.nord)
+        store.updateReaderThemeOverride(
+            ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        )
+
+        store.updateTheme(.dracula)
+
+        #expect(store.currentSettings.readerThemeOverride == nil)
+    }
+
+    @Test @MainActor func updateThemeKeepsOverrideWhenKindIsUnchanged() {
+        let storage = TestSettingsKeyValueStorage()
+        let store = SettingsStore(storage: storage, storageKey: "reader.settings.keep-on-resame.tests")
+        store.updateTheme(.nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        store.updateReaderThemeOverride(override)
+
+        store.updateTheme(.nord)
+
+        #expect(store.currentSettings.readerThemeOverride == override)
+    }
 }

--- a/minimarkTests/Core/SettingsAndModelsTests.swift
+++ b/minimarkTests/Core/SettingsAndModelsTests.swift
@@ -952,4 +952,53 @@ struct SettingsAndModelsTests {
         #expect(reloadedStore.isHintDismissed(.changeNavigation))
         #expect(!reloadedStore.isHintDismissed(.multiSelect))
     }
+
+    @Test @MainActor func readerSettingsStorePersistsReaderThemeOverride() {
+        let storage = TestSettingsKeyValueStorage()
+        let storageKey = "reader.settings.override.tests"
+        let store = SettingsStore(
+            storage: storage,
+            storageKey: storageKey,
+            minimumPersistInterval: 0
+        )
+
+        store.updateTheme(.nord)
+        store.updateReaderThemeOverride(
+            ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        )
+
+        let reloadedStore = SettingsStore(storage: storage, storageKey: storageKey)
+        #expect(reloadedStore.currentSettings.readerThemeOverride?.themeKind == .nord)
+        #expect(reloadedStore.currentSettings.readerThemeOverride?.backgroundHex == "#112233")
+        #expect(reloadedStore.currentSettings.readerThemeOverride?.foregroundHex == "#AABBCC")
+    }
+
+    @Test @MainActor func readerSettingsLegacyPayloadDecodesOverrideAsNil() throws {
+        let storage = TestSettingsKeyValueStorage()
+        let storageKey = "reader.settings.legacy-override.tests"
+        let legacy: [String: Any] = [
+            "appAppearance": "system",
+            "readerTheme": "nord",
+            "syntaxTheme": "monokai",
+            "baseFontSize": 15,
+            "autoRefreshOnExternalChange": true,
+            "notificationsEnabled": true,
+            "multiFileDisplayMode": "sidebarLeft",
+            "sidebarSortMode": "openOrder",
+            "sidebarGroupSortMode": "lastChangedNewestFirst",
+            "favoriteWatchedFolders": [],
+            "recentWatchedFolders": [],
+            "recentManuallyOpenedFiles": [],
+            "trustedImageFolders": [],
+            "diffBaselineLookback": "twoMinutes",
+            "dismissedHints": []
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacy)
+        storage.set(data, forKey: storageKey)
+
+        let store = SettingsStore(storage: storage, storageKey: storageKey)
+
+        #expect(store.currentSettings.readerThemeOverride == nil)
+        #expect(store.currentSettings.readerTheme == .nord)
+    }
 }

--- a/minimarkTests/Core/ThemeOverrideTests.swift
+++ b/minimarkTests/Core/ThemeOverrideTests.swift
@@ -27,4 +27,68 @@ import Testing
         #expect(decoded.backgroundHex == nil)
         #expect(decoded.foregroundHex == nil)
     }
+
+    @Test func applyingOverrideReturnsSelfWhenOverrideIsNil() {
+        let base = Theme.theme(for: .nord)
+        let patched = base.applyingOverride(nil)
+
+        #expect(patched == base)
+    }
+
+    @Test func applyingOverrideIgnoresOverrideFromDifferentThemeKind() {
+        let base = Theme.theme(for: .nord)
+        let override = ThemeOverride(
+            themeKind: .dracula,
+            backgroundHex: "#000000",
+            foregroundHex: "#FFFFFF"
+        )
+
+        let patched = base.applyingOverride(override)
+
+        #expect(patched == base)
+    }
+
+    @Test func applyingOverrideReplacesOnlyBackgroundWhenOnlyBackgroundIsSet() {
+        let base = Theme.theme(for: .nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+
+        let patched = base.applyingOverride(override)
+
+        #expect(patched.backgroundHex == "#112233")
+        #expect(patched.foregroundHex == base.foregroundHex)
+        #expect(patched.kind == base.kind)
+    }
+
+    @Test func applyingOverrideReplacesOnlyForegroundWhenOnlyForegroundIsSet() {
+        let base = Theme.theme(for: .nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: nil, foregroundHex: "#AABBCC")
+
+        let patched = base.applyingOverride(override)
+
+        #expect(patched.backgroundHex == base.backgroundHex)
+        #expect(patched.foregroundHex == "#AABBCC")
+    }
+
+    @Test func applyingOverrideReplacesBothWhenBothAreSet() {
+        let base = Theme.theme(for: .nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+
+        let patched = base.applyingOverride(override)
+
+        #expect(patched.backgroundHex == "#112233")
+        #expect(patched.foregroundHex == "#AABBCC")
+        #expect(patched.secondaryForegroundHex == base.secondaryForegroundHex)
+        #expect(patched.linkHex == base.linkHex)
+        #expect(patched.borderHex == base.borderHex)
+        #expect(patched.codeBackgroundHex == base.codeBackgroundHex)
+    }
+
+    @Test func applyingOverrideIsNoOpWhenBothFieldsAreNilEvenWithMatchingKind() {
+        let base = Theme.theme(for: .nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: nil, foregroundHex: nil)
+
+        let patched = base.applyingOverride(override)
+
+        #expect(patched == base)
+    }
 }

--- a/minimarkTests/Core/ThemeOverrideTests.swift
+++ b/minimarkTests/Core/ThemeOverrideTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite struct ThemeOverrideTests {
+    @Test func themeOverrideRoundTripsFullPayload() throws {
+        let override = ThemeOverride(
+            themeKind: .nord,
+            backgroundHex: "#112233",
+            foregroundHex: "#EEDDCC"
+        )
+
+        let data = try JSONEncoder().encode(override)
+        let decoded = try JSONDecoder().decode(ThemeOverride.self, from: data)
+
+        #expect(decoded.themeKind == .nord)
+        #expect(decoded.backgroundHex == "#112233")
+        #expect(decoded.foregroundHex == "#EEDDCC")
+    }
+
+    @Test func themeOverrideRoundTripsNilFields() throws {
+        let override = ThemeOverride(themeKind: .blackOnWhite, backgroundHex: nil, foregroundHex: nil)
+        let data = try JSONEncoder().encode(override)
+        let decoded = try JSONDecoder().decode(ThemeOverride.self, from: data)
+
+        #expect(decoded.themeKind == .blackOnWhite)
+        #expect(decoded.backgroundHex == nil)
+        #expect(decoded.foregroundHex == nil)
+    }
+}

--- a/minimarkTests/Core/WindowAppearanceControllerOverrideTests.swift
+++ b/minimarkTests/Core/WindowAppearanceControllerOverrideTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite @MainActor struct WindowAppearanceControllerOverrideTests {
+    @Test func effectiveAppearanceIncludesOverrideAtConstruction() {
+        let settingsStore = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settingsStore.updateTheme(.nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        settingsStore.updateReaderThemeOverride(override)
+
+        let controller = WindowAppearanceController(settingsStore: settingsStore)
+
+        #expect(controller.effectiveAppearance.readerThemeOverride == override)
+    }
+
+    @Test func publisherUpdatesPropagateOverrideWhenUnlocked() async {
+        let settingsStore = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settingsStore.updateTheme(.nord)
+        let controller = WindowAppearanceController(settingsStore: settingsStore)
+
+        settingsStore.updateReaderThemeOverride(
+            ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+        )
+
+        _ = await waitUntil { controller.effectiveAppearance.readerThemeOverride?.backgroundHex == "#112233" }
+        #expect(controller.effectiveAppearance.readerThemeOverride?.backgroundHex == "#112233")
+    }
+
+    @Test func lockedAppearanceExposesOverride() {
+        let settingsStore = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settingsStore.updateTheme(.nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+        settingsStore.updateReaderThemeOverride(override)
+        let controller = WindowAppearanceController(settingsStore: settingsStore)
+
+        controller.lock()
+
+        #expect(controller.lockedAppearance?.readerThemeOverride == override)
+    }
+
+    @Test func restoreFromLockedAppearanceAppliesOverride() {
+        let settingsStore = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settingsStore.updateTheme(.nord)
+        let controller = WindowAppearanceController(settingsStore: settingsStore)
+        let locked = LockedAppearance(
+            readerTheme: .nord,
+            baseFontSize: 16,
+            syntaxTheme: .monokai,
+            readerThemeOverride: ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: "#AABBCC")
+        )
+
+        controller.restore(from: locked)
+
+        #expect(controller.effectiveAppearance == locked)
+        #expect(controller.isLocked)
+    }
+}

--- a/minimarkTests/Rendering/CSSFactoryCacheTests.swift
+++ b/minimarkTests/Rendering/CSSFactoryCacheTests.swift
@@ -5,8 +5,8 @@ final class CSSFactoryCacheTests: XCTestCase {
 
     func testSameInputsReturnIdenticalCSS() {
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
-        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
+        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
+        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
 
         XCTAssertEqual(css1, css2)
     }
@@ -14,24 +14,24 @@ final class CSSFactoryCacheTests: XCTestCase {
     func testDifferentThemeProducesDifferentCSS() {
         let theme1 = ThemeKind.blackOnWhite.themeDefinition
         let theme2 = ThemeKind.newspaper.themeDefinition
-        let css1 = CSSThemeGenerator.makeCSS(theme: theme1, syntaxTheme: .monokai, baseFontSize: 15)
-        let css2 = CSSThemeGenerator.makeCSS(theme: theme2, syntaxTheme: .monokai, baseFontSize: 15)
+        let css1 = CSSThemeGenerator.makeCSS(theme: theme1, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
+        let css2 = CSSThemeGenerator.makeCSS(theme: theme2, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
 
         XCTAssertNotEqual(css1, css2)
     }
 
     func testDifferentFontSizeProducesDifferentCSS() {
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
-        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 20)
+        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
+        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 20, readerThemeOverride: nil)
 
         XCTAssertNotEqual(css1, css2)
     }
 
     func testDifferentSyntaxThemeProducesDifferentCSS() {
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15)
-        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .dracula, baseFontSize: 15)
+        let css1 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 15, readerThemeOverride: nil)
+        let css2 = CSSThemeGenerator.makeCSS(theme: theme, syntaxTheme: .dracula, baseFontSize: 15, readerThemeOverride: nil)
 
         XCTAssertNotEqual(css1, css2)
     }

--- a/minimarkTests/Rendering/CSSThemeGeneratorOverrideTests.swift
+++ b/minimarkTests/Rendering/CSSThemeGeneratorOverrideTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite struct CSSThemeGeneratorOverrideTests {
+    @Test func cssReflectsBackgroundOverride() {
+        let theme = ThemeKind.nord.themeDefinition
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+
+        let css = CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15,
+            readerThemeOverride: override
+        )
+
+        #expect(css.contains("--reader-bg: #112233;"))
+        #expect(css.contains("--reader-fg: \(theme.colors.foregroundHex);"))
+    }
+
+    @Test func cssReflectsForegroundOverride() {
+        let theme = ThemeKind.nord.themeDefinition
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: nil, foregroundHex: "#AABBCC")
+
+        let css = CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15,
+            readerThemeOverride: override
+        )
+
+        #expect(css.contains("--reader-fg: #AABBCC;"))
+        #expect(css.contains("--reader-bg: \(theme.colors.backgroundHex);"))
+    }
+
+    @Test func cssIgnoresOverrideFromDifferentThemeKind() {
+        let theme = ThemeKind.nord.themeDefinition
+        let override = ThemeOverride(themeKind: .dracula, backgroundHex: "#000000", foregroundHex: "#FFFFFF")
+
+        let css = CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15,
+            readerThemeOverride: override
+        )
+
+        #expect(css.contains("--reader-bg: \(theme.colors.backgroundHex);"))
+        #expect(css.contains("--reader-fg: \(theme.colors.foregroundHex);"))
+    }
+
+    @Test func cacheDoesNotMixOverriddenAndPlainOutputs() {
+        let theme = ThemeKind.nord.themeDefinition
+
+        let plain = CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15,
+            readerThemeOverride: nil
+        )
+        let overridden = CSSThemeGenerator.makeCSS(
+            theme: theme,
+            syntaxTheme: .monokai,
+            baseFontSize: 15,
+            readerThemeOverride: ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+        )
+
+        #expect(plain != overridden)
+        #expect(plain.contains("--reader-bg: \(theme.colors.backgroundHex);"))
+        #expect(overridden.contains("--reader-bg: #112233;"))
+    }
+}

--- a/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
+++ b/minimarkTests/Rendering/CalloutBlockRenderingTests.swift
@@ -19,7 +19,8 @@ struct CalloutBlockRenderingTests {
             unsavedChangedRegions: [],
             theme: theme,
             syntaxTheme: .monokai,
-            baseFontSize: 15
+            baseFontSize: 15,
+            readerThemeOverride: nil
         ).htmlDocument
     }
 

--- a/minimarkTests/Rendering/CheckboxCSSTests.swift
+++ b/minimarkTests/Rendering/CheckboxCSSTests.swift
@@ -11,7 +11,8 @@ struct CheckboxCSSTests {
     private let css = CSSFactory().makeCSS(
         theme: ThemeKind.blackOnWhite.themeDefinition,
         syntaxTheme: .default,
-        baseFontSize: 16.0
+        baseFontSize: 16.0,
+        readerThemeOverride: nil
     )
 
     @Test

--- a/minimarkTests/Rendering/MarkdownRenderingServiceTests.swift
+++ b/minimarkTests/Rendering/MarkdownRenderingServiceTests.swift
@@ -19,7 +19,8 @@ struct MarkdownRenderingServiceTests {
             unsavedChangedRegions: [],
             theme: theme,
             syntaxTheme: .monokai,
-            baseFontSize: 15
+            baseFontSize: 15,
+            readerThemeOverride: nil
         )
 
         let containsHTML = result.htmlDocument.contains("<html") || result.htmlDocument.contains("<!DOCTYPE")
@@ -34,7 +35,8 @@ struct MarkdownRenderingServiceTests {
             unsavedChangedRegions: [],
             theme: theme,
             syntaxTheme: .monokai,
-            baseFontSize: 15
+            baseFontSize: 15,
+            readerThemeOverride: nil
         )
 
         #expect(result.changedRegions == [region])
@@ -48,7 +50,8 @@ struct MarkdownRenderingServiceTests {
             unsavedChangedRegions: [],
             theme: theme,
             syntaxTheme: .monokai,
-            baseFontSize: 15
+            baseFontSize: 15,
+            readerThemeOverride: nil
         )
 
         #expect(result.renderedAt >= before)

--- a/minimarkTests/Rendering/RenderingAndDiffTests.swift
+++ b/minimarkTests/Rendering/RenderingAndDiffTests.swift
@@ -417,7 +417,7 @@ struct RenderingAndDiffTests {
     @Test func readerCSSUsesFullAvailableDocumentWidth() {
         let factory = CSSFactory()
 
-        let css = factory.makeCSS(theme: ThemeKind.blackOnWhite.themeDefinition, syntaxTheme: .default, baseFontSize: 16)
+        let css = factory.makeCSS(theme: ThemeKind.blackOnWhite.themeDefinition, syntaxTheme: .default, baseFontSize: 16, readerThemeOverride: nil)
 
         #expect(css.contains("width: 100%;"))
         #expect(css.contains("margin: 0;"))

--- a/minimarkTests/Rendering/RenderingControllerOverrideTests.swift
+++ b/minimarkTests/Rendering/RenderingControllerOverrideTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@MainActor
+private final class CapturingMarkdownRenderer: MarkdownRendering {
+    var lastOverride: ThemeOverride?
+    var renderCallCount = 0
+
+    func render(
+        markdown: String,
+        changedRegions: [ChangedRegion],
+        unsavedChangedRegions: [ChangedRegion],
+        theme: ThemeDefinition,
+        syntaxTheme: SyntaxThemeKind,
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
+    ) throws -> RenderedMarkdown {
+        lastOverride = readerThemeOverride
+        renderCallCount += 1
+        return RenderedMarkdown(
+            htmlDocument: "<html></html>",
+            changedRegions: changedRegions,
+            renderedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+}
+
+@MainActor
+private func makeController(
+    settings: TestSettingsStore,
+    renderer: CapturingMarkdownRenderer
+) -> RenderingController {
+    let securityScopeResolver = SecurityScopeResolver(
+        securityScope: TestSecurityScopeAccess(),
+        settingsStore: settings,
+        requestWatchedFolderReauthorization: { _ in nil }
+    )
+    return RenderingController(
+        renderingDependencies: RenderingDependencies(
+            renderer: renderer,
+            differ: TestChangedRegionDiffer()
+        ),
+        settingsStore: settings,
+        securityScopeResolver: securityScopeResolver
+    )
+}
+
+@Suite @MainActor struct RenderingControllerOverrideTests {
+    @Test func rendererReceivesSettingsOverrideWhenNoAppearanceOverride() throws {
+        let settings = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settings.updateTheme(.nord)
+        let override = ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+        settings.updateReaderThemeOverride(override)
+        let renderer = CapturingMarkdownRenderer()
+        let controller = makeController(settings: settings, renderer: renderer)
+
+        try controller.renderImmediately(
+            sourceMarkdown: "# hi",
+            changedRegions: [],
+            unsavedChangedRegions: [],
+            fileURL: nil,
+            folderWatchSession: nil
+        )
+
+        #expect(renderer.renderCallCount == 1)
+        #expect(renderer.lastOverride == override)
+    }
+
+    @Test func rendererReceivesAppearanceOverrideWhenAppearanceIsSet() throws {
+        let settings = TestSettingsStore(autoRefreshOnExternalChange: true)
+        settings.updateTheme(.nord)
+        settings.updateReaderThemeOverride(
+            ThemeOverride(themeKind: .nord, backgroundHex: "#112233", foregroundHex: nil)
+        )
+        let renderer = CapturingMarkdownRenderer()
+        let controller = makeController(settings: settings, renderer: renderer)
+        let appearanceOverride = ThemeOverride(themeKind: .dracula, backgroundHex: "#AABBCC", foregroundHex: "#DDEEFF")
+
+        try controller.renderWithAppearance(
+            LockedAppearance(
+                readerTheme: .dracula,
+                baseFontSize: 16,
+                syntaxTheme: .monokai,
+                readerThemeOverride: appearanceOverride
+            ),
+            sourceMarkdown: "# hi",
+            changedRegions: [],
+            unsavedChangedRegions: [],
+            fileURL: nil,
+            folderWatchSession: nil
+        )
+
+        #expect(renderer.lastOverride == appearanceOverride)
+    }
+}

--- a/minimarkTests/Rendering/ThemeDefinitionTests.swift
+++ b/minimarkTests/Rendering/ThemeDefinitionTests.swift
@@ -86,7 +86,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testSimpleThemeCSSDoesNotContainCustomCSS() {
         let factory = CSSFactory()
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
         XCTAssertTrue(css.contains("--reader-bg:"))
         XCTAssertTrue(css.contains(".hljs-keyword"), "Should contain syntax theme CSS from SyntaxThemeKind")
         XCTAssertFalse(css.contains("Amber Terminal"), "Should not contain amber custom CSS")
@@ -95,7 +95,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testAmberTerminalCSSIncludesCustomCSSAfterStructural() {
         let factory = CSSFactory()
         let theme = ThemeKind.amberTerminal.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
 
         XCTAssertTrue(css.contains("--reader-bg:"), "Should contain CSS variables")
         XCTAssertTrue(css.contains("repeating-linear-gradient"), "Should contain scanlines from customCSS")
@@ -111,7 +111,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testAmberTerminalUsesSyntaxCSSInsteadOfSyntaxTheme() {
         let factory = CSSFactory()
         let theme = ThemeKind.amberTerminal.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
 
         // Should contain amber syntax tokens, not Monokai ones
         XCTAssertTrue(css.contains("color: #FFB000"), "Should contain amber syntax CSS")
@@ -121,7 +121,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testSimpleThemeUsesSelectedSyntaxTheme() {
         let factory = CSSFactory()
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
 
         XCTAssertTrue(css.contains("#F92672"), "Should contain Monokai keyword color")
     }
@@ -238,7 +238,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testGreenTerminalUsesSyntaxCSSInsteadOfSyntaxTheme() {
         let factory = CSSFactory()
         let theme = ThemeKind.greenTerminal.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
 
         XCTAssertTrue(css.contains("color: #00FF41"), "Should contain green syntax CSS")
         XCTAssertFalse(css.contains("#F92672"), "Should not contain Monokai keyword color")
@@ -360,7 +360,7 @@ final class ThemeDefinitionTests: XCTestCase {
         let factory = CSSFactory()
         for kind in [ThemeKind.blackOnWhite, .whiteOnBlack, .darkGreyOnLightGrey, .lightGreyOnDarkGrey] {
             let theme = kind.themeDefinition
-            let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16)
+            let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16, readerThemeOverride: nil)
             let expectedColors = Theme.theme(for: kind)
             XCTAssertTrue(css.contains(expectedColors.backgroundHex), "CSS should contain background hex for \(kind)")
             XCTAssertTrue(css.contains(expectedColors.foregroundHex), "CSS should contain foreground hex for \(kind)")
@@ -458,7 +458,7 @@ final class ThemeDefinitionTests: XCTestCase {
         let newThemes: [ThemeKind] = [.gruvboxDark, .gruvboxLight, .dracula, .monokai]
         for kind in newThemes {
             let theme = kind.themeDefinition
-            let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+            let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
             let colors = theme.colors
             XCTAssertTrue(css.contains("--reader-h1: \(colors.h1Hex!)"), "Missing h1 variable for \(kind)")
             XCTAssertTrue(css.contains("--reader-h2: \(colors.h2Hex!)"), "Missing h2 variable for \(kind)")
@@ -469,14 +469,14 @@ final class ThemeDefinitionTests: XCTestCase {
     func testNewThemesUseSelectedSyntaxTheme() {
         let factory = CSSFactory()
         let theme = ThemeKind.gruvboxDark.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .github, baseFontSize: 16, readerThemeOverride: nil)
         XCTAssertTrue(css.contains("#D73A49"), "Should contain GitHub keyword color from selected syntax theme")
     }
 
     func testSimpleThemesDoNotEmitHeaderVariables() {
         let factory = CSSFactory()
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
         XCTAssertFalse(css.contains("--reader-h1:"), "Simple themes should not emit h1 variable")
         XCTAssertFalse(css.contains("--reader-h2:"), "Simple themes should not emit h2 variable")
         XCTAssertFalse(css.contains("--reader-h3:"), "Simple themes should not emit h3 variable")
@@ -485,7 +485,7 @@ final class ThemeDefinitionTests: XCTestCase {
     func testHeaderColorFallbackInCSS() {
         let factory = CSSFactory()
         let theme = ThemeKind.blackOnWhite.themeDefinition
-        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16)
+        let css = factory.makeCSS(theme: theme, syntaxTheme: .monokai, baseFontSize: 16, readerThemeOverride: nil)
         XCTAssertTrue(css.contains("color: var(--reader-h1, var(--reader-fg))"), "h1 should fall back to foreground")
         XCTAssertTrue(css.contains("color: var(--reader-h2, var(--reader-fg))"), "h2 should fall back to foreground")
         XCTAssertTrue(css.contains("color: var(--reader-h3, var(--reader-fg))"), "h3 should fall back to foreground")

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -16,7 +16,8 @@ final class TestMarkdownRenderer: MarkdownRendering {
         unsavedChangedRegions: [ChangedRegion],
         theme: ThemeDefinition,
         syntaxTheme: SyntaxThemeKind,
-        baseFontSize: Double
+        baseFontSize: Double,
+        readerThemeOverride: ThemeOverride?
     ) throws -> RenderedMarkdown {
         RenderedMarkdown(
             htmlDocument: "<html><body>\(markdown)</body></html>",

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -145,6 +145,12 @@ final class TestSettingsStore: SettingsStoring {
         subject.send(next)
     }
 
+    func updateReaderThemeOverride(_ override: ThemeOverride?) {
+        var next = subject.value
+        next.readerThemeOverride = override
+        subject.send(next)
+    }
+
     func updateSyntaxTheme(_ kind: SyntaxThemeKind) {
         var next = subject.value
         next.syntaxTheme = kind


### PR DESCRIPTION
## Summary

- Add per-session background and text color overrides for the active reader theme via color pickers in Settings > Theme
- Override flows through the full render pipeline (CSS generation, source HTML, preview card, locked appearance) and persists via the existing staged Apply flow
- Legacy-decode safe: existing Settings and LockedAppearance payloads decode with `nil` override (no migration needed)

## Changes

**Data model:** `ThemeOverride` value type on `Settings` and `LockedAppearance`, with `Theme.applyingOverride(_:)` extension that patches background/foreground when the override's `themeKind` matches.

**Render pipeline:** Override threaded through `RenderingController → MarkdownRendering.render → CSSFactory → CSSThemeGenerator` (cache key extended to include override).

**Direct call sites:** `WindowRootView`, `ContentAreaViewModel`, `MarkdownSourceHTMLRenderer`, `ThemePreviewCard` all apply the override at their `Theme.theme(for:)` derivation point.

**Settings UI:** New `ThemeColorOverrideRow` subview with Background/Text color pickers and a "Reset to theme defaults" button. Inserted between the 3-column layout and Apply bar in `ThemeSelectorView`. Color panel repositions near the picker row on open.

**Lock appearance:** Override captured in all three `LockedAppearance` construction sites in `WindowAppearanceController`. Locked favorites freeze their override; switching global theme doesn't affect them.

**Color conversion:** `ColorHexConversion` helper normalizes through sRGB for stable round-trips on wide-gamut displays.

## Test plan

- [x] `ThemeOverride` Codable round-trip
- [x] `Theme.applyingOverride` — kind match/nil/mismatch, single-field, both-fields
- [x] `Settings` persistence + legacy decode
- [x] Override cleared on theme kind change, kept on same-kind re-apply
- [x] `LockedAppearance` Codable round-trip + legacy decode
- [x] `WindowAppearanceController` — construction, publisher propagation, locked state, restore
- [x] `CSSThemeGenerator` — override applied in CSS output, cache isolation
- [x] `RenderingController` — override precedence (locked appearance > live settings)
- [x] Full test suite passes (`xcodebuild test -only-testing:minimarkTests`)
- [ ] Manual: open Settings > Theme, pick colors, verify live preview, Apply, confirm reader windows repaint
- [ ] Manual: lock a favorite workspace's appearance with an override, change global theme, confirm locked favorite keeps its colors