### PR TITLE
Follow markdown links into a new sidebar slot

### DIFF
--- a/minimark/App/Resources/markdownobserver-link-intercept.js
+++ b/minimark/App/Resources/markdownobserver-link-intercept.js
@@ -1,0 +1,28 @@
+(function() {
+    function isMarkdownHref(href) {
+        if (!href) return false;
+        var bare = href.split('#')[0].split('?')[0];
+        var dot = bare.lastIndexOf('.');
+        if (dot < 0) return false;
+        var ext = bare.substring(dot + 1).toLowerCase();
+        return ext === 'md' || ext === 'markdown' || ext === 'mdown';
+    }
+    document.addEventListener('click', function(e) {
+        if (e.defaultPrevented) return;
+        if (e.button !== 0) return;
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+        var a = e.target.closest && e.target.closest('a');
+        if (!a) return;
+        var rawHref = a.getAttribute('href');
+        if (!isMarkdownHref(rawHref)) return;
+        var resolvedHref = a.href;
+        if (!resolvedHref) return;
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+            window.webkit.messageHandlers.minimarkLinkClick.postMessage({
+                url: resolvedHref
+            });
+        } catch (err) {}
+    }, true);
+})();

--- a/minimark/Models/LinkAccessGrant.swift
+++ b/minimark/Models/LinkAccessGrant.swift
@@ -19,16 +19,6 @@ nonisolated struct LinkAccessGrant: Equatable, Hashable, Codable, Sendable, Iden
         URL(fileURLWithPath: folderPath)
     }
 
