### PR TITLE
Hide Tahoe toolbar pill on custom toolbar buttons

### DIFF
--- a/minimark/Views/WindowRootView.swift
+++ b/minimark/Views/WindowRootView.swift
@@ -102,6 +102,26 @@ struct WindowRootView: View {
 
     @ToolbarContentBuilder
     private var windowToolbarItems: some ToolbarContent {
+        if #available(macOS 26.0, *) {
+            folderWatchToolbarItem
+                .sharedBackgroundVisibility(.hidden)
+            sidebarPlacementToolbarItem
+                .sharedBackgroundVisibility(.hidden)
+        } else {
+            folderWatchToolbarItem
+            sidebarPlacementToolbarItem
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var sidebarPlacementToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            sidebarPlacementToggleButton
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var folderWatchToolbarItem: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
             FolderWatchToolbarButton(
                 state: currentToolbarFolderWatchState,
@@ -118,20 +138,21 @@ struct WindowRootView: View {
             .allowsHitTesting(windowCoordinator.hasCompletedWindowPhase)
             .padding(.trailing, 8)
         }
+    }
 
-        ToolbarItem(placement: .primaryAction) {
-            if windowCoordinator.hasCompletedWindowPhase && sidebarDocumentController.documents.count > 1 {
-                Button(action: {
-                    windowCoordinator.sidebarActions.toggleSidebarPlacement(currentMultiFileDisplayMode: multiFileDisplayMode)
-                }) {
-                    Image(systemName: sidebarPlacement == .left ? "sidebar.right" : "sidebar.left")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                }
-                .help(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
-                .accessibilityLabel(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
-                .accessibilityIdentifier(.sidebarPlacementToggle)
+    @ViewBuilder
+    private var sidebarPlacementToggleButton: some View {
+        if windowCoordinator.hasCompletedWindowPhase && sidebarDocumentController.documents.count > 1 {
+            Button(action: {
+                windowCoordinator.sidebarActions.toggleSidebarPlacement(currentMultiFileDisplayMode: multiFileDisplayMode)
+            }) {
+                Image(systemName: sidebarPlacement == .left ? "sidebar.right" : "sidebar.left")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
             }
+            .help(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
+            .accessibilityLabel(sidebarPlacement == .left ? "Move Sidebar Right" : "Move Sidebar Left")
+            .accessibilityIdentifier(.sidebarPlacementToggle)
         }
     }
 


### PR DESCRIPTION
## Summary
- On macOS 26 (Tahoe), SwiftUI auto-applies a Liquid Glass pill background to `ToolbarItem` content. The Watch Folder button and the sidebar-placement toggle already draw their own backgrounds, so the result is a doubled pill that looks off (see report).
- Opt out via `.sharedBackgroundVisibility(.hidden)` on both toolbar items, gated behind `#available(macOS 26.0, *)` so macOS 15 behavior is unchanged.
- Refactored `windowToolbarItems` to extract the two items into named `@ToolbarContentBuilder` properties for the conditional branches.

## Test plan
- [ ] Run on macOS 26 (Tahoe): Watch Folder button has no surrounding pill; the sidebar-placement toggle (visible with 2+ documents open) has no surrounding pill.
- [ ] Run on macOS 15: toolbar appearance unchanged.
- [ ] Watch Folder button still works (click activates picker, chevron opens menu, ⌥⌘W shortcut works).
- [ ] Sidebar-placement toggle still flips left/right.