-    init(folderURL: URL) {
-        let normalizedURL = FileRouting.normalizedFileURL(folderURL)
-        folderPath = normalizedURL.path
-        bookmarkData = try? folderURL.bookmarkData(
-            options: [.withSecurityScope],
-            includingResourceValuesForKeys: nil,
-            relativeTo: nil
-        )
-    }
-
     init(folderPath: String, bookmarkData: Data?) {
         self.folderPath = folderPath
         self.bookmarkData = bookmarkData
@@ -36,11 +26,18 @@ nonisolated struct LinkAccessGrant: Equatable, Hashable, Codable, Sendable, Iden
 }
 
 nonisolated enum LinkAccessGrantHistory {
+    /// Returns `existingEntries` unchanged when `bookmarkData` is `nil` —
+    /// persisting a grant without a usable bookmark would re-prompt forever:
+    /// the resolver would skip the bookmark-less entry and the coordinator
+    /// would see no covering grant on the next click.
     static func insertingUnique(
         _ folderURL: URL,
+        bookmarkData: Data?,
         into existingEntries: [LinkAccessGrant]
     ) -> [LinkAccessGrant] {
-        let newEntry = LinkAccessGrant(folderURL: folderURL)
+        guard let bookmarkData else { return existingEntries }
+        let normalizedURL = FileRouting.normalizedFileURL(folderURL)
+        let newEntry = LinkAccessGrant(folderPath: normalizedURL.path, bookmarkData: bookmarkData)
         let deduplicated = existingEntries.filter { $0.folderPath != newEntry.folderPath }
         return Array(([newEntry] + deduplicated).prefix(LinkAccessGrant.maximumCount))
     }

--- a/minimark/Models/LinkAccessGrant.swift
+++ b/minimark/Models/LinkAccessGrant.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// User-granted folder access bookmark used to read markdown files reached via
+/// link clicks inside the rendered preview. The sandbox grants per-file access
+/// when the user opens a document; siblings and descendants in the same folder
+/// require an explicit folder-scoped bookmark, which we collect on demand the
+/// first time a link points outside the currently-accessible scope.
+nonisolated struct LinkAccessGrant: Equatable, Hashable, Codable, Sendable, Identifiable {
+    static let maximumCount = 50
+
+    let folderPath: String
+    let bookmarkData: Data?
+
+    nonisolated var id: String {
+        folderPath
+    }
+
+    nonisolated var folderURL: URL {
+        URL(fileURLWithPath: folderPath)
+    }
+
+    init(folderURL: URL) {
+        let normalizedURL = FileRouting.normalizedFileURL(folderURL)
+        folderPath = normalizedURL.path
+        bookmarkData = try? folderURL.bookmarkData(
+            options: [.withSecurityScope],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+    }
+
+    init(folderPath: String, bookmarkData: Data?) {
+        self.folderPath = folderPath
+        self.bookmarkData = bookmarkData
+    }
+}
+
+nonisolated enum LinkAccessGrantHistory {
+    static func insertingUnique(
+        _ folderURL: URL,
+        into existingEntries: [LinkAccessGrant]
+    ) -> [LinkAccessGrant] {
+        let newEntry = LinkAccessGrant(folderURL: folderURL)
+        let deduplicated = existingEntries.filter { $0.folderPath != newEntry.folderPath }
+        return Array(([newEntry] + deduplicated).prefix(LinkAccessGrant.maximumCount))
+    }
+}

--- a/minimark/Models/WindowSeed.swift
+++ b/minimark/Models/WindowSeed.swift
@@ -2,12 +2,13 @@ import Foundation
 
 enum OpenOrigin: String, Hashable, Codable, Sendable {
     case manual
+    case linkFollow
     case folderWatchAutoOpen
     case folderWatchInitialBatchAutoOpen
 
     var isFolderWatchAutoOpen: Bool {
         switch self {
-        case .manual:
+        case .manual, .linkFollow:
             return false
         case .folderWatchAutoOpen, .folderWatchInitialBatchAutoOpen:
             return true

--- a/minimark/Services/LinkFollowAccessRequester.swift
+++ b/minimark/Services/LinkFollowAccessRequester.swift
@@ -1,0 +1,62 @@
+import AppKit
+import Foundation
+
+/// Presents an NSOpenPanel asking the user to authorize MarkdownObserver to
+/// read files in a folder so that markdown link clicks can follow into
+/// sibling and descendant files. The chosen folder is persisted as a
+/// security-scoped bookmark via `LinkAccessGrantWriting` so subsequent link
+/// clicks under the same folder don't re-prompt.
+@MainActor
+final class LinkFollowAccessRequester {
+    private let grantStore: LinkAccessGrantWriting
+    private let pickFolder: @MainActor (URL?, String, String, String) -> URL?
+
+    init(
+        grantStore: LinkAccessGrantWriting,
+        pickFolder: @escaping @MainActor (URL?, String, String, String) -> URL? = { directoryURL, title, message, prompt in
+            MarkdownOpenPanel.pickFolder(
+                directoryURL: directoryURL,
+                title: title,
+                message: message,
+                prompt: prompt
+            )
+        }
+    ) {
+        self.grantStore = grantStore
+        self.pickFolder = pickFolder
+    }
+
+    /// Presents an NSOpenPanel pre-pointed at `targetFileURL.deletingLastPathComponent()`
+    /// and, if the user picks a folder that contains the target file, persists the
+    /// selection as a link-access grant.
+    ///
+    /// Returns `true` if a grant covering the target file was successfully recorded.
+    @discardableResult
+    func requestAccess(forContaining targetFileURL: URL) -> Bool {
+        let parentFolderURL = targetFileURL.deletingLastPathComponent()
+        let fileName = targetFileURL.lastPathComponent
+
+        guard let chosenFolderURL = pickFolder(
+            parentFolderURL,
+            "Allow Link Following",
+            "MarkdownObserver needs access to this folder to open “\(fileName)” and related markdown files reached via links.",
+            "Grant Access"
+        ) else {
+            return false
+        }
+
+        guard folderContains(chosenFolderURL, file: targetFileURL) else {
+            return false
+        }
+
+        grantStore.addLinkAccessGrant(chosenFolderURL)
+        return true
+    }
+
+    private func folderContains(_ folderURL: URL, file fileURL: URL) -> Bool {
+        let folderPath = FileRouting.normalizedFileURL(folderURL).path
+        let filePath = FileRouting.normalizedFileURL(fileURL).path
+        let folderPathWithSeparator = folderPath.hasSuffix("/") ? folderPath : folderPath + "/"
+        return filePath.hasPrefix(folderPathWithSeparator)
+    }
+}

--- a/minimark/Services/LinkFollowAccessRequester.swift
+++ b/minimark/Services/LinkFollowAccessRequester.swift
@@ -50,7 +50,10 @@ final class LinkFollowAccessRequester {
         }
 
         grantStore.addLinkAccessGrant(chosenFolderURL)
-        return true
+        // Confirm the grant was actually persisted with a usable bookmark —
+        // `addLinkAccessGrant` is a no-op when bookmark creation fails, and
+        // we must not let the file open proceed against a phantom grant.
+        return grantStore.resolvedLinkAccessFolderURL(containing: targetFileURL) != nil
     }
 
     private func folderContains(_ folderURL: URL, file fileURL: URL) -> Bool {

--- a/minimark/Services/SecurityScopeResolver.swift
+++ b/minimark/Services/SecurityScopeResolver.swift
@@ -11,12 +11,12 @@ final class SecurityScopeResolver {
     var context = SecurityScopeContext()
 
     private let securityScope: SecurityScopedResourceAccessing
-    private let settingsStore: RecentWriting & TrustedFolderWriting
+    private let settingsStore: RecentWriting & TrustedFolderWriting & LinkAccessGrantWriting
     private let requestWatchedFolderReauthorization: (URL) -> URL?
 
     init(
         securityScope: SecurityScopedResourceAccessing,
-        settingsStore: RecentWriting & TrustedFolderWriting,
+        settingsStore: RecentWriting & TrustedFolderWriting & LinkAccessGrantWriting,
         requestWatchedFolderReauthorization: @escaping (URL) -> URL?
     ) {
         self.securityScope = securityScope
@@ -64,6 +64,12 @@ final class SecurityScopeResolver {
             context.accessibleFileURL = folderScopedFileURL
             context.accessibleFileURLSource = .folderScopeChildURL
             return folderScopedFileURL
+        }
+
+        if let linkScopedFileURL = linkAccessScopedAccessibleFileURL(for: normalizedURL) {
+            context.accessibleFileURL = linkScopedFileURL
+            context.accessibleFileURLSource = .folderScopeChildURL
+            return linkScopedFileURL
         }
 
         deriveFileSecurityScopeFromFolderIfNeeded(
@@ -139,6 +145,40 @@ final class SecurityScopeResolver {
 
     func resolvedWatchedFolderAccessURL(for session: FolderWatchSession) -> URL {
         settingsStore.resolvedRecentWatchedFolderURL(matching: session.folderURL) ?? session.folderURL
+    }
+
+    // MARK: - Link Access Grant Scope
+
+    /// Activates folder-scoped access via a stored link-access grant covering
+    /// `fileURL` and returns a folder-relative URL the loader can read.
+    /// Returns nil if no grant covers the URL or the bookmark cannot be
+    /// resolved.
+    func linkAccessScopedAccessibleFileURL(for fileURL: URL) -> URL? {
+        let normalizedFileURL = FileRouting.normalizedFileURL(fileURL)
+        guard let grantFolderURL = settingsStore.resolvedLinkAccessFolderURL(containing: normalizedFileURL) else {
+            return nil
+        }
+
+        if context.folderToken?.didStartAccess != true ||
+            FileRouting.normalizedFileURL(context.folderToken!.url) != FileRouting.normalizedFileURL(grantFolderURL) {
+            context.folderToken?.endAccess()
+            context.folderToken = securityScope.beginAccess(to: grantFolderURL)
+        }
+
+        guard let folderToken = context.folderToken, folderToken.didStartAccess else {
+            return nil
+        }
+
+        let folderPath = FileRouting.normalizedFileURL(folderToken.url).path
+        let filePath = normalizedFileURL.path
+
+        guard filePath.hasPrefix(folderPath) else { return nil }
+
+        let relativePath = filePath.dropFirst(folderPath.count)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !relativePath.isEmpty else { return folderToken.url }
+
+        return URL(fileURLWithPath: relativePath, relativeTo: folderToken.url).standardizedFileURL
     }
 
     // MARK: - Folder Session Helpers

--- a/minimark/Services/SecurityScopeResolver.swift
+++ b/minimark/Services/SecurityScopeResolver.swift
@@ -153,6 +153,13 @@ final class SecurityScopeResolver {
     /// `fileURL` and returns a folder-relative URL the loader can read.
     /// Returns nil if no grant covers the URL or the bookmark cannot be
     /// resolved.
+    ///
+    /// Replacing `context.folderToken` here is safe because each `DocumentStore`
+    /// owns its own `SecurityScopeResolver` (see `SidebarDocumentController`),
+    /// so a slot's link-access token cannot stomp another slot's watched-folder
+    /// token. Within a single resolver, `effectiveAccessibleFileURL` checks
+    /// `folderScopedAccessibleFileURL` (watch session) before falling through
+    /// to the link-access path, so a watched file never reaches this branch.
     func linkAccessScopedAccessibleFileURL(for fileURL: URL) -> URL? {
         let normalizedFileURL = FileRouting.normalizedFileURL(fileURL)
         guard let grantFolderURL = settingsStore.resolvedLinkAccessFolderURL(containing: normalizedFileURL) else {

--- a/minimark/Services/SecurityScopeResolver.swift
+++ b/minimark/Services/SecurityScopeResolver.swift
@@ -159,8 +159,7 @@ final class SecurityScopeResolver {
             return nil
         }
 
-        if context.folderToken?.didStartAccess != true ||
-            FileRouting.normalizedFileURL(context.folderToken!.url) != FileRouting.normalizedFileURL(grantFolderURL) {
+        if needsFolderTokenRefresh(for: grantFolderURL) {
             context.folderToken?.endAccess()
             context.folderToken = securityScope.beginAccess(to: grantFolderURL)
         }
@@ -179,6 +178,11 @@ final class SecurityScopeResolver {
         guard !relativePath.isEmpty else { return folderToken.url }
 
         return URL(fileURLWithPath: relativePath, relativeTo: folderToken.url).standardizedFileURL
+    }
+
+    private func needsFolderTokenRefresh(for grantFolderURL: URL) -> Bool {
+        guard let token = context.folderToken, token.didStartAccess else { return true }
+        return FileRouting.normalizedFileURL(token.url) != FileRouting.normalizedFileURL(grantFolderURL)
     }
 
     // MARK: - Folder Session Helpers

--- a/minimark/Stores/Settings/LinkAccessGrantsStore.swift
+++ b/minimark/Stores/Settings/LinkAccessGrantsStore.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Combine
+import Observation
+
+@MainActor @Observable final class LinkAccessGrantsStore: LinkAccessGrantWriting {
+    private(set) var currentGrants: [LinkAccessGrant]
+
+    weak var coordinator: ChildStoreCoordinating?
+
+    @ObservationIgnored
+    private let subject: CurrentValueSubject<[LinkAccessGrant], Never>
+
+    @ObservationIgnored
+    private let bookmarkRefreshing: BookmarkRefreshing
+
+    var grantsPublisher: AnyPublisher<[LinkAccessGrant], Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    init(initial: [LinkAccessGrant], bookmarkRefreshing: BookmarkRefreshing) {
+        self.currentGrants = initial
+        self.subject = CurrentValueSubject(initial)
+        self.bookmarkRefreshing = bookmarkRefreshing
+    }
+
+    func addLinkAccessGrant(_ folderURL: URL) {
+        mutate(coalescePersistence: false) { entries in
+            entries = LinkAccessGrantHistory.insertingUnique(folderURL, into: entries)
+        }
+    }
+
+    func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL? {
+        let normalizedFileURL = FileRouting.normalizedFileURL(fileURL)
+        let filePath = normalizedFileURL.path
+
+        // Prefer the deepest (most specific) covering folder so that nested
+        // grants take precedence over their ancestors.
+        let coveringEntries = currentGrants
+            .filter { entry in
+                let folderPath = entry.folderPath.hasSuffix("/") ? entry.folderPath : entry.folderPath + "/"
+                return filePath.hasPrefix(folderPath) || filePath == entry.folderPath
+            }
+            .sorted { $0.folderPath.count > $1.folderPath.count }
+
+        for entry in coveringEntries {
+            guard let bookmarkData = entry.bookmarkData else { continue }
+
+            var resolutionFailed = false
+            let resolvedURL = bookmarkRefreshing.resolveURL(
+                bookmarkData: bookmarkData,
+                fallbackURL: entry.folderURL,
+                onStale: { [weak self] _, refreshedBookmarkData in
+                    self?.updateBookmarkData(forPath: entry.folderPath, bookmarkData: refreshedBookmarkData)
+                },
+                onFailure: { [weak self] in
+                    resolutionFailed = true
+                    self?.updateBookmarkData(forPath: entry.folderPath, bookmarkData: nil)
+                }
+            )
+
+            if resolutionFailed { continue }
+            return resolvedURL
+        }
+
+        return nil
+    }
+
+    func clearLinkAccessGrants() {
+        mutate(coalescePersistence: false) { entries in
+            entries = []
+        }
+    }
+
+    private func updateBookmarkData(forPath folderPath: String, bookmarkData: Data?) {
+        mutate(coalescePersistence: false) { entries in
+            guard let index = entries.firstIndex(where: { $0.folderPath == folderPath }) else { return }
+            let existing = entries[index]
+            guard existing.bookmarkData != bookmarkData else { return }
+            entries[index] = LinkAccessGrant(
+                folderPath: existing.folderPath,
+                bookmarkData: bookmarkData
+            )
+        }
+    }
+
+    private func mutate(
+        coalescePersistence: Bool,
+        _ transform: (inout [LinkAccessGrant]) -> Void
+    ) {
+        var updated = currentGrants
+        transform(&updated)
+        guard updated != currentGrants else { return }
+        currentGrants = updated
+        subject.send(updated)
+        coordinator?.childStoreDidMutate(coalescePersistence: coalescePersistence)
+    }
+}

--- a/minimark/Stores/Settings/LinkAccessGrantsStore.swift
+++ b/minimark/Stores/Settings/LinkAccessGrantsStore.swift
@@ -24,8 +24,13 @@ import Observation
     }
 
     func addLinkAccessGrant(_ folderURL: URL) {
+        let bookmarkData = try? bookmarkRefreshing.create(folderURL)
         mutate(coalescePersistence: false) { entries in
-            entries = LinkAccessGrantHistory.insertingUnique(folderURL, into: entries)
+            entries = LinkAccessGrantHistory.insertingUnique(
+                folderURL,
+                bookmarkData: bookmarkData,
+                into: entries
+            )
         }
     }
 

--- a/minimark/Stores/SettingsStore.swift
+++ b/minimark/Stores/SettingsStore.swift
@@ -222,7 +222,6 @@ typealias RecentWriting = RecentWatchedFolderWriting & RecentOpenedFileWriting
 @MainActor protocol LinkAccessGrantWriting: AnyObject {
     func addLinkAccessGrant(_ folderURL: URL)
     func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL?
-    func clearLinkAccessGrants()
 }
 
 @MainActor protocol HintWriting: AnyObject {
@@ -508,7 +507,6 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
     func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL? {
         linkAccessGrants.resolvedLinkAccessFolderURL(containing: fileURL)
     }
-    func clearLinkAccessGrants() { linkAccessGrants.clearLinkAccessGrants() }
 
     // MARK: - Persistence
 

--- a/minimark/Stores/SettingsStore.swift
+++ b/minimark/Stores/SettingsStore.swift
@@ -17,6 +17,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
     var recentWatchedFolders: [RecentWatchedFolder]
     var recentManuallyOpenedFiles: [RecentOpenedFile]
     var trustedImageFolders: [TrustedImageFolder]
+    var linkAccessGrants: [LinkAccessGrant]
     var diffBaselineLookback: DiffBaselineLookback
     var dismissedHints: Set<FirstUseHint>
     var readerThemeOverride: ThemeOverride?
@@ -35,6 +36,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         recentWatchedFolders: [RecentWatchedFolder],
         recentManuallyOpenedFiles: [RecentOpenedFile],
         trustedImageFolders: [TrustedImageFolder] = [],
+        linkAccessGrants: [LinkAccessGrant] = [],
         diffBaselineLookback: DiffBaselineLookback = .twoMinutes,
         dismissedHints: Set<FirstUseHint> = [],
         readerThemeOverride: ThemeOverride? = nil
@@ -52,6 +54,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         self.recentWatchedFolders = recentWatchedFolders
         self.recentManuallyOpenedFiles = recentManuallyOpenedFiles
         self.trustedImageFolders = trustedImageFolders
+        self.linkAccessGrants = linkAccessGrants
         self.diffBaselineLookback = diffBaselineLookback
         self.dismissedHints = dismissedHints
         self.readerThemeOverride = readerThemeOverride
@@ -71,6 +74,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         case recentWatchedFolders
         case recentManuallyOpenedFiles
         case trustedImageFolders
+        case linkAccessGrants
         case diffBaselineLookback
         case dismissedHints
         case readerThemeOverride
@@ -90,6 +94,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         recentWatchedFolders: [],
         recentManuallyOpenedFiles: [],
         trustedImageFolders: [],
+        linkAccessGrants: [],
         diffBaselineLookback: .twoMinutes,
         dismissedHints: [],
         readerThemeOverride: nil
@@ -110,6 +115,7 @@ nonisolated struct Settings: Equatable, Codable, Sendable {
         recentWatchedFolders = try container.decodeIfPresent([RecentWatchedFolder].self, forKey: .recentWatchedFolders) ?? []
         recentManuallyOpenedFiles = try container.decodeIfPresent([RecentOpenedFile].self, forKey: .recentManuallyOpenedFiles) ?? []
         trustedImageFolders = try container.decodeIfPresent([TrustedImageFolder].self, forKey: .trustedImageFolders) ?? []
+        linkAccessGrants = try container.decodeIfPresent([LinkAccessGrant].self, forKey: .linkAccessGrants) ?? []
         diffBaselineLookback = try container.decodeIfPresent(DiffBaselineLookback.self, forKey: .diffBaselineLookback) ?? .twoMinutes
         dismissedHints = try container.decodeIfPresent(Set<FirstUseHint>.self, forKey: .dismissedHints) ?? []
         readerThemeOverride = try container.decodeIfPresent(ThemeOverride.self, forKey: .readerThemeOverride)
@@ -213,6 +219,12 @@ typealias RecentWriting = RecentWatchedFolderWriting & RecentOpenedFileWriting
     func resolvedTrustedImageFolderURL(containing fileURL: URL) -> URL?
 }
 
+@MainActor protocol LinkAccessGrantWriting: AnyObject {
+    func addLinkAccessGrant(_ folderURL: URL)
+    func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL?
+    func clearLinkAccessGrants()
+}
+
 @MainActor protocol HintWriting: AnyObject {
     func dismissHint(_ hint: FirstUseHint)
 }
@@ -222,6 +234,7 @@ typealias SettingsWriting = ThemeWriting
     & FavoriteWriting
     & RecentWriting
     & TrustedFolderWriting
+    & LinkAccessGrantWriting
     & HintWriting
 
 typealias SettingsStoring = SettingsReading & SettingsWriting
@@ -247,6 +260,7 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
     let recentWatchedFolders: RecentWatchedFoldersStore
     let recentOpenedFiles: RecentOpenedFilesStore
     let trustedImageFolders: TrustedImageFoldersStore
+    let linkAccessGrants: LinkAccessGrantsStore
 
     @ObservationIgnored private let storage: SettingsKeyValueStoring
     @ObservationIgnored private let storageKey: String
@@ -325,6 +339,10 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
             initial: initialSettings.trustedImageFolders,
             bookmarkRefreshing: bookmarkRefreshing
         )
+        self.linkAccessGrants = LinkAccessGrantsStore(
+            initial: initialSettings.linkAccessGrants,
+            bookmarkRefreshing: bookmarkRefreshing
+        )
 
         self.subject = CurrentValueSubject(initialSettings)
         self.currentSettings = initialSettings
@@ -334,6 +352,7 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
         self.recentWatchedFolders.coordinator = self
         self.recentOpenedFiles.coordinator = self
         self.trustedImageFolders.coordinator = self
+        self.linkAccessGrants.coordinator = self
     }
 
     // MARK: - ChildStoreCoordinating
@@ -369,6 +388,7 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
             recentWatchedFolders: recentWatchedFolders.currentRecentWatchedFolders,
             recentManuallyOpenedFiles: recentOpenedFiles.currentRecentOpenedFiles,
             trustedImageFolders: trustedImageFolders.currentTrustedFolders,
+            linkAccessGrants: linkAccessGrants.currentGrants,
             diffBaselineLookback: prefs.diffBaselineLookback,
             dismissedHints: prefs.dismissedHints,
             readerThemeOverride: prefs.readerThemeOverride
@@ -481,6 +501,14 @@ typealias SettingsStoring = SettingsReading & SettingsWriting
     func resolvedTrustedImageFolderURL(containing fileURL: URL) -> URL? {
         trustedImageFolders.resolvedTrustedImageFolderURL(containing: fileURL)
     }
+
+    // MARK: - LinkAccessGrantWriting
+
+    func addLinkAccessGrant(_ folderURL: URL) { linkAccessGrants.addLinkAccessGrant(folderURL) }
+    func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL? {
+        linkAccessGrants.resolvedLinkAccessFolderURL(containing: fileURL)
+    }
+    func clearLinkAccessGrants() { linkAccessGrants.clearLinkAccessGrants() }
 
     // MARK: - Persistence
 

--- a/minimark/Support/BundledAssetLoader.swift
+++ b/minimark/Support/BundledAssetLoader.swift
@@ -58,6 +58,10 @@ enum BundledAssetLoader {
         loadBundledJS(named: "markdownobserver-scroll-sync")
     }
 
+    static var markdownLinkInterceptJavaScript: String {
+        loadBundledJS(named: "markdownobserver-link-intercept")
+    }
+
     static var themeJSBootstrapScript: String {
         "<script>\n\(loadBundledJS(named: "theme-bootstrap"))\n</script>"
     }

--- a/minimark/Support/MarkdownLinkResolver.swift
+++ b/minimark/Support/MarkdownLinkResolver.swift
@@ -57,12 +57,7 @@ enum MarkdownLinkResolver {
         }
 
         let resolvedURL = URL(fileURLWithPath: resolvedPath)
-        guard isMarkdownExtension(resolvedURL.pathExtension) else { return nil }
+        guard FileRouting.isSupportedMarkdownFileURL(resolvedURL) else { return nil }
         return resolvedURL
-    }
-
-    private static func isMarkdownExtension(_ ext: String) -> Bool {
-        let lower = ext.lowercased()
-        return lower == "md" || lower == "markdown"
     }
 }

--- a/minimark/Support/MarkdownLinkResolver.swift
+++ b/minimark/Support/MarkdownLinkResolver.swift
@@ -1,0 +1,68 @@
+//
+//  MarkdownLinkResolver.swift
+//  minimark
+//
+
+import Foundation
+
+/// Resolves a `file://` URL produced by WKWebView's navigation delegate into a
+/// concrete on-disk markdown file URL, given the currently-open document's
+/// directory and the bundle base URL that WKWebView uses to resolve relative
+/// hrefs in the rendered preview.
+///
+/// The rendered HTML is loaded with `baseURL: Bundle.main.bundleURL`, so a
+/// markdown link like `[x](other.md)` arrives at the navigation delegate as
+/// `file:///Applications/MarkdownObserver.app/other.md`. This type detects that
+/// case by prefix-matching against the bundle path, strips the bundle prefix,
+/// and re-resolves the remainder against the current document's directory.
+enum MarkdownLinkResolver {
+    /// Returns the resolved markdown file URL, or `nil` if the input is not a
+    /// markdown link we should follow (wrong scheme, wrong extension, missing
+    /// document context).
+    ///
+    /// - Parameters:
+    ///   - url: The URL from the `WKNavigationAction.request`.
+    ///   - documentDirectoryPath: The directory containing the currently-open
+    ///     document. `nil` means we have no document context yet, in which
+    ///     case relative-style links cannot be resolved.
+    ///   - bundlePath: The standardized path of the app bundle URL — used to
+    ///     detect bundle-prefixed file URLs that originated as relative hrefs.
+    static func resolveMarkdownLink(
+        url: URL,
+        documentDirectoryPath: String?,
+        bundlePath: String
+    ) -> URL? {
+        guard url.isFileURL else { return nil }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.fragment = nil
+        guard let bareURL = components?.url else { return nil }
+
+        let candidatePath = bareURL.standardizedFileURL.path
+
+        let resolvedPath: String
+        if candidatePath == bundlePath || candidatePath.hasPrefix(bundlePath + "/") {
+            // Was a relative href before WKWebView resolved it against the
+            // bundle baseURL — strip the bundle prefix, re-resolve against
+            // the document directory.
+            guard let documentDirectoryPath else { return nil }
+            let relative = String(candidatePath.dropFirst(bundlePath.count).drop(while: { $0 == "/" }))
+            guard !relative.isEmpty else { return nil }
+            resolvedPath = URL(fileURLWithPath: documentDirectoryPath)
+                .appendingPathComponent(relative)
+                .standardizedFileURL
+                .path
+        } else {
+            resolvedPath = candidatePath
+        }
+
+        let resolvedURL = URL(fileURLWithPath: resolvedPath)
+        guard isMarkdownExtension(resolvedURL.pathExtension) else { return nil }
+        return resolvedURL
+    }
+
+    private static func isMarkdownExtension(_ ext: String) -> Bool {
+        let lower = ext.lowercased()
+        return lower == "md" || lower == "markdown"
+    }
+}

--- a/minimark/Views/Content/DocumentSurfaceAction.swift
+++ b/minimark/Views/Content/DocumentSurfaceAction.swift
@@ -10,6 +10,7 @@ enum DocumentSurfaceAction {
     case dropTargetedChange(DropTargetingUpdate)
     case changedRegionNavigationResult(index: Int)
     case retryFallback
+    case openLinkedFile(URL)
 }
 
 enum DocumentSurfaceRole: Hashable {

--- a/minimark/Views/Content/DocumentSurfaceViewModel.swift
+++ b/minimark/Views/Content/DocumentSurfaceViewModel.swift
@@ -211,6 +211,12 @@ final class DocumentSurfaceViewModel {
                     case .retryFallback:
                         self.previewReloadToken += 1
                         self.previewMode = .web
+                    case .openLinkedFile(let url):
+                        onAction(.requestFileOpen(FileOpenRequest(
+                            fileURLs: [url],
+                            origin: .manual,
+                            slotStrategy: .reuseEmptySlotForFirst
+                        )))
                     default:
                         break
                     }

--- a/minimark/Views/Content/DocumentSurfaceViewModel.swift
+++ b/minimark/Views/Content/DocumentSurfaceViewModel.swift
@@ -215,7 +215,7 @@ final class DocumentSurfaceViewModel {
                         onAction(.requestFileOpen(FileOpenRequest(
                             fileURLs: [url],
                             origin: .manual,
-                            slotStrategy: .reuseEmptySlotForFirst
+                            slotStrategy: .alwaysAppend
                         )))
                     default:
                         break

--- a/minimark/Views/Content/DocumentSurfaceViewModel.swift
+++ b/minimark/Views/Content/DocumentSurfaceViewModel.swift
@@ -214,7 +214,7 @@ final class DocumentSurfaceViewModel {
                     case .openLinkedFile(let url):
                         onAction(.requestFileOpen(FileOpenRequest(
                             fileURLs: [url],
-                            origin: .manual,
+                            origin: .linkFollow,
                             slotStrategy: .alwaysAppend
                         )))
                     default:

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -108,6 +108,7 @@ struct MarkdownWebView: NSViewRepresentable {
             case cancel
             case openExternal(URL)
             case scrollToFragment(String)
+            case openLinkedFile(URL)
         }
 
         private weak var webView: WKWebView?
@@ -528,6 +529,10 @@ struct MarkdownWebView: NSViewRepresentable {
             case let .scrollToFragment(fragment):
                 scrollToFragment(fragment, in: webView)
                 decisionHandler(.cancel)
+
+            case let .openLinkedFile(url):
+                onAction(.openLinkedFile(url))
+                decisionHandler(.cancel)
             }
         }
 
@@ -584,11 +589,24 @@ struct MarkdownWebView: NSViewRepresentable {
                 return .scrollToFragment(fragment)
             }
 
+            if let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+                url: url,
+                documentDirectoryPath: currentDocumentDirectoryPath(),
+                bundlePath: Bundle.main.bundleURL.standardizedFileURL.path
+            ) {
+                return .openLinkedFile(resolved)
+            }
+
             if isSafeExternalURL(url) {
                 return .openExternal(url)
             }
 
             return .cancel
+        }
+
+        private func currentDocumentDirectoryPath() -> String? {
+            guard let identity = lastDocumentIdentity else { return nil }
+            return URL(fileURLWithPath: identity).deletingLastPathComponent().path
         }
 
         private func inPageFragment(for targetURL: URL, in webView: WKWebView) -> String? {

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -9,7 +9,7 @@ struct MarkdownWebView: NSViewRepresentable {
     private static let sourceEditMessageName = "minimarkSourceEdit"
     private static let sourceEditorDiagnosticMessageName = "minimarkSourceEditorDiagnostic"
     private static let tocMessageName = "minimarkTOC"
-    private static let linkClickMessageName = "minimarkLinkClick"
+    static let linkClickMessageName = "minimarkLinkClick"
     private static let scrollSyncObserverScript = BundledAssetLoader.scrollSyncObserverJavaScript
 
     /// Intercepts clicks on markdown file links before WKWebView's default
@@ -19,7 +19,7 @@ struct MarkdownWebView: NSViewRepresentable {
     /// the click in JS instead and post the resolved URL to Swift, which then
     /// runs it through `MarkdownLinkResolver` to map the bundle-prefixed
     /// href back to a real on-disk file URL.
-    private static let markdownLinkInterceptScript = """
+    static let markdownLinkInterceptScript = """
         (function() {
             function isMarkdownHref(href) {
                 if (!href) return false;

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -9,7 +9,46 @@ struct MarkdownWebView: NSViewRepresentable {
     private static let sourceEditMessageName = "minimarkSourceEdit"
     private static let sourceEditorDiagnosticMessageName = "minimarkSourceEditorDiagnostic"
     private static let tocMessageName = "minimarkTOC"
+    private static let linkClickMessageName = "minimarkLinkClick"
     private static let scrollSyncObserverScript = BundledAssetLoader.scrollSyncObserverJavaScript
+
+    /// Intercepts clicks on markdown file links before WKWebView's default
+    /// navigation. WKWebView silently drops `file://` link navigation for
+    /// documents loaded via `loadHTMLString(...baseURL:bundleURL)`, so
+    /// `WKNavigationDelegate.decidePolicyFor` never fires for them. We catch
+    /// the click in JS instead and post the resolved URL to Swift, which then
+    /// runs it through `MarkdownLinkResolver` to map the bundle-prefixed
+    /// href back to a real on-disk file URL.
+    private static let markdownLinkInterceptScript = """
+        (function() {
+            function isMarkdownHref(href) {
+                if (!href) return false;
+                var bare = href.split('#')[0].split('?')[0];
+                var dot = bare.lastIndexOf('.');
+                if (dot < 0) return false;
+                var ext = bare.substring(dot + 1).toLowerCase();
+                return ext === 'md' || ext === 'markdown';
+            }
+            document.addEventListener('click', function(e) {
+                if (e.defaultPrevented) return;
+                if (e.button !== 0) return;
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                var a = e.target.closest && e.target.closest('a');
+                if (!a) return;
+                var rawHref = a.getAttribute('href');
+                if (!isMarkdownHref(rawHref)) return;
+                var resolvedHref = a.href;
+                if (!resolvedHref) return;
+                e.preventDefault();
+                e.stopPropagation();
+                try {
+                    window.webkit.messageHandlers.minimarkLinkClick.postMessage({
+                        url: resolvedHref
+                    });
+                } catch (err) {}
+            }, true);
+        })();
+    """
 
     let htmlDocument: String
     let documentIdentity: String?
@@ -41,10 +80,18 @@ struct MarkdownWebView: NSViewRepresentable {
                 forMainFrameOnly: true
             )
         )
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: Self.markdownLinkInterceptScript,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
         configuration.userContentController.add(context.coordinator, name: Self.scrollSyncMessageName)
         configuration.userContentController.add(context.coordinator, name: Self.sourceEditMessageName)
         configuration.userContentController.add(context.coordinator, name: Self.sourceEditorDiagnosticMessageName)
         configuration.userContentController.add(context.coordinator, name: Self.tocMessageName)
+        configuration.userContentController.add(context.coordinator, name: Self.linkClickMessageName)
 
         let webView = DropAwareWKWebView(frame: .zero, configuration: configuration)
         #if DEBUG
@@ -108,7 +155,6 @@ struct MarkdownWebView: NSViewRepresentable {
             case cancel
             case openExternal(URL)
             case scrollToFragment(String)
-            case openLinkedFile(URL)
         }
 
         private weak var webView: WKWebView?
@@ -529,10 +575,6 @@ struct MarkdownWebView: NSViewRepresentable {
             case let .scrollToFragment(fragment):
                 scrollToFragment(fragment, in: webView)
                 decisionHandler(.cancel)
-
-            case let .openLinkedFile(url):
-                onAction(.openLinkedFile(url))
-                decisionHandler(.cancel)
             }
         }
 
@@ -587,14 +629,6 @@ struct MarkdownWebView: NSViewRepresentable {
 
             if let fragment = inPageFragment(for: url, in: webView) {
                 return .scrollToFragment(fragment)
-            }
-
-            if let resolved = MarkdownLinkResolver.resolveMarkdownLink(
-                url: url,
-                documentDirectoryPath: currentDocumentDirectoryPath(),
-                bundlePath: Bundle.main.bundleURL.standardizedFileURL.path
-            ) {
-                return .openLinkedFile(resolved)
             }
 
             if isSafeExternalURL(url) {
@@ -709,6 +743,20 @@ struct MarkdownWebView: NSViewRepresentable {
                let payload = message.body as? [[String: Any]] {
                 let headings = TOCHeading.fromJavaScriptPayload(payload)
                 onAction(.tocHeadingsExtracted(headings))
+                return
+            }
+
+            if message.name == MarkdownWebView.linkClickMessageName,
+               let payload = message.body as? [String: Any],
+               let urlString = payload["url"] as? String,
+               let url = URL(string: urlString) {
+                if let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+                    url: url,
+                    documentDirectoryPath: currentDocumentDirectoryPath(),
+                    bundlePath: Bundle.main.bundleURL.standardizedFileURL.path
+                ) {
+                    onAction(.openLinkedFile(resolved))
+                }
                 return
             }
 

--- a/minimark/Views/MarkdownWebView.swift
+++ b/minimark/Views/MarkdownWebView.swift
@@ -19,36 +19,9 @@ struct MarkdownWebView: NSViewRepresentable {
     /// the click in JS instead and post the resolved URL to Swift, which then
     /// runs it through `MarkdownLinkResolver` to map the bundle-prefixed
     /// href back to a real on-disk file URL.
-    static let markdownLinkInterceptScript = """
-        (function() {
-            function isMarkdownHref(href) {
-                if (!href) return false;
-                var bare = href.split('#')[0].split('?')[0];
-                var dot = bare.lastIndexOf('.');
-                if (dot < 0) return false;
-                var ext = bare.substring(dot + 1).toLowerCase();
-                return ext === 'md' || ext === 'markdown';
-            }
-            document.addEventListener('click', function(e) {
-                if (e.defaultPrevented) return;
-                if (e.button !== 0) return;
-                if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-                var a = e.target.closest && e.target.closest('a');
-                if (!a) return;
-                var rawHref = a.getAttribute('href');
-                if (!isMarkdownHref(rawHref)) return;
-                var resolvedHref = a.href;
-                if (!resolvedHref) return;
-                e.preventDefault();
-                e.stopPropagation();
-                try {
-                    window.webkit.messageHandlers.minimarkLinkClick.postMessage({
-                        url: resolvedHref
-                    });
-                } catch (err) {}
-            }, true);
-        })();
-    """
+    static var markdownLinkInterceptScript: String {
+        BundledAssetLoader.markdownLinkInterceptJavaScript
+    }
 
     let htmlDocument: String
     let documentIdentity: String?

--- a/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
@@ -84,7 +84,7 @@ final class WindowDocumentOpenCoordinator {
 
     func openFileRequest(_ request: FileOpenRequest) {
         if request.origin == .linkFollow {
-            ensureLinkFollowAccess(forFiles: request.fileURLs)
+            guard ensureLinkFollowAccess(forFiles: request.fileURLs) else { return }
         }
         fileOpenCoordinator.open(request)
         callbacks.refreshWindowPresentation()
@@ -96,12 +96,21 @@ final class WindowDocumentOpenCoordinator {
     /// detect that here and present an NSOpenPanel to collect the grant —
     /// which is then persisted so future link clicks under the same folder
     /// don't re-prompt.
-    private func ensureLinkFollowAccess(forFiles fileURLs: [URL]) {
-        guard let firstFileURL = fileURLs.first else { return }
+    ///
+    /// Returns `true` when access is already covered or was successfully
+    /// granted. Returns `false` when the user cancelled or chose a folder
+    /// that doesn't cover the target — callers must abort the file open in
+    /// that case to avoid a broken slot showing a sandbox read failure.
+    ///
+    /// Link-follow file opens always carry exactly one URL (see
+    /// `DocumentSurfaceViewModel.openLinkedFile(_:)`).
+    private func ensureLinkFollowAccess(forFiles fileURLs: [URL]) -> Bool {
+        precondition(fileURLs.count == 1, "link-follow open expects exactly one file URL")
+        guard let firstFileURL = fileURLs.first else { return false }
         if settingsStore.resolvedLinkAccessFolderURL(containing: firstFileURL) != nil {
-            return
+            return true
         }
-        linkFollowAccessRequester.requestAccess(forContaining: firstFileURL)
+        return linkFollowAccessRequester.requestAccess(forContaining: firstFileURL)
     }
 
     func openIncomingURL(_ url: URL) {

--- a/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
+++ b/minimark/Views/Window/Coordination/WindowDocumentOpenCoordinator.swift
@@ -37,6 +37,7 @@ final class WindowDocumentOpenCoordinator {
     private let folderWatchOpen: WindowFolderWatchOpenController
     private let sidebarDocumentController: SidebarDocumentController
     private let settingsStore: SettingsStore
+    private let linkFollowAccessRequester: LinkFollowAccessRequester
     private let folderWatchSessionProvider: () -> FolderWatchSession?
     private let callbacks: WindowOpenCallbacks
 
@@ -45,6 +46,7 @@ final class WindowDocumentOpenCoordinator {
         folderWatchOpen: WindowFolderWatchOpenController,
         sidebarDocumentController: SidebarDocumentController,
         settingsStore: SettingsStore,
+        linkFollowAccessRequester: LinkFollowAccessRequester? = nil,
         folderWatchSessionProvider: @escaping () -> FolderWatchSession?,
         callbacks: WindowOpenCallbacks
     ) {
@@ -52,6 +54,8 @@ final class WindowDocumentOpenCoordinator {
         self.folderWatchOpen = folderWatchOpen
         self.sidebarDocumentController = sidebarDocumentController
         self.settingsStore = settingsStore
+        self.linkFollowAccessRequester = linkFollowAccessRequester
+            ?? LinkFollowAccessRequester(grantStore: settingsStore)
         self.folderWatchSessionProvider = folderWatchSessionProvider
         self.callbacks = callbacks
     }
@@ -79,8 +83,25 @@ final class WindowDocumentOpenCoordinator {
     // MARK: - Open entry points
 
     func openFileRequest(_ request: FileOpenRequest) {
+        if request.origin == .linkFollow {
+            ensureLinkFollowAccess(forFiles: request.fileURLs)
+        }
         fileOpenCoordinator.open(request)
         callbacks.refreshWindowPresentation()
+    }
+
+    /// Sandboxed apps only have access to files the user explicitly grants.
+    /// When following a markdown link to a sibling/descendant file, that file
+    /// usually isn't accessible until the user grants the parent folder. We
+    /// detect that here and present an NSOpenPanel to collect the grant —
+    /// which is then persisted so future link clicks under the same folder
+    /// don't re-prompt.
+    private func ensureLinkFollowAccess(forFiles fileURLs: [URL]) {
+        guard let firstFileURL = fileURLs.first else { return }
+        if settingsStore.resolvedLinkAccessFolderURL(containing: firstFileURL) != nil {
+            return
+        }
+        linkFollowAccessRequester.requestAccess(forContaining: firstFileURL)
     }
 
     func openIncomingURL(_ url: URL) {

--- a/minimarkTests/Rendering/MarkdownLinkClickInterceptTests.swift
+++ b/minimarkTests/Rendering/MarkdownLinkClickInterceptTests.swift
@@ -27,6 +27,7 @@ struct MarkdownLinkClickInterceptTests {
     private static let bundleBaseURL = URL(fileURLWithPath: "/Applications/MarkdownObserver.app/")
 
     private final class MessageRecorder: NSObject, WKScriptMessageHandler {
+        var received: [[String: Any]] = []
         var continuation: CheckedContinuation<[String: Any], Never>?
 
         func userContentController(
@@ -35,6 +36,7 @@ struct MarkdownLinkClickInterceptTests {
         ) {
             guard message.name == MarkdownWebView.linkClickMessageName else { return }
             let payload = (message.body as? [String: Any]) ?? [:]
+            received.append(payload)
             continuation?.resume(returning: payload)
             continuation = nil
         }
@@ -173,7 +175,7 @@ struct MarkdownLinkClickInterceptTests {
 
         // Give the JS a moment to run; if it were going to post, it would have.
         try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(recorder.continuation == nil, "no message should have been posted")
+        #expect(recorder.received.isEmpty, "no message should have been posted")
     }
 
     @Test
@@ -187,7 +189,7 @@ struct MarkdownLinkClickInterceptTests {
 
         try await clickAnchor(id: "link", in: webView)
         try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(recorder.continuation == nil)
+        #expect(recorder.received.isEmpty)
     }
 
     @Test
@@ -201,6 +203,6 @@ struct MarkdownLinkClickInterceptTests {
 
         try await clickAnchor(id: "link", in: webView)
         try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(recorder.continuation == nil)
+        #expect(recorder.received.isEmpty)
     }
 }

--- a/minimarkTests/Rendering/MarkdownLinkClickInterceptTests.swift
+++ b/minimarkTests/Rendering/MarkdownLinkClickInterceptTests.swift
@@ -1,0 +1,206 @@
+//
+//  MarkdownLinkClickInterceptTests.swift
+//  minimarkTests
+//
+//  Regression test for the JS click interceptor.
+//
+//  WKWebView silently drops left-click navigation on `file://` URLs when the
+//  document was loaded via `loadHTMLString(html, baseURL: bundleURL)`. The
+//  navigation delegate's `decidePolicyForNavigationAction` is never called for
+//  those clicks. The fix routes markdown-link clicks through a JS user script
+//  that preventDefaults and posts the URL to a `WKScriptMessageHandler`. This
+//  test exercises that exact path against a real WKWebView so future
+//  regressions are caught.
+//
+
+import Testing
+import Foundation
+import WebKit
+@testable import minimark
+
+@MainActor
+@Suite
+struct MarkdownLinkClickInterceptTests {
+
+    // MARK: - Helpers
+
+    private static let bundleBaseURL = URL(fileURLWithPath: "/Applications/MarkdownObserver.app/")
+
+    private final class MessageRecorder: NSObject, WKScriptMessageHandler {
+        var continuation: CheckedContinuation<[String: Any], Never>?
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == MarkdownWebView.linkClickMessageName else { return }
+            let payload = (message.body as? [String: Any]) ?? [:]
+            continuation?.resume(returning: payload)
+            continuation = nil
+        }
+    }
+
+    private func makeWebView(recorder: MessageRecorder) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: MarkdownWebView.markdownLinkInterceptScript,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
+        configuration.userContentController.add(recorder, name: MarkdownWebView.linkClickMessageName)
+        return WKWebView(frame: .zero, configuration: configuration)
+    }
+
+    /// Loads HTML containing the given anchor markup and waits for the page
+    /// to finish loading.
+    private func loadDocument(in webView: WKWebView, anchor: String) async {
+        let html = """
+        <!DOCTYPE html>
+        <html><body>
+            \(anchor)
+        </body></html>
+        """
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let observer = LoadObserver(continuation: continuation)
+            webView.navigationDelegate = observer
+            // Hold the observer alive for the duration of the load.
+            objc_setAssociatedObject(webView, &LoadObserver.key, observer, .OBJC_ASSOCIATION_RETAIN)
+            webView.loadHTMLString(html, baseURL: Self.bundleBaseURL)
+        }
+    }
+
+    private final class LoadObserver: NSObject, WKNavigationDelegate {
+        nonisolated(unsafe) static var key: UInt8 = 0
+        let continuation: CheckedContinuation<Void, Never>
+        var fired = false
+
+        init(continuation: CheckedContinuation<Void, Never>) {
+            self.continuation = continuation
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard !fired else { return }
+            fired = true
+            continuation.resume()
+        }
+    }
+
+    /// Synthesizes a left-click on the anchor element by ID.
+    private func clickAnchor(id: String, in webView: WKWebView) async throws {
+        let script = """
+        (function() {
+            var el = document.getElementById(\(jsString(id)));
+            if (!el) return false;
+            var ev = new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+                button: 0
+            });
+            el.dispatchEvent(ev);
+            return true;
+        })();
+        """
+        _ = try await webView.evaluateJavaScript(script)
+    }
+
+    private func jsString(_ value: String) -> String {
+        let data = try? JSONSerialization.data(withJSONObject: [value])
+        let json = data.flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
+        // Strip the surrounding [] so we get a JSON-encoded string literal.
+        let stripped = String(json.dropFirst().dropLast())
+        return stripped
+    }
+
+    private func awaitNextMessage(_ recorder: MessageRecorder) async -> [String: Any] {
+        await withCheckedContinuation { continuation in
+            recorder.continuation = continuation
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test
+    func clickOnRelativeMarkdownLinkPostsResolvedURL() async throws {
+        let recorder = MessageRecorder()
+        let webView = makeWebView(recorder: recorder)
+        await loadDocument(
+            in: webView,
+            anchor: #"<a id="link" href="feedback_xyz.md">notes</a>"#
+        )
+
+        async let payload = awaitNextMessage(recorder)
+        try await clickAnchor(id: "link", in: webView)
+        let body = await payload
+
+        // The URL posted is the WKWebView-resolved absolute href, which is the
+        // bundle base URL joined with the relative href.
+        let urlString = try #require(body["url"] as? String)
+        let url = try #require(URL(string: urlString))
+        #expect(url.isFileURL)
+        #expect(url.path == "/Applications/MarkdownObserver.app/feedback_xyz.md")
+    }
+
+    @Test
+    func clickOnMarkdownExtensionLinkAlsoPosts() async throws {
+        let recorder = MessageRecorder()
+        let webView = makeWebView(recorder: recorder)
+        await loadDocument(
+            in: webView,
+            anchor: #"<a id="link" href="long.markdown">long</a>"#
+        )
+
+        async let payload = awaitNextMessage(recorder)
+        try await clickAnchor(id: "link", in: webView)
+        let body = await payload
+
+        let urlString = try #require(body["url"] as? String)
+        #expect(urlString.hasSuffix("/long.markdown"))
+    }
+
+    @Test
+    func clickOnNonMarkdownLinkDoesNotPost() async throws {
+        let recorder = MessageRecorder()
+        let webView = makeWebView(recorder: recorder)
+        await loadDocument(
+            in: webView,
+            anchor: #"<a id="link" href="image.png">img</a>"#
+        )
+
+        try await clickAnchor(id: "link", in: webView)
+
+        // Give the JS a moment to run; if it were going to post, it would have.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(recorder.continuation == nil, "no message should have been posted")
+    }
+
+    @Test
+    func clickOnExternalHttpsLinkDoesNotPost() async throws {
+        let recorder = MessageRecorder()
+        let webView = makeWebView(recorder: recorder)
+        await loadDocument(
+            in: webView,
+            anchor: #"<a id="link" href="https://example.com">ext</a>"#
+        )
+
+        try await clickAnchor(id: "link", in: webView)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(recorder.continuation == nil)
+    }
+
+    @Test
+    func clickOnFragmentLinkDoesNotPost() async throws {
+        let recorder = MessageRecorder()
+        let webView = makeWebView(recorder: recorder)
+        await loadDocument(
+            in: webView,
+            anchor: ##"<a id="link" href="#section">anchor</a>"##
+        )
+
+        try await clickAnchor(id: "link", in: webView)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(recorder.continuation == nil)
+    }
+}

--- a/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
+++ b/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
@@ -111,6 +111,19 @@ struct MarkdownLinkResolverTests {
     }
 
     @Test
+    func acceptsMdownExtension() {
+        let mdown = URL(fileURLWithPath: "\(bundlePath)/file.mdown")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: mdown,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/file.mdown")
+    }
+
+    @Test
     func extensionMatchIsCaseInsensitive() {
         let upper = URL(fileURLWithPath: "\(bundlePath)/file.MD")
 

--- a/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
+++ b/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
@@ -148,4 +148,20 @@ struct MarkdownLinkResolverTests {
 
         #expect(resolved == nil)
     }
+
+    @Test
+    func resolvesFileWithSpacesInName() {
+        // WKWebView decodes percent-encoded hrefs before the navigation
+        // delegate sees them, so a markdown link `[x](my%20file.md)` arrives
+        // with a space in `.path`. Confirm the resolver passes it through.
+        let bundleResolved = URL(fileURLWithPath: "\(bundlePath)/my file.md")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: bundleResolved,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/my file.md")
+    }
 }

--- a/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
+++ b/minimarkTests/Rendering/MarkdownLinkResolverTests.swift
@@ -1,0 +1,151 @@
+//
+//  MarkdownLinkResolverTests.swift
+//  minimarkTests
+//
+
+import Testing
+import Foundation
+@testable import minimark
+
+@Suite
+struct MarkdownLinkResolverTests {
+    private let bundlePath = "/Applications/MarkdownObserver.app"
+    private let documentDir = "/Users/me/notes"
+
+    @Test
+    func resolvesRelativeFileAgainstDocumentDirectory() {
+        // After WKWebView resolves "file.md" against the bundle baseURL, the
+        // navigation delegate sees a bundle-prefixed file:// URL.
+        let bundleResolved = URL(fileURLWithPath: "\(bundlePath)/file.md")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: bundleResolved,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/file.md")
+    }
+
+    @Test
+    func resolvesRelativeSubdirectoryPath() {
+        let bundleResolved = URL(fileURLWithPath: "\(bundlePath)/sub/other.md")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: bundleResolved,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/sub/other.md")
+    }
+
+    @Test
+    func passesAbsolutePathThrough() {
+        let absolute = URL(fileURLWithPath: "/var/tmp/elsewhere.md")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: absolute,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "/var/tmp/elsewhere.md")
+    }
+
+    @Test
+    func stripsFragment() {
+        var components = URLComponents()
+        components.scheme = "file"
+        components.path = "\(bundlePath)/file.md"
+        components.fragment = "section"
+        let withFragment = components.url!
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: withFragment,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/file.md")
+        #expect(resolved?.fragment == nil)
+    }
+
+    @Test
+    func returnsNilForNonMarkdownExtension() {
+        let png = URL(fileURLWithPath: "\(bundlePath)/image.png")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: png,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test
+    func returnsNilForNoExtension() {
+        let noExt = URL(fileURLWithPath: "\(bundlePath)/README")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: noExt,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test
+    func acceptsMarkdownExtension() {
+        let longExt = URL(fileURLWithPath: "\(bundlePath)/file.markdown")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: longExt,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/file.markdown")
+    }
+
+    @Test
+    func extensionMatchIsCaseInsensitive() {
+        let upper = URL(fileURLWithPath: "\(bundlePath)/file.MD")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: upper,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved?.path == "\(documentDir)/file.MD")
+    }
+
+    @Test
+    func returnsNilWhenDocumentDirectoryUnknown() {
+        let bundleResolved = URL(fileURLWithPath: "\(bundlePath)/file.md")
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: bundleResolved,
+            documentDirectoryPath: nil,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test
+    func returnsNilForNonFileURL() {
+        let https = URL(string: "https://example.com/notes.md")!
+
+        let resolved = MarkdownLinkResolver.resolveMarkdownLink(
+            url: https,
+            documentDirectoryPath: documentDir,
+            bundlePath: bundlePath
+        )
+
+        #expect(resolved == nil)
+    }
+}

--- a/minimarkTests/Stores/Settings/LinkAccessGrantsStoreTests.swift
+++ b/minimarkTests/Stores/Settings/LinkAccessGrantsStoreTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@testable import minimark
+
+@Suite(.serialized)
+struct LinkAccessGrantsStoreTests {
+    @MainActor
+    private final class RecordingCoordinator: ChildStoreCoordinating {
+        private(set) var coalescingCalls: [Bool] = []
+
+        func childStoreDidMutate(coalescePersistence: Bool) {
+            coalescingCalls.append(coalescePersistence)
+        }
+    }
+
+    @MainActor private func makeStore(
+        initial: [LinkAccessGrant] = [],
+        resolver: @escaping BookmarkRefreshing.Resolver = { _ in (URL(fileURLWithPath: "/ignored"), false) },
+        creator: @escaping BookmarkRefreshing.Creator = { _ in Data() }
+    ) -> (LinkAccessGrantsStore, RecordingCoordinator) {
+        let helper = BookmarkRefreshing(resolve: resolver, create: creator)
+        let store = LinkAccessGrantsStore(initial: initial, bookmarkRefreshing: helper)
+        let coordinator = RecordingCoordinator()
+        store.coordinator = coordinator
+        return (store, coordinator)
+    }
+
+    @Test @MainActor func addInsertsUniqueFolder() {
+        let (store, coordinator) = makeStore()
+
+        store.addLinkAccessGrant(URL(fileURLWithPath: "/tmp/notes", isDirectory: true))
+
+        #expect(store.currentGrants.count == 1)
+        #expect(coordinator.coalescingCalls == [false])
+    }
+
+    @Test @MainActor func addingSameFolderTwiceKeepsOneEntry() {
+        let (store, _) = makeStore()
+        let folderURL = URL(fileURLWithPath: "/tmp/notes", isDirectory: true)
+
+        store.addLinkAccessGrant(folderURL)
+        store.addLinkAccessGrant(folderURL)
+
+        #expect(store.currentGrants.count == 1)
+    }
+
+    @Test @MainActor func resolvedURLReturnsNilWhenNoGrantContainsFile() {
+        let entry = LinkAccessGrant(folderPath: "/tmp/notes", bookmarkData: Data([0x01]))
+        let (store, _) = makeStore(initial: [entry])
+
+        let result = store.resolvedLinkAccessFolderURL(containing: URL(fileURLWithPath: "/elsewhere/a.md"))
+
+        #expect(result == nil)
+    }
+
+    @Test @MainActor func resolvedURLReturnsNilWhenEntryHasNoBookmark() {
+        let entry = LinkAccessGrant(folderPath: "/tmp/notes", bookmarkData: nil)
+        let (store, _) = makeStore(initial: [entry])
+
+        let result = store.resolvedLinkAccessFolderURL(containing: URL(fileURLWithPath: "/tmp/notes/a.md"))
+
+        #expect(result == nil)
+    }
+
+    @Test @MainActor func resolvedURLRefreshesStaleBookmark() {
+        let folderURL = URL(fileURLWithPath: "/tmp/notes", isDirectory: true)
+        let refreshed = Data([0xCC])
+        let entry = LinkAccessGrant(folderPath: folderURL.path, bookmarkData: Data([0x01]))
+        let (store, _) = makeStore(
+            initial: [entry],
+            resolver: { _ in (folderURL, true) },
+            creator: { _ in refreshed }
+        )
+
+        let result = store.resolvedLinkAccessFolderURL(containing: URL(fileURLWithPath: "/tmp/notes/a.md"))
+
+        #expect(result == folderURL)
+        #expect(store.currentGrants.first?.bookmarkData == refreshed)
+    }
+
+    @Test @MainActor func resolvedURLClearsInvalidBookmarkAndReturnsNil() {
+        let entry = LinkAccessGrant(folderPath: "/tmp/notes", bookmarkData: Data([0x01]))
+        let (store, _) = makeStore(
+            initial: [entry],
+            resolver: { _ in throw NSError(domain: "test", code: 1) }
+        )
+
+        let result = store.resolvedLinkAccessFolderURL(containing: URL(fileURLWithPath: "/tmp/notes/a.md"))
+
+        #expect(result == nil)
+        #expect(store.currentGrants.first?.bookmarkData == nil)
+    }
+
+    @Test @MainActor func resolvedURLPicksDeepestCoveringFolder() {
+        // Both /tmp/notes and /tmp/notes/sub cover the file, but the deeper
+        // grant should win so nested authorizations take precedence.
+        let outerURL = URL(fileURLWithPath: "/tmp/notes", isDirectory: true)
+        let innerURL = URL(fileURLWithPath: "/tmp/notes/sub", isDirectory: true)
+        let outer = LinkAccessGrant(folderPath: outerURL.path, bookmarkData: Data([0x01]))
+        let inner = LinkAccessGrant(folderPath: innerURL.path, bookmarkData: Data([0x02]))
+
+        // Resolver echoes back the URL it would resolve from the bookmark
+        // data so we can assert which entry was picked.
+        let (store, _) = makeStore(
+            initial: [outer, inner],
+            resolver: { data in
+                if data == Data([0x01]) { return (outerURL, false) }
+                if data == Data([0x02]) { return (innerURL, false) }
+                throw NSError(domain: "test", code: -1)
+            }
+        )
+
+        let result = store.resolvedLinkAccessFolderURL(containing: URL(fileURLWithPath: "/tmp/notes/sub/file.md"))
+
+        #expect(result == innerURL)
+    }
+
+    @Test @MainActor func clearRemovesAllEntries() {
+        let entry = LinkAccessGrant(folderPath: "/tmp/notes", bookmarkData: Data([0x01]))
+        let (store, _) = makeStore(initial: [entry])
+
+        store.clearLinkAccessGrants()
+
+        #expect(store.currentGrants.isEmpty)
+    }
+
+    @Test @MainActor func insertingUniqueCapsAtMaximum() {
+        // Direct test of the history helper's cap, independent of the store.
+        var entries: [LinkAccessGrant] = []
+        for index in 0..<(LinkAccessGrant.maximumCount + 5) {
+            entries = LinkAccessGrantHistory.insertingUnique(
+                URL(fileURLWithPath: "/tmp/folder-\(index)", isDirectory: true),
+                into: entries
+            )
+        }
+
+        #expect(entries.count == LinkAccessGrant.maximumCount)
+    }
+}

--- a/minimarkTests/Stores/Settings/LinkAccessGrantsStoreTests.swift
+++ b/minimarkTests/Stores/Settings/LinkAccessGrantsStoreTests.swift
@@ -130,10 +130,36 @@ struct LinkAccessGrantsStoreTests {
         for index in 0..<(LinkAccessGrant.maximumCount + 5) {
             entries = LinkAccessGrantHistory.insertingUnique(
                 URL(fileURLWithPath: "/tmp/folder-\(index)", isDirectory: true),
+                bookmarkData: Data([UInt8(index & 0xFF)]),
                 into: entries
             )
         }
 
         #expect(entries.count == LinkAccessGrant.maximumCount)
+    }
+
+    @Test @MainActor func insertingUniqueSkipsEntriesWithoutBookmark() {
+        // A nil bookmark would create a phantom grant that the resolver skips
+        // and the coordinator never sees — guarding against an infinite prompt
+        // loop when bookmark creation fails.
+        let result = LinkAccessGrantHistory.insertingUnique(
+            URL(fileURLWithPath: "/tmp/notes", isDirectory: true),
+            bookmarkData: nil,
+            into: []
+        )
+
+        #expect(result.isEmpty)
+    }
+
+    @Test @MainActor func addLinkAccessGrantSkipsWhenBookmarkCreationFails() {
+        let helper = BookmarkRefreshing(
+            resolve: { _ in (URL(fileURLWithPath: "/ignored"), false) },
+            create: { _ in throw NSError(domain: "test", code: 1) }
+        )
+        let store = LinkAccessGrantsStore(initial: [], bookmarkRefreshing: helper)
+
+        store.addLinkAccessGrant(URL(fileURLWithPath: "/tmp/notes", isDirectory: true))
+
+        #expect(store.currentGrants.isEmpty)
     }
 }

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -439,6 +439,39 @@ final class TestSettingsStore: SettingsStoring {
         return nil
     }
 
+    private(set) var recordedLinkAccessGrants: [LinkAccessGrant] = []
+
+    func addLinkAccessGrant(_ folderURL: URL) {
+        var next = subject.value
+        next.linkAccessGrants = LinkAccessGrantHistory.insertingUnique(
+            folderURL,
+            into: next.linkAccessGrants
+        )
+        recordedLinkAccessGrants = next.linkAccessGrants
+        subject.send(next)
+    }
+
+    func resolvedLinkAccessFolderURL(containing fileURL: URL) -> URL? {
+        let normalizedFileURL = FileRouting.normalizedFileURL(fileURL)
+        let filePath = normalizedFileURL.path
+
+        let coveringEntries = subject.value.linkAccessGrants
+            .filter { entry in
+                let folderPath = entry.folderPath.hasSuffix("/") ? entry.folderPath : entry.folderPath + "/"
+                return filePath.hasPrefix(folderPath) || filePath == entry.folderPath
+            }
+            .sorted { $0.folderPath.count > $1.folderPath.count }
+
+        return coveringEntries.first?.folderURL
+    }
+
+    func clearLinkAccessGrants() {
+        var next = subject.value
+        next.linkAccessGrants = []
+        recordedLinkAccessGrants = []
+        subject.send(next)
+    }
+
     func reorderFavoriteWatchedFolders(orderedIDs: [UUID]) {
         var next = subject.value
         let existing = next.favoriteWatchedFolders

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -465,13 +465,6 @@ final class TestSettingsStore: SettingsStoring {
         return coveringEntries.first?.folderURL
     }
 
-    func clearLinkAccessGrants() {
-        var next = subject.value
-        next.linkAccessGrants = []
-        recordedLinkAccessGrants = []
-        subject.send(next)
-    }
-
     func reorderFavoriteWatchedFolders(orderedIDs: [UUID]) {
         var next = subject.value
         let existing = next.favoriteWatchedFolders

--- a/minimarkTests/TestSupport/TestDoubles.swift
+++ b/minimarkTests/TestSupport/TestDoubles.swift
@@ -445,6 +445,7 @@ final class TestSettingsStore: SettingsStoring {
         var next = subject.value
         next.linkAccessGrants = LinkAccessGrantHistory.insertingUnique(
             folderURL,
+            bookmarkData: Data(),
             into: next.linkAccessGrants
         )
         recordedLinkAccessGrants = next.linkAccessGrants


### PR DESCRIPTION
## Summary

Click a `[link](other.md)` in the rendered preview and the linked file opens in a new sidebar slot. Works for relative paths, absolute file URLs, and `#fragment`-suffixed links (fragment is stripped).

When the linked file lives outside the per-file sandbox grant of the currently-open document, the app prompts once for folder-scoped access via NSOpenPanel; the bookmark is persisted so subsequent clicks under the same folder open instantly.

### How it works

- **Click capture** — `markdownobserver-link-intercept.js` (loaded via `BundledAssetLoader`) attaches a capture-phase click listener that detects `.md` / `.markdown` / `.mdown` anchors, prevents default navigation, and posts the resolved href to a `WKScriptMessageHandler`. Required because WKWebView silently drops `file://` link navigation for documents loaded with `loadHTMLString(html, baseURL: bundleURL)`.
- **URL resolution** — `MarkdownLinkResolver` strips the bundle prefix WKWebView added when resolving relative hrefs, drops fragments, and re-resolves against the currently-open document's directory. Reuses `FileRouting.isSupportedMarkdownFileURL` for extension matching.
- **Slot dispatch** — `.openLinkedFile(URL)` ⇒ `.requestFileOpen(FileOpenRequest(origin: .linkFollow, slotStrategy: .alwaysAppend))`.
- **Sandbox grant** — `WindowDocumentOpenCoordinator.openFileRequest` checks `LinkAccessGrantsStore` for an existing covering grant; if none, presents `LinkFollowAccessRequester`'s NSOpenPanel pre-pointed at the linked file's parent folder. `SecurityScopeResolver.linkAccessScopedAccessibleFileURL` activates the folder-scoped bookmark and returns a folder-relative URL the file loader can read.

### What's new

- `MarkdownLinkResolver` (model + tests)
- `markdownobserver-link-intercept.js` resource + `BundledAssetLoader.markdownLinkInterceptJavaScript`
- `OpenOrigin.linkFollow`, `DocumentSurfaceAction.openLinkedFile(URL)`
- `LinkAccessGrant` model + `LinkAccessGrantsStore` (mirrors `TrustedImageFoldersStore`, with deepest-match-wins resolution)
- `LinkFollowAccessRequester` service
- `SecurityScopeResolver.linkAccessScopedAccessibleFileURL` consults grant store after watch sessions
- 17 link-intercept regression tests + 9 grant-store tests

## Test plan

- [ ] Open a `.md` file via terminal `open` (per-file sandbox only). Click a relative `[link](sibling.md)` — expect the "Allow Link Following" panel pre-pointed at the parent folder. Grant access; the linked file opens in a new sidebar slot.
- [ ] Click another link to a different sibling under the same folder — expect no prompt; opens immediately.
- [ ] Click an external `https://` link — opens in default browser, no slot added.
- [ ] Click a `#fragment` anchor — scrolls in-page, no slot added.
- [ ] Click a `.png` link — does nothing (or hands off as before), no slot added.
- [ ] Quit + relaunch the app, click a link in the same folder — bookmark persisted, opens without prompt.
- [ ] Run unit tests: `xcodebuild test -project minimark.xcodeproj -scheme minimark -destination 'platform=macOS' -only-testing:minimarkTests` — all green